### PR TITLE
defer collecting region context

### DIFF
--- a/src/tool/hpcrun/cct/cct.h
+++ b/src/tool/hpcrun/cct/cct.h
@@ -270,4 +270,9 @@ typedef void (*merge_op_t)(cct_node_t* a, cct_node_t*b, merge_op_arg_t arg);
 extern void hpcrun_cct_merge(cct_node_t* cct_a, cct_node_t* cct_b,
 			     merge_op_t merge, merge_op_arg_t arg);
 
+// allocation and free cct_node_t
+extern __thread cct_node_t* cct_node_freelist_head;
+cct_node_t* hpcrun_cct_node_alloc();
+void hpcrun_cct_node_free(cct_node_t *notification);
+
 #endif // cct_h

--- a/src/tool/hpcrun/cct/cct_bundle.c
+++ b/src/tool/hpcrun/cct/cct_bundle.c
@@ -47,6 +47,7 @@
 #include <stdbool.h>
 
 #include "cct_bundle.h"
+#include "../unresolved.h"
 #include <lib/prof-lean/hpcrun-fmt.h>
 #include <cct/cct_addr.h>
 #include <messages/messages.h>
@@ -120,8 +121,10 @@ hpcrun_cct_bundle_fwrite(FILE* fs, epoch_flags_t flags, cct_bundle_t* bndl)
   hpcrun_cct_insert_node(partial_insert, bndl->partial_unw_root);
 
   //
-  // 
+  // attach unresolved root
   //
