### PR TITLE
hpcproftt is now a debugging tool only

### DIFF
--- a/doc/man/hpcproftt.tex
+++ b/doc/man/hpcproftt.tex
@@ -84,7 +84,7 @@ The third section of the profile reports the metric table.  This lists
 all metrics collected during the execution of an MPI rank or thread.
 Information about a metric includes its name, type, format, and whether
 there is another partner metric.  The show and showPercent fields
-indicate whether the metrics should be displayed by default in hpcvieer.
+indicate whether the metrics should be displayed by default in hpcviewer.
 The period field is used to scale the number of samples collected, e.g. to
 convert samples collected every 1M cache misses into cache miss counts.
 

--- a/doc/man/hpcproftt.tex
+++ b/doc/man/hpcproftt.tex
@@ -44,7 +44,7 @@
 
 \begin{Name}{1}{hpcproftt}{The HPCToolkit Performance Tools}{The HPCToolkit Performance Tools}{hpcproftt:\\ Correlation of Flat Profile Metrics for Teletype Output}
 
-\Prog{hpcproftt} generates textual dumps of profile files.
+\Prog{hpcproftt} generates textual dumps of call path profiles recorded by hpcrun.
 
 \end{Name}
 
@@ -57,34 +57,73 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Description}
 
-\Prog{hpcproftt} generates textual dumps of profile files.
-The profile list may contain either flat or call path profile files.
+\Prog{hpcproftt} generates textual dumps of call path profiles recorded
+by hpcrun.  The profile list may contain one or more call path profiles.
 
+This tool principally intended for use by HPCToolkit developers rather
+than end users. Under some circumstances, a user might be interested in
+examining the raw measurement data (1) if HPCToolkit's tool chain has a problem processing
+the measurement data, or (2) if he or she is interested in inspecting
+measurements data associated with an individual instruction, which is below the
+line-level attribution reported by HPCToolkit's graphical user interfaces.
 
-Warnings:
-\begin{itemize}
-\item On ISA's with variable sized instructions, histogram buckets (4 bytes in size) may contain information for more than one instruction.
-In this case, multiple instructions will report counts for the \emph{same} bucket.
+The first section of the output describes the profile header. The profile
+header contains information including the name of the executable, its
+path, and the value of the PATH environment variable when the program was
+run, along with other metadata including the batch scheduler job id, MPI
+rank, thread ID, host ID, process ID on the host, and times when the first
+and last samples were recorded if tracing was enabled during an execution.
 
-\item On some architectures, delays between event triggers, interrupt generation and sampling of the IP means that an event may be associated with a different instruction than one that caused the event.  It is not abnormal for this gap to be 50-70 instructions wide.
-\end{itemize}
+The second section describes the epoch header. Conceptually, measurement
+of an execution is divided into one or more epochs in time. Measurements
+taken during an epoch are collected and flushed to disk separately. This
+section is mostly of historical interest as now hpcrun typically collects
+measurements in a single epoch.
+
+The third section of the profile reports the metric table.  This lists
+all metrics collected during the execution of an MPI rank or thread.
+Information about a metric includes its name, type, format, and whether
+there is another partner metric.  The show and showPercent fields
+indicate whether the metrics should be displayed by default in hpcvieer.
+The period field is used to scale the number of samples collected, e.g. to
+convert samples collected every 1M cache misses into cache miss counts.
+
+The next section of the output reports information that HPCToolkit's
+collected about the application's load map during execution.  The load
+map consists of a series of pairs, where an executable or shared
+library is assigned an integer load module ID, known as an lm-id.
+Call path samples consist of a sequence of (load module ID, offset)
+pairs. Each pair represents a location in an application binary or one
+of its associated shared libraries. Load module IDs present in a call
+path profile generally correspond to load module IDs in this table. In
+certain cases, the special dummy load module ID 0 used to represent CCT
+nodes that are not associated with object code. The calling context tree
+root is an example of one of these nodes.
+
+The last component of the file is the Calling Context Tree (CCT). Each
+node in the tree has an ID, the ID of its parent in the tree, an
+(lm-id, lm-ip) pair that represents the load module and a relative
+instruction pointer within that load module that represents a location
+in a call path.  A node in the tree may or may not have non-zero metric
+values associated with it. If a node's ID is negative, that means the
+node is a leaf in the tree. If a node's ID is odd, that means that it
+was recorded in an associated trace file and must be handled carefully
+during post-processing.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Arguments}
 
 \begin{Description}
-\item[\Arg{profile-file}...] A list of flat profile files.
+\item[\Arg{profile-file}...] A list of profile files.
 \end{Description}
 
 Default values for an option's optional arguments are shown in \{\}.
 
-\subsection{Options: General}
+\subsection{Options}
 
 \begin{Description}
-\item[\OptoArg{-v}{n}, \OptoArg{--verbose}{n}] Verbose: generate progress messages to stderr at verbosity level \Arg{n}.  \{1\} 
 \item[\Opt{-V}, \Opt{--version}] Print version information.
 \item[\Opt{-h}, \Opt{--help}] Print help.
-\item[\OptoArg{--debug}{n}]   Debug: use debug level \Arg{n}. \{1\}
 \end{Description}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/doc/man/hpcproftt.tex
+++ b/doc/man/hpcproftt.tex
@@ -30,7 +30,7 @@
 \rcsInfo $Id$
 \setDate{\rcsInfoLongDate}
 }{
-\setDate{ 2012/04/19}
+\setDate{ 2018/08/27}
 \message{package rcsinfo not present, discard it}
 }
 
@@ -44,60 +44,22 @@
 
 \begin{Name}{1}{hpcproftt}{The HPCToolkit Performance Tools}{The HPCToolkit Performance Tools}{hpcproftt:\\ Correlation of Flat Profile Metrics for Teletype Output}
 
-\Prog{hpcproftt} correlates `flat' profile metrics with either source code structure or object code and generates textual output suitable for a terminal.
-Alternatively, it also generates textual dumps of profile files.
+\Prog{hpcproftt} generates textual dumps of profile files.
 
 \end{Name}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Synopsis}
 
-\Prog{hpcproftt} [--source] \oOpt{options} \Arg{profile-file}...
-
-\Prog{hpcproftt} --object \oOpt{options} \Arg{profile-file}...
-
-\Prog{hpcproftt} --dump \Arg{profile-file}...
+\Prog{hpcproftt} \Arg{profile-file}...
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Description}
 
-\Prog{hpcproftt} correlates `flat' profile metrics with either source code structure (the first and default mode) or object code (second mode) and generates textual output suitable for a terminal (hence the tt, for teletype, in its name).
-In both of these modes, \Prog{hpcproftt} expects a list of flat profile files.
-\Prog{hpcproftt} also supports a third mode in which it generates textual dumps of profile files.
-In this mode, the profile list may contain either flat or call path profile files.
+\Prog{hpcproftt} generates textual dumps of profile files.
+The profile list may contain either flat or call path profile files.
 
-\Prog{hpcproftt} defaults to source code correlation mode.
-Without any mode switch, it behaves as if passed \Opt{--source=pgm,lm}.
-
-\textbf{Source Source Structure Correlation}.
-First, \Prog{hpcproftt} creates raw metrics for every native event with in each profile file.
-Derived summary metrics can be optionally created with the \Opt{--metric} option.
-All metrics are normalized to use the unit 'events' rather than 'samples' since this enables meaningful comparisons and derived metrics.
-Since percents facilitate rapid comprehension (compared to values), all raw metrics display as percents; derived metrics likewise default to percent, if sensible.
-
-Then, \Prog{hpcproftt} correlates metrics to program structure.
-If \HTMLhref{hpcstruct.html}{\Cmd{hpcstruct}{1}} structure information is available, this is used for correlation; if not, a simple 'File | Procedure | Statement' structure is computed using the load module's line map.
-
-Finally, \Prog{hpcproftt} generates metric summaries and annotated source files to standard out.
-Each metric summary compares a certain source structure element (such as a procedure) with all other elements of that type across the whole program.
-Structure elements include: Program, Load Module, File, Procedure, Loop (requires \HTMLhref{hpcstruct.html}{\Cmd{hpcstruct}{1}}), and Statement.
-For example, the procedure summary shows (exclusive) metric values for each procedure in the program.
-(Structure elements are pruned if all corresponding metrics are 0.)
-Summaries are rank ordered by the first metric.
-\Prog{hpcproftt} optionally annotates source files with Statement (line) level metrics.
-Note that it can only annotate files found by combining debug information with \Opt{--include} search paths.
-
-%%% If the same native event name appears more than once, min/max/sum \emph{derived} events are computed.
-
-\textbf{Object Correlation}.
-
-\Prog{hpcproftt}'s object correlation mode is intended for inspection of fine-grained correlation.
-In contrast to the source structure correlation mode, true summaries are not computed; rather (like an annotated source file) \Prog{hpcproftt} generates annotated object code, i.e., procedures and instructions.
-Moreover, only raw metrics corresponding to the native events in \textbf{one} profile file may be correlated to the object code touched by those metrics.
-Accordingly, \Prog{hpcproftt} creates raw metrics for every native event in one profile file.
-Metrics use the unit 'samples' rather than 'events' and default to percents, though absolute values may optionally be displayed.
-Procedures are pruned from the output if no associated metric totals to the provided threshold.
 
 Warnings:
 \begin{itemize}
@@ -124,110 +86,6 @@ Default values for an option's optional arguments are shown in \{\}.
 \item[\Opt{-h}, \Opt{--help}] Print help.
 \item[\OptoArg{--debug}{n}]   Debug: use debug level \Arg{n}. \{1\}
 \end{Description}