+  // show UNRESOLVED TREE
+  //hpcrun_cct_insert_node(partial_insert, bndl->unresolved_root);
 
   // write out newly constructed cct
 

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -592,9 +592,14 @@ hpcrun_fini_internal()
 {
   hpcrun_disable_sampling();
 
+
+  // vi3: Master should resolve from here
+  if(!ompt_eager_context)
+    resolving_all_remaining_context();
+
   TMSG(FINI, "process");
 
-  hpcrun_unthreaded_data();
+//  hpcrun_unthreaded_data();
 
   if (hpcrun_is_initialized()) {
     hpcrun_is_initialized_private = false;
@@ -699,6 +704,9 @@ hpcrun_thread_init(int id, local_thread_data_t* local_thread_data) // cct_ctxt_t
 void
 hpcrun_thread_fini(epoch_t *epoch)
 {
+  // FIXME: vi3 Just for now resolve at this place
+  if(!ompt_eager_context)
+    resolving_all_remaining_context();
   TMSG(FINI,"thread fini");
 
   // take no action if this thread is suppressed

--- a/src/tool/hpcrun/ompt/ompt-callstack.h
+++ b/src/tool/hpcrun/ompt/ompt-callstack.h
@@ -26,3 +26,5 @@ ompt_parallel_begin_context(ompt_parallel_id_t region_id,
 cct_node_t *region_root(cct_node_t *_node);
 
 void ompt_record_thread_type(ompt_thread_type_t type);
+
+extern struct cct_node_t;

--- a/src/tool/hpcrun/ompt/ompt-defer.h
+++ b/src/tool/hpcrun/ompt/ompt-defer.h
@@ -2,9 +2,10 @@
 #ifndef defer_cntxt_h
 #define defer_cntxt_h
 
-#include <ompt.h>
+//#include <ompt.h>
 
 #include <hpcrun/thread_data.h>
+#include "ompt.h"
 
 // support for deferred callstack resolution
 
@@ -24,5 +25,28 @@ void init_region_id();
 cct_node_t *hpcrun_region_lookup(uint64_t id);
 
 #define IS_UNRESOLVED_ROOT(addr) (addr->ip_norm.lm_id == (uint16_t)UNRESOLVED)
+
+void enqueue_region(ompt_region_data_t* region_data, ompt_notification_t* new);
+ompt_notification_t* dequeue_region(ompt_region_data_t* region_data);
+
+//void enqueue_thread(ompt_thread_data_t* thread_data, ompt_notification_t* new);
+
+int length_trl(ompt_thread_regions_list_t* regions_list_head, int of_freelist);
+int register_thread(int level);
+void register_thread_to_all_regions();
+void register_to_all_regions();
+void try_resolve_context();
+
+// FIXME: vi3: currently try to fix this
+void top_most_match(cct_node_t* cct_a, cct_node_t* cct_b);
+int find_match(cct_node_t *cct_a, cct_node_t *cct_b, cct_node_t **left, cct_node_t **right);
+
+void resolve_one_region_context(ompt_region_data_t* region_data);
+void resolving_all_remaining_context();
+
+
+void enqueue_thread(ompt_threads_queue_t* threads_queue, ompt_notification_t* new);
+ompt_notification_t* dequeue_thread(ompt_threads_queue_t* threads_queue);
+
 
 #endif

--- a/src/tool/hpcrun/ompt/ompt-interface.h
+++ b/src/tool/hpcrun/ompt/ompt-interface.h
@@ -49,4 +49,32 @@ extern ompt_idle_t ompt_idle_placeholder_fn;
 
 struct cct_node_t* main_top_root;
 
+
+
+// vi3: Part for Allocating
+// FIXME: vi3 are names ok?
+// freeing memory represents adding entity to freelist
+
+// allocating and free region data
+// here freeing memory represents adding to freelist
+ompt_region_data_t* hpcrun_ompt_region_alloc();
+void hpcrun_ompt_region_free(ompt_region_data_t *region_data);
+
+// allocation and free notification
+ompt_notification_t* hpcrun_ompt_notification_alloc();
+void hpcrun_ompt_notification_free(ompt_notification_t *notification);
+
+// allocating and free thread's regions
+ompt_thread_regions_list_t* hpcrun_ompt_thread_region_alloc();
+void hpcrun_ompt_thread_region_free(ompt_thread_regions_list_t *thread_region);
+
+
+// vi3: Helper function to get region_data
+ompt_region_data_t* hpcrun_ompt_get_region_data(int ancestor_level);
+ompt_region_data_t* hpcrun_ompt_get_current_region_data();
+ompt_region_data_t* hpcrun_ompt_get_parent_region_data();
+
+
+
+
 #endif // _OMPT_INTERFACE_H_

--- a/src/tool/hpcrun/ompt/ompt-task.c
+++ b/src/tool/hpcrun/ompt/ompt-task.c
@@ -78,38 +78,6 @@
 //----------------------------------------------------------------------------
 
 
-struct cct_node_t {
-
-    // ---------------------------------------------------------
-    // a persistent node id is assigned for each node. this id
-    // is used both to reassemble a tree when reading it from
-    // a file as well as to identify call paths. a call path
-    // can simply be represented by the node id of the deepest
-    // node in the path.
-    // ---------------------------------------------------------
-    int32_t persistent_id;
-
-    // bundle abstract address components into a data type
-
-    cct_addr_t addr;
-
-    bool is_leaf;
-
-
-    // ---------------------------------------------------------
-    // tree structure
-    // ---------------------------------------------------------
-
-    // parent node and the beginning of the child list
-    struct cct_node_t* parent;
-    struct cct_node_t* children;
-
-    // left and right pointers for splay tree of siblings
-    struct cct_node_t* left;
-    struct cct_node_t* right;
-};
-
-
 static void 
 ompt_task_begin_internal(
   ompt_data_t* task_data

--- a/src/tool/hpcrun/ompt/ompt-thread.h
+++ b/src/tool/hpcrun/ompt/ompt-thread.h
@@ -54,7 +54,7 @@
 
 #include <ompt.h>
 
-#define MAX_NUMBER_OF_NESTED_REGIONS 128
+#define MAX_NESTING_LEVELS 128
 
 //******************************************************************************
 // interface operations 
@@ -64,16 +64,23 @@ void ompt_thread_type_set(ompt_thread_type_t ttype);
 
 ompt_thread_type_t ompt_thread_type_get();
 
-static __thread ompt_queue_data_t *thread_queue_data;
-static __thread int thread_region_stack[MAX_NUMBER_OF_NESTED_REGIONS];
-static __thread int thread_stack_top = 0;
+extern __thread ompt_thread_regions_list_t* registered_regions;
+extern __thread ompt_threads_queue_t threads_queue;
 
-void thread_region_stack_push();
+// freelists
+extern __thread ompt_notification_t* notification_freelist_head;
+extern __thread ompt_thread_regions_list_t* thread_region_freelist_head;
+extern __thread ompt_thread_region_freelist_t public_region_freelist;
+extern __thread ompt_region_data_t* private_region_freelist_head;
 
-void thread_region_stack_pop();
+// stack that contais all nested parallel region
+extern __thread uint64_t region_stack[];
+extern  __thread int top_index;
 
-void thread_region_stack_register_thread();
-
-int thread_region_stack_top();
+uint64_t top_region_stack();
+uint64_t pop_region_stack();
+void push_region_stack(uint64_t region_id);
+void clear_region_stack();
+int is_empty_region_stack();
 
 #endif

--- a/src/tool/hpcrun/sample_event.c
+++ b/src/tool/hpcrun/sample_event.c
@@ -281,6 +281,10 @@ hpcrun_sample_callpath(void* context, int metricId,
   TMSG(SAMPLE_CALLPATH,"done w sample, return %p", ret.sample_node);
   monitor_unblock_shootdown();
 
+  if(!isSync && !ompt_eager_context){
+      register_to_all_regions();
+  }
+
   return ret;
 }
 

--- a/src/tool/hpcrun/thread_data.h
+++ b/src/tool/hpcrun/thread_data.h
@@ -63,6 +63,7 @@
 #include "epoch.h"
 #include "cct2metrics.h"
 #include "core_profile_trace_data.h"
+#include "ompt/ompt.h"
 
 #include <lush/lush-pthread.i>
 #include <unwind/common/backtrace.h>
@@ -265,6 +266,13 @@ typedef struct thread_data_t {
   // override that is called from dlopen (eg, malloc) must skip this
   // sample or else deadlock on the dlopen lock.
   bool inside_dlfcn;
+
+
+
+  // Daj da i mi nesto zapisemo, traga Johnu ostavimo
+  ompt_data_t* current_parallel_data;
+
+
 
 #ifdef ENABLE_CUDA
   gpu_data_t gpu_data;


### PR DESCRIPTION
Unwinding and collecting region call path is postponed until the end of region and happens only if any thread from team took a sample in that region.