-
-\subsection{Options: Source Structure Correlation}
-
-\begin{Description}
-\item[\OptoArg{--source}{=all,sum,pgm,lm,f,p,l,s,src}]
-\item[\OptoArg{--src}{=all,sum,pgm,lm,f,p,l,s,src}] 
-Correlate metrics to source code structure.
-Use the following flags to control which source code structures appear in the output:
-  \begin{itemize}
-  \item[all] all summaries plus annotated source files
-  \item[sum] all summaries
-  \item[pgm] program summary
-  \item[lm]  load module summary
-  \item[f]   files summary
-  \item[p]   procedure summary
-  \item[l]   loop summary
-  \item[s]   statement summary
-  \item[src] annotate source files with metrics; equivalent to \Opt{--srcannot '*'}
-  \end{itemize}
-Without \Opt{--source}, the default set of flags is \{pgm,lm\}; with \Opt{--source}, the default set is \{sum\}.
-
-\item[\OptArg{--srcannot}{glob}] 
-Annotate source files with path names that match file glob \Arg{glob}.
-(Protect glob characters from shell with single quotes or backslash.)
-May pass multiple times to logically OR additional globs.
-
-\item[\OptArg{-M}{metric}, \OptArg{--metric}{metric}]
-Specify the set of metrics to compute, where \Arg{metric} is one of the following:
-  \begin{itemize}
-  \item[sum] Sum over threads/processes
-  \item[stats] Sum, Mean, StdDev (standard deviation), CoefVar (coefficient of variation), Min, Max over threads/processes
-  \item[thread] per-thread/process metrics
-  \end{itemize}
-Default is 'thread'.
-
-\item[\OptArg{-I}{dir}, \OptArg{--include}{dir}]
-Use \Arg{dir} as a search directory to find source files.
-For a recursive search, append a '*' after the last slash, e.g., \verb+'/mypath/*'+ (quote or escape to protect from the shell).
-May pass multiple times.
-
-Note: With multiple search-directory arguments, it may be the case that file \Arg{f} exists within more than one search directory.
-In this case, the ambiguity is resolved in favor of the search directory that appears first on the command line.
-
-\item[\OptArg{-S}{file}, \OptArg{--structure}{file}]
-Use \HTMLhref{hpcstruct.html}{\Cmd{hpcstruct}{1}} structure file \Arg{file} for correlation.
-May pass multiple times (e.g., for shared libraries).
-
-\item[\OptArg{-R}{'old-path=new-path'}, \OptArg{--replace-path}{'old-path=new-path'}]
-Substitute instances of \Arg{old-path} with \Arg{new-path}; apply to all paths (e.g., a profile's load map and source code) for which \Arg{old-path} is a prefix.
-Use '\Bs'\ to escape instances of '=' within a path. May pass multiple times.
-
-Use this option when a profile or binary contains references to files that have been relocated, such as might occur with a file system change.
-\end{Description}
-
-\subsection{Options: Object Correlation}
-
-\begin{Description}
-
-\item[\OptoArg{--object}{=s}] 
-\item[\OptoArg{--obj}{=s}] 
-Correlate metrics with object code by annotating object code procedures and instructions. \{\}
-  \begin{itemize}
-  \item s: intermingle source line info with object code
-  \end{itemize}
-
-\item[\OptArg{--objannot}{glob}] 
-Annotate object procedures with (unmangled) names that match glob \Arg{glob}.
-(Protect glob characters from shell with single quotes or backslash.)
-May pass multiple times to logically OR additional globs.
-
-\item[\OptArg{--obj-threshold}{n}] 
-Prune procedures with an event count < \Arg{n} \{1\}
-
-\item[\Opt{--obj-values}] 
-Show raw metrics as values instead of percents
-
-\end{Description}
-
-\subsection{Options: Dump Raw Profile Data}
-
-\begin{Description}
-\item[\Opt{--dump}] Generate textual representation of raw profile data.
-\end{Description}
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Examples}
-
-\begin{itemize}
-
-\item Assume we have collected flat profiling information using \HTMLhref{hpcrun-flat.html}{\Cmd{hpcrun-flat}{1}}).
-Let the executable and profile be named \File{poissonSolve} and \File{poissonSolve.PAPI_L2_DCM-etc...}, respectively.
-Assume further that we wish to correlate derived summary metrics (Mean, RStdDev, Min, Max) with source code and generate summary tables.
-To do this, execute:
-\begin{verbatim}
-    hpcproftt --src --metric=sum poissonSolve.hpcrun*
-\end{verbatim}
-
-\item Using the same example as above, assume we wish to correlate the profile with object code.  Execute the following command:
-\begin{verbatim}
-    hpcproftt --obj poissonSolve.hpcrun*
-\end{verbatim}
-
-\end{itemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %\section{Notes}

--- a/src/tool/hpcproftt/Args.cpp
+++ b/src/tool/hpcproftt/Args.cpp
@@ -94,25 +94,12 @@ using std::string;
 
 static const char* version_info = HPCTOOLKIT_VERSION_STRING;
 
-static const char* usage_summary1 =
-"[--source] [options] <profile-file>...";
-
-static const char* usage_summary2 =
-"--object [options] <profile-file>...";
-
-static const char* usage_summary3 =
-"--dump <profile-file>...\n";
+static const char* usage_summary =
+"<profile-file>...\n";
 
 static const char* usage_details = "\
-hpcproftt correlates 'flat' profile metrics with either source code structure\n\
-(the first and default mode) or object code (second mode) and generates\n\
-textual output suitable for a terminal.  In both of these modes, hpcproftt\n\
-expects a list of flat profile files. hpcproftt also supports a third mode\n\
-in which it generates textual dumps of profile files.  In this mode, the\n\
+hpcproftt generates textual dumps of profile files.  The\n\
 profile list may contain either flat or call path profile files.\n\
-\n\
-hpcproftt defaults to source code correlation mode. Without any mode switch,\n\
-it behaves as if passed --source=pgm,lm.\n\
 \n\
 Options: General:\n\
   -v [<n>], --verbose [<n>]\n\
@@ -121,108 +108,13 @@ Options: General:\n\
   -V, --version        Print version information.\n\
   -h, --help           Print this help.\n\
   --debug [<n>]        Debug: use debug level <n>. {1}\n\
-\n\
-Options: Source Structure Correlation:\n\
-  --source[=all,sum,pgm,lm,f,p,l,s,src]\n\
-  --src[=all,sum,pgm,lm,f,p,l,s,src]\n\
-                       Correlate metrics to source code structure. Without\n\
-                       --source, default is {pgm,lm}; with, it is {sum}.\n\
-                         all: all summaries plus annotated source files\n\
-                         sum: all summaries\n\
-                         pgm: program summary\n\
-                         lm:  load module summary\n\
-                         f:   file summary\n\
-                         p:   procedure summary\n\
-                         l:   loop summary\n\
-                         s:   statement summary\n\
-                         src: annotate source files; equiv to --srcannot '*'\n\
-  --srcannot <glob>    Annotate source files with path names that match\n\
-                       file glob <glob>. (Protect glob characters from shell\n\
-                       with single quotes or backslash.) May pass multiple\n\
-                       times to logically OR additional globs.\n\
-  -M <metric>, --metric <metric>\n\
-                       Specify metrics to compute, where <metric> is one of\n\
-                       the following:\n\
-                         sum:   sum over threads/processes\n\
-                         stats: sum, mean, standard dev, coef of var, min, &\n\
-                                max over threads/processes\n\
-                         thread: per-thread metrics\n\
-                       Default: {thread}. May pass multiple times.\n\
-  -I <path>, --include <path>\n\
-                       Use <path> when searching for source files. For a\n\
-                       recursive search, append a '+' after the last slash,\n\
-                       e.g., '/mypath/+'. (Quote or escape to protect from\n\
-                       shell.) May pass multiple times.\n\
-  -S <file>, --structure <file>\n\
-                       Use hpcstruct structure file <file> for correlation.\n\
-                       May pass multiple times (e.g., for shared libraries).\n\
-  -R '<old-path>=<new-path>', --replace-path '<old-path>=<new-path>'\n\
-                       Substitute instances of <old-path> with <new-path>;\n\
-                       apply to all paths (profile\'s load map, source code)\n\
-                       for which <old-path> is a prefix.  Use '\\' to escape\n\
-                       instances of '=' within a path. May pass multiple\n\
-                       times.\n\
-\n\
-Options: Object Correlation:\n\
-  --object[=s], --obj[=s]\n\
-                       Correlate metrics with object code by annotating\n\
-                       object code procedures and instructions. {}\n\
-                         s: intermingle source line info with object code\n\
-  --objannot <glob>    Annotate object procedures with (unmangled) names that\n\
-                       match glob <glob>. (Protect glob characters from the\n\
-                       shell with single quotes or backslash.) May pass\n\
-                       multiple times to logically OR additional globs.\n\
-  --obj-threshold <n>  Prune procedures with an event count < n {1}\n\
-  --obj-values         Show raw metrics as values instead of percents\n\
-\n\
-Options: Dump Raw Profile Data:\n\
-  --dump               Generate textual representation of raw profile data.\n\
 ";
-
-
-static bool isOptArg_src(const char* x);
-static bool isOptArg_obj(const char* x);
-
 
 #define CLP CmdLineParser
 #define CLP_SEPARATOR "!!!"
 
 // Note: Changing the option name requires changing the name in Parse()
 CmdLineParser::OptArgDesc Args::optArgs[] = {
-  // Source structure correlation options
-  {  0 , "source",          CLP::ARG_OPT,  CLP::DUPOPT_CLOB, NULL,
-     isOptArg_src },
-  {  0 , "src",             CLP::ARG_OPT,  CLP::DUPOPT_CLOB, NULL,
-     isOptArg_src },
-  {  0 , "srcannot",        CLP::ARG_REQ,  CLP::DUPOPT_CAT,  CLP_SEPARATOR,
-     NULL },
-
-  { 'M', "metric",          CLP::ARG_REQ,  CLP::DUPOPT_CAT,  CLP_SEPARATOR,
-     NULL },
-
-  { 'I', "include",         CLP::ARG_REQ,  CLP::DUPOPT_CAT,  CLP_SEPARATOR,
-     NULL },
-  { 'S', "structure",       CLP::ARG_REQ,  CLP::DUPOPT_CAT,  CLP_SEPARATOR,
-     NULL },
-  { 'R', "replace-path",    CLP::ARG_REQ,  CLP::DUPOPT_CAT,  CLP_SEPARATOR,
-     NULL},
-
-  // Object correlation options
-  {  0 , "object",          CLP::ARG_OPT , CLP::DUPOPT_CLOB, NULL,
-     isOptArg_obj },
-  {  0 , "obj",             CLP::ARG_OPT , CLP::DUPOPT_CLOB, NULL,
-     isOptArg_obj },
-  {  0 , "objannot",        CLP::ARG_REQ,  CLP::DUPOPT_CAT,  CLP_SEPARATOR,
-     NULL },
-  {  0 , "obj-values",      CLP::ARG_NONE, CLP::DUPOPT_CLOB, NULL,
-     NULL },
-  {  0 , "obj-threshold",   CLP::ARG_REQ,  CLP::DUPOPT_CLOB, NULL,
-     NULL },
-
-  // Raw profile data
-  {  0 , "dump",            CLP::ARG_NONE, CLP::DUPOPT_CLOB, NULL,
-     NULL },
-
   // General
   { 'v', "verbose",         CLP::ARG_OPT,  CLP::DUPOPT_CLOB, NULL,
      CLP::isOptArg_long },
@@ -236,50 +128,6 @@ CmdLineParser::OptArgDesc Args::optArgs[] = {
 };
 
 #undef CLP
-
-
-static bool
-isOptArg_src(const char* x)
-{
-  string opt(x);
-  bool ret = true;
-  try {
-    Args::parseArg_source(NULL, opt, "");
-  }
-  catch (const Args::Exception& /*ex*/) {
-    // To enable good error messages, consider strings with a ratio of
-    // commas:characters >= 1/3 to be an attempt at a src argument.
-    // NOTE: this metric assumes an implicit comma at the end of the string
-    const double tolerance = 1.0/3.0;
-
-    double commas = 1;
-    for (size_t p = 0; (p = opt.find_first_of(',', p)) != string::npos; ++p) {
-      commas += 1;
-    }
-
-    double characters = (double)opt.size();
-    
-    ret = (commas / characters) >= tolerance;
-  }
-  return ret;
-}
-
-
-static bool
-isOptArg_obj(const char* x)
-{
-  string opt(x);
-  bool ret = true;
-  try {
-    Args::parseArg_object(NULL, opt, "");
-  }
-  catch (const Args::Exception& /*ex*/) {
-    // To enable good error messages, consider strings of size 1
-    return (opt.size() == 1);
-  }
-  return ret;
-}
-
 
 //***************************************************************************
 // Args
@@ -301,8 +149,6 @@ Args::Args(int argc, const char* const argv[])
 void
 Args::Ctor()
 {
-  mode = Mode_SourceCorrelation;
-
   obj_metricsAsPercents = true;
   obj_showSourceCode = false;
   obj_procThreshold = 1;
@@ -340,9 +186,7 @@ void
 Args::printUsage(std::ostream& os) const
 {
   os << "Usage: \n"
-     << "  " << getCmd() << " " << usage_summary1 << endl
-     << "  " << getCmd() << " " << usage_summary2 << endl
-     << "  " << getCmd() << " " << usage_summary3 << endl
+     << "  " << getCmd() << " " << usage_summary << endl
      << usage_details << endl;
 }
 
@@ -410,102 +254,6 @@ Args::parse(int argc, const char* const argv[])
       Diagnostics_SetDiagnosticFilterLevel(verb);
     }
 
-    // Check for other options: Source correlation options
-    if (parser.isOpt("source") || parser.isOpt("src")) {
-      mode = Mode_SourceCorrelation;
-      txt_summary = TxtSum_ALL;
-      
-      string opt;
-      if (parser.isOptArg("source"))   { opt = parser.getOptArg("source"); }
-      else if (parser.isOptArg("src")) { opt = parser.getOptArg("src"); }
-
-      if (!opt.empty()) {
-	txt_summary = Analysis::Args::TxtSum_NULL;
-	parseArg_source(this, opt, "--source/--src option");
-      }
-    }
-    if (parser.isOpt("srcannot")) {
-      txt_srcAnnotation = true;
-      string str = parser.getOptArg("srcannot");
-      StrUtil::tokenize_str(str, CLP_SEPARATOR, txt_srcFileGlobs);
-    }
-    if (parser.isOpt("include")) {
-      string str = parser.getOptArg("include");
-
-      std::vector<std::string> searchPaths;
-      StrUtil::tokenize_str(str, CLP_SEPARATOR, searchPaths);
-      
-      for (uint i = 0; i < searchPaths.size(); ++i) {
-	searchPathTpls.push_back(Analysis::PathTuple(searchPaths[i],
-						     Analysis::DefaultPathTupleTarget));
-      }
-    }
-    if (parser.isOpt("structure")) {
-      string str = parser.getOptArg("structure");
-      StrUtil::tokenize_str(str, CLP_SEPARATOR, structureFiles);
-    }
-   
-    if (parser.isOpt("replace-path")) {
-      string arg = parser.getOptArg("replace-path");
-      
-      std::vector<std::string> replacePaths;
-      StrUtil::tokenize_str(arg, CLP_SEPARATOR, replacePaths);
-      
-      for (uint i = 0; i < replacePaths.size(); ++i) {
-	int occurancesOfEquals =
-	  Analysis::Util::parseReplacePath(replacePaths[i]);
-	
-	if (occurancesOfEquals > 1) {
-	  ARG_ERROR("Too many occurances of \'=\'; make sure to escape any \'=\' in your paths");
-	}
-	else if(occurancesOfEquals == 0) {
-	  ARG_ERROR("The \'=\' between the old path and new path is missing");
-	}
-      }
-    }
-
-    if (parser.isOpt("metric")) {
-      prof_metrics = Analysis::Args::MetricFlg_NULL;
-
-      string str = parser.getOptArg("metric");
-
-      std::vector<std::string> metricVec;
-      StrUtil::tokenize_str(str, CLP_SEPARATOR, metricVec);
-
-      for (uint i = 0; i < metricVec.size(); ++i) {
-	parseArg_metric(this, metricVec[i], "--metric/-M option");
-      }
-    }
-    
-    // Check for other options: Object correlation options
-    if (parser.isOpt("object") || parser.isOpt("obj")) {
-      mode = Mode_ObjectCorrelation;
-
-      string opt;
-      if (parser.isOptArg("object"))   { opt = parser.getOptArg("object"); }
-      else if (parser.isOptArg("obj")) { opt = parser.getOptArg("obj"); }
-
-      if (!opt.empty()) {
-	parseArg_object(this, opt, "--object/--obj option");
-      }
-    }
-    if (parser.isOpt("objannot")) {
-      string str = parser.getOptArg("objannot");
-      StrUtil::tokenize_str(str, CLP_SEPARATOR, obj_procGlobs);
-    }
-    if (parser.isOpt("obj-values")) {
-      obj_metricsAsPercents = false;
-    }
-    if (parser.isOpt("obj-threshold")) {
-      const string& arg = parser.getOptArg("obj-threshold");
-      obj_procThreshold = CmdLineParser::toUInt64(arg);
-    }
-
-    // Check for other options: Dump raw profile data
-    if (parser.isOpt("dump")) {
-      mode = Mode_RawDataDump;
-    }
-
     // FIXME: sanity check that options correspond to mode
     
     // Check for required arguments
@@ -528,53 +276,6 @@ Args::parse(int argc, const char* const argv[])
   }
   catch (const Args::Exception& x) {
     ARG_ERROR(x.what());
-  }
-}
-
-
-void
-Args::parseArg_source(Args* args, const string& value, const char* errTag)
-{
-  std::vector<std::string> srcOptVec;
-  StrUtil::tokenize_char(value, ",", srcOptVec);
-
-  for (uint i = 0; i < srcOptVec.size(); ++i) {
-    const string& opt = srcOptVec[i];
-    
-    Analysis::Args::TxtSum flg = Analysis::Args::TxtSum_NULL;
-    if      (opt == "all") { flg = TxtSum_ALL; }
-    else if (opt == "sum") { flg = TxtSum_ALL; }
-    else if (opt == "pgm") { flg = TxtSum_fPgm; }
-    else if (opt == "lm")  { flg = TxtSum_fLM; }
-    else if (opt == "f")   { flg = TxtSum_fFile; }
-    else if (opt == "p")   { flg = TxtSum_fProc; }
-    else if (opt == "l")   { flg = TxtSum_fLoop; }
-    else if (opt == "s")   { flg = TxtSum_fStmt; }
-    else if (opt == "src") { ; }
-    else {
-      ARG_Throw(errTag << ": Unexpected value received: '" << opt << "'");
-    }
-
-    if (args) {
-      args->txt_summary = (args->txt_summary | flg);
-      if (opt == "all" || opt == "src") {
-	args->txt_srcAnnotation = true;
-      }
-    }
-  }
-}
-
-
-void
-Args::parseArg_object(Args* args, const string& value, const char* errTag)
-{
-  if (value == "s") {
-    if (args) {
-      args->obj_showSourceCode = true;
-    }
-  }
-  else {
-    ARG_Throw(errTag << ": Unexpected value received: '" << value << "'");
   }
 }
 

--- a/src/tool/hpcproftt/Args.cpp
+++ b/src/tool/hpcproftt/Args.cpp
@@ -98,16 +98,13 @@ static const char* usage_summary =
 "<profile-file>...\n";
 
 static const char* usage_details = "\
-hpcproftt generates textual dumps of profile files.  The\n\
-profile list may contain either flat or call path profile files.\n\
+hpcproftt generates textual dumps of call path profiles\n\
+recorded by hpcrun.  The profile list may contain one or\n\
+more call path profiles.\n\
 \n\
-Options: General:\n\
-  -v [<n>], --verbose [<n>]\n\
-                       Verbose: generate progress messages to stderr at\n\
-                       verbosity level <n>. {1}\n\
+Options:\n\
   -V, --version        Print version information.\n\
   -h, --help           Print this help.\n\
-  --debug [<n>]        Debug: use debug level <n>. {1}\n\
 ";
 
 #define CLP CmdLineParser
@@ -116,14 +113,10 @@ Options: General:\n\
 // Note: Changing the option name requires changing the name in Parse()
 CmdLineParser::OptArgDesc Args::optArgs[] = {
   // General
-  { 'v', "verbose",         CLP::ARG_OPT,  CLP::DUPOPT_CLOB, NULL,
-     CLP::isOptArg_long },
   { 'V', "version",         CLP::ARG_NONE, CLP::DUPOPT_CLOB, NULL,
      NULL },
   { 'h', "help",            CLP::ARG_NONE, CLP::DUPOPT_CLOB, NULL,
      NULL },
-  {  0 , "debug",           CLP::ARG_OPT,  CLP::DUPOPT_CLOB, NULL,  // hidden
-     CLP::isOptArg_long },
   CmdLineParser_OptArgDesc_NULL_MACRO // SGI's compiler requires this version
 };
 
@@ -228,15 +221,6 @@ Args::parse(int argc, const char* const argv[])
     // -------------------------------------------------------
     
     // Special options that should be checked first
-    if (parser.isOpt("debug")) {
-      int dbg = 1;
-      if (parser.isOptArg("debug")) {
-	const string& arg = parser.getOptArg("debug");
-	dbg = (int)CmdLineParser::toLong(arg);
-      }
-      Diagnostics_SetDiagnosticFilterLevel(dbg);
-      trace = dbg;
-    }
     if (parser.isOpt("help")) {
       printUsage(std::cerr);
       exit(1);
@@ -244,14 +228,6 @@ Args::parse(int argc, const char* const argv[])
     if (parser.isOpt("version")) {
       printVersion(std::cerr);
       exit(1);
-    }
-    if (parser.isOpt("verbose")) {
-      int verb = 1;
-      if (parser.isOptArg("verbose")) {
-	const string& arg = parser.getOptArg("verbose");
-	verb = (int)CmdLineParser::toLong(arg);
-      }
-      Diagnostics_SetDiagnosticFilterLevel(verb);
     }
 
     // FIXME: sanity check that options correspond to mode

--- a/src/tool/hpcproftt/Args.hpp
+++ b/src/tool/hpcproftt/Args.hpp
@@ -81,12 +81,6 @@
 
 class Args : public Analysis::Args {
 public:
-  enum Mode_t {
-    Mode_NULL,
-    Mode_SourceCorrelation,
-    Mode_ObjectCorrelation,
-    Mode_RawDataDump
-  };
 
   class Exception : public Diagnostics::Exception {
   public:
@@ -137,17 +131,9 @@ public:
   getCmd() /*const*/;
 
   static void
-  parseArg_source(Args* args, const std::string& opts, const char* errTag);
-
-  static void
-  parseArg_object(Args* args, const std::string& opts, const char* errTag);
-
-  static void
   parseArg_metric(Args* args, const std::string& opts, const char* errTag);
 
 public:
-  // Parsed Data
-  Mode_t mode;
 
   // Object Correlation args
   std::vector<std::string> obj_procGlobs;

--- a/src/tool/hpcproftt/Makefile.am
+++ b/src/tool/hpcproftt/Makefile.am
@@ -120,9 +120,8 @@ MYCLEAN = @HOST_LIBTREPOSITORY@
 pkglibdir = @my_pkglibdir@
 pkglibexecdir = @my_pkglibexecdir@
 
-bin_SCRIPTS = hpcproftt
-
 pkglibexec_PROGRAMS = hpcproftt-bin
+pkglibexec_SCRIPTS = hpcproftt
 
 hpcproftt_bin_SOURCES   = $(MYSOURCES)
 hpcproftt_bin_CFLAGS    = $(MYCFLAGS)

--- a/src/tool/hpcproftt/Makefile.in
+++ b/src/tool/hpcproftt/Makefile.in
@@ -136,7 +136,8 @@ mkinstalldirs = $(SHELL) $(top_srcdir)/config/mkinstalldirs
 CONFIG_HEADER = $(top_builddir)/src/include/hpctoolkit-config.h
 CONFIG_CLEAN_FILES = hpcproftt
 CONFIG_CLEAN_VPATH_FILES =
-am__installdirs = "$(DESTDIR)$(pkglibexecdir)" "$(DESTDIR)$(bindir)"
+am__installdirs = "$(DESTDIR)$(pkglibexecdir)" \
+	"$(DESTDIR)$(pkglibexecdir)"
 PROGRAMS = $(pkglibexec_PROGRAMS)
 am__objects_1 = hpcproftt_bin-main.$(OBJEXT) \
 	hpcproftt_bin-Args.$(OBJEXT)
@@ -184,7 +185,7 @@ am__uninstall_files_from_dir = { \
     || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
-SCRIPTS = $(bin_SCRIPTS)
+SCRIPTS = $(pkglibexec_SCRIPTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -583,7 +584,7 @@ MYLDADD = \
 @HOST_CPU_X86_FAMILY_FALSE@MY_LIB_XED = 
 @HOST_CPU_X86_FAMILY_TRUE@MY_LIB_XED = $(XED2_LIB_FLAGS)
 MYCLEAN = @HOST_LIBTREPOSITORY@
-bin_SCRIPTS = hpcproftt
+pkglibexec_SCRIPTS = hpcproftt
 hpcproftt_bin_SOURCES = $(MYSOURCES)
 hpcproftt_bin_CFLAGS = $(MYCFLAGS)
 hpcproftt_bin_CXXFLAGS = $(MYCXXFLAGS)
@@ -687,12 +688,12 @@ clean-pkglibexecPROGRAMS:
 hpcproftt-bin$(EXEEXT): $(hpcproftt_bin_OBJECTS) $(hpcproftt_bin_DEPENDENCIES) $(EXTRA_hpcproftt_bin_DEPENDENCIES) 
 	@rm -f hpcproftt-bin$(EXEEXT)
 	$(AM_V_CXXLD)$(hpcproftt_bin_LINK) $(hpcproftt_bin_OBJECTS) $(hpcproftt_bin_LDADD) $(LIBS)
-install-binSCRIPTS: $(bin_SCRIPTS)
+install-pkglibexecSCRIPTS: $(pkglibexec_SCRIPTS)
 	@$(NORMAL_INSTALL)
-	@list='$(bin_SCRIPTS)'; test -n "$(bindir)" || list=; \
+	@list='$(pkglibexec_SCRIPTS)'; test -n "$(pkglibexecdir)" || list=; \
 	if test -n "$$list"; then \
-	  echo " $(MKDIR_P) '$(DESTDIR)$(bindir)'"; \
-	  $(MKDIR_P) "$(DESTDIR)$(bindir)" || exit 1; \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(pkglibexecdir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(pkglibexecdir)" || exit 1; \
 	fi; \
 	for p in $$list; do \
 	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
@@ -711,17 +712,17 @@ install-binSCRIPTS: $(bin_SCRIPTS)
 	while read type dir files; do \
 	     if test "$$dir" = .; then dir=; else dir=/$$dir; fi; \
 	     test -z "$$files" || { \
-	       echo " $(INSTALL_SCRIPT) $$files '$(DESTDIR)$(bindir)$$dir'"; \
-	       $(INSTALL_SCRIPT) $$files "$(DESTDIR)$(bindir)$$dir" || exit $$?; \
+	       echo " $(INSTALL_SCRIPT) $$files '$(DESTDIR)$(pkglibexecdir)$$dir'"; \
+	       $(INSTALL_SCRIPT) $$files "$(DESTDIR)$(pkglibexecdir)$$dir" || exit $$?; \
 	     } \
 	; done
 
-uninstall-binSCRIPTS:
+uninstall-pkglibexecSCRIPTS:
 	@$(NORMAL_UNINSTALL)
-	@list='$(bin_SCRIPTS)'; test -n "$(bindir)" || exit 0; \
+	@list='$(pkglibexec_SCRIPTS)'; test -n "$(pkglibexecdir)" || exit 0; \
 	files=`for p in $$list; do echo "$$p"; done | \
 	       sed -e 's,.*/,,;$(transform)'`; \
-	dir='$(DESTDIR)$(bindir)'; $(am__uninstall_files_from_dir)
+	dir='$(DESTDIR)$(pkglibexecdir)'; $(am__uninstall_files_from_dir)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
@@ -873,7 +874,7 @@ check-am: all-am
 check: check-am
 all-am: Makefile $(PROGRAMS) $(SCRIPTS)
 installdirs:
-	for dir in "$(DESTDIR)$(pkglibexecdir)" "$(DESTDIR)$(bindir)"; do \
+	for dir in "$(DESTDIR)$(pkglibexecdir)" "$(DESTDIR)$(pkglibexecdir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -936,7 +937,7 @@ install-dvi: install-dvi-am
 
 install-dvi-am:
 
-install-exec-am: install-binSCRIPTS install-pkglibexecPROGRAMS
+install-exec-am: install-pkglibexecPROGRAMS install-pkglibexecSCRIPTS
 	@$(NORMAL_INSTALL)
 	$(MAKE) $(AM_MAKEFLAGS) install-exec-hook
 install-html: install-html-am
@@ -977,7 +978,7 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-binSCRIPTS uninstall-pkglibexecPROGRAMS
+uninstall-am: uninstall-pkglibexecPROGRAMS uninstall-pkglibexecSCRIPTS
 
 .MAKE: install-am install-exec-am install-strip
 
@@ -985,17 +986,17 @@ uninstall-am: uninstall-binSCRIPTS uninstall-pkglibexecPROGRAMS
 	clean-libtool clean-pkglibexecPROGRAMS cscopelist-am ctags \
 	ctags-am distclean distclean-compile distclean-generic \
 	distclean-libtool distclean-tags distdir dvi dvi-am html \
-	html-am info info-am install install-am install-binSCRIPTS \
-	install-data install-data-am install-dvi install-dvi-am \
-	install-exec install-exec-am install-exec-hook install-html \
-	install-html-am install-info install-info-am install-man \
-	install-pdf install-pdf-am install-pkglibexecPROGRAMS \
-	install-ps install-ps-am install-strip installcheck \
-	installcheck-am installdirs maintainer-clean \
-	maintainer-clean-generic mostlyclean mostlyclean-compile \
-	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
-	tags tags-am uninstall uninstall-am uninstall-binSCRIPTS \
-	uninstall-pkglibexecPROGRAMS
+	html-am info info-am install install-am install-data \
+	install-data-am install-dvi install-dvi-am install-exec \
+	install-exec-am install-exec-hook install-html install-html-am \
+	install-info install-info-am install-man install-pdf \
+	install-pdf-am install-pkglibexecPROGRAMS \
+	install-pkglibexecSCRIPTS install-ps install-ps-am \
+	install-strip installcheck installcheck-am installdirs \
+	maintainer-clean maintainer-clean-generic mostlyclean \
+	mostlyclean-compile mostlyclean-generic mostlyclean-libtool \
+	pdf pdf-am ps ps-am tags tags-am uninstall uninstall-am \
+	uninstall-pkglibexecPROGRAMS uninstall-pkglibexecSCRIPTS
 
 .PRECIOUS: Makefile
 

--- a/src/tool/hpcproftt/hpcproftt.in
+++ b/src/tool/hpcproftt/hpcproftt.in
@@ -31,7 +31,7 @@ binary_name=hpcproftt-bin
 # Find path to this script
 #------------------------------------------------------------
 
-hpc_path_to_root=..
+hpc_path_to_root=../..
 @export_hpctoolkit@
 
 #------------------------------------------------------------

--- a/src/tool/hpcproftt/main.cpp
+++ b/src/tool/hpcproftt/main.cpp
@@ -74,12 +74,6 @@ static int
 realmain(int argc, char* const* argv);
 
 static int
-main_srcCorrelation(const Args& args);
-
-static int
-main_objCorrelation(const Args& args);
-
-static int
 main_rawData(const std::vector<string>& profileFiles);
 
 
@@ -128,87 +122,13 @@ static int
 realmain(int argc, char* const* argv) 
 {
   Args args(argc, argv);  // exits if error on command line
-
-  int ret = 0;
-
-  switch (args.mode) {
-    case Args::Mode_SourceCorrelation:
-      ret = main_srcCorrelation(args);
-      break;
-    case Args::Mode_ObjectCorrelation:
-      ret = main_objCorrelation(args);
-      break;
-    case Args::Mode_RawDataDump:
-      ret = main_rawData(args.profileFiles);
-      break;
-    default:
-      DIAG_Die("Unhandled case: " << args.mode);
-  }
-
-  return ret; 
+  return main_rawData(args.profileFiles); 
 }
 
 
 //****************************************************************************
 //
 //****************************************************************************
-
-static void
-makeDerivedMetrics(Prof::Metric::Mgr& metricMgr,
-		   uint /*Analysis::Args::MetricFlg*/ metrics);
-
-static int
-main_srcCorrelation(const Args& args)
-{
-  RealPathMgr::singleton().searchPaths(args.searchPathStr());
-
-  //-------------------------------------------------------
-  // Create metric descriptors
-  //-------------------------------------------------------
-  Prof::Metric::Mgr metricMgr;
-  metricMgr.makeRawMetrics(args.profileFiles);
-  makeDerivedMetrics(metricMgr, args.prof_metrics);
-
-  //-------------------------------------------------------
-  // Correlate metrics with program structure and Generate output
-  //-------------------------------------------------------
-  Prof::Struct::Tree structure("", new Prof::Struct::Root(""));
-
-  Analysis::Flat::Driver driver(args, metricMgr, structure);
-  int ret = driver.run();
-
-  return ret;
-}
-
-
-static int
-main_objCorrelation(const Args& args)
-{
-  std::ostream& os = std::cout;
-  
-  for (uint i = 0; i < args.profileFiles.size(); ++i) {
-    const std::string& fnm = args.profileFiles[i];
-
-    // 0. Generate nice header
-    os << std::setfill('=') << std::setw(77) << "=" << std::endl;
-    os << fnm << std::endl;
-    os << std::setfill('=') << std::setw(77) << "=" << std::endl;
-
-    // 1. Create metric descriptors
-    Prof::Metric::Mgr metricMgr;
-    metricMgr.makeRawMetrics(fnm, 
-			     false/*isUnitsEvents*/, 
-			     args.obj_metricsAsPercents);
-    
-    // 2. Correlate
-    Analysis::Flat::correlateWithObject(metricMgr, os,
-					args.obj_showSourceCode,
-					args.obj_procGlobs,
-					args.obj_procThreshold);
-  }
-  return 0;
-}
-
 
 static int
 main_rawData(const std::vector<string>& profileFiles)
@@ -229,38 +149,3 @@ main_rawData(const std::vector<string>& profileFiles)
 }
 
 //****************************************************************************
-
-static void
-makeDerivedMetrics(Prof::Metric::Mgr& metricMgr,
-		   uint /*Analysis::Args::MetricFlg*/ metrics)
-{
-  if (Analysis::Args::MetricFlg_isSum(metrics)) {
-    bool needAllStats =
-      Analysis::Args::MetricFlg_isSet(metrics,
-				      Analysis::Args::MetricFlg_StatsAll);
-    bool needMultiOccurance = Analysis::Args::MetricFlg_isThread(metrics);
-    metricMgr.makeSummaryMetrics(needAllStats, needMultiOccurance);
-  }
-  
-  if (!Analysis::Args::MetricFlg_isThread(metrics)) {
-    using namespace Prof;
-
-    for (uint i = 0; i < metricMgr.size(); i++) {
-      Metric::ADesc* m = metricMgr.metric(i);
-      Metric::SampledDesc* mm = dynamic_cast<Metric::SampledDesc*>(m);
-      if (mm) {
-	mm->isVisible(false);
-	mm->isSortKey(false);
-      }
-    }
-
-    for (uint i = 0; i < metricMgr.size(); i++) {
-      Metric::ADesc* m = metricMgr.metric(i);
-      Metric::DerivedDesc* mm = dynamic_cast<Metric::DerivedDesc*>(m);
-      if (mm) {
-	mm->isSortKey(true);
-	break;
-      }
-    }
-  }
-}


### PR DESCRIPTION
- remove (unavailable) capabilities and options for anything other than dumping hpcrun files
- fix help message and man page
- move hpcproftt from bin directory to libexec/hpctoolkit by adjusting Makefile.am and hpcproftt.in