### PR TITLE
Fix libunwind

### DIFF
--- a/src/tool/hpcrun/unwind/common/libunw_intervals.c
+++ b/src/tool/hpcrun/unwind/common/libunw_intervals.c
@@ -117,7 +117,7 @@ libunw_finalize_cursor(hpcrun_unw_cursor_t* cursor)
   bool found = uw_recipe_map_lookup(pc, DWARF_UNWINDER, &cursor->unwr_info);
   compute_normalized_ips(cursor);
   TMSG(UNW, "unw_step: advance pc: %p\n", pc);
-  cursor->libunw_status = LIBUNW_OK;
+  cursor->libunw_status = found ? LIBUNW_READY : LIBUNW_UNAVAIL;
   return found;
 }
 

--- a/src/tool/hpcrun/unwind/common/libunw_intervals.h
+++ b/src/tool/hpcrun/unwind/common/libunw_intervals.h
@@ -58,7 +58,7 @@ void libunw_unw_init_cursor(hpcrun_unw_cursor_t* cursor, void* context);
 
 btuwi_status_t libunw_build_intervals(char *beg_insn, unsigned int len);
 
-step_state libunw_find_step(hpcrun_unw_cursor_t* cursor);
+bool libunw_finalize_cursor(hpcrun_unw_cursor_t* cursor);
 
 step_state libunw_take_step(hpcrun_unw_cursor_t* cursor);
 

--- a/src/tool/hpcrun/unwind/common/std_unw_cursor.h
+++ b/src/tool/hpcrun/unwind/common/std_unw_cursor.h
@@ -76,8 +76,8 @@
 #endif
 
 enum libunw_state {
-  LIBUNW_OK,
-  LIBUNW_FAIL,
+  LIBUNW_UNAVAIL,
+  LIBUNW_READY,
 };
 
 typedef struct hpcrun_unw_cursor_t {

--- a/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
+++ b/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
@@ -179,8 +179,8 @@ hpcrun_unw_step(hpcrun_unw_cursor_t* cursor)
   if (state == STEP_ERROR) {
     unw_cursor_t *unw_cursor = &(cursor->uc);
     if (unw_step(unw_cursor)) {
-      cursor->libunw_status = LIBUNW_OK;
-      state = libunw_find_step(cursor);
+      state = STEP_OK;
+      libunw_finalize_cursor(cursor);
     }
   }
   return state;

--- a/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
+++ b/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
@@ -174,7 +174,7 @@ step_state
 hpcrun_unw_step(hpcrun_unw_cursor_t* cursor)
 {
   step_state state = STEP_ERROR;
-  if (cursor->libunw_status == LIBUNW_OK)
+  if (cursor->libunw_status == LIBUNW_READY)
     state = libunw_unw_step(cursor);
   if (state == STEP_ERROR) {
     unw_cursor_t *unw_cursor = &(cursor->uc);

--- a/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
+++ b/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
@@ -174,8 +174,7 @@ step_state
 hpcrun_unw_step(hpcrun_unw_cursor_t* cursor)
 {
   step_state state = STEP_ERROR;
-  if (cursor->libunw_status == LIBUNW_READY)
-    state = libunw_unw_step(cursor);
+  state = libunw_unw_step(cursor);
   if (state == STEP_ERROR) {
     unw_cursor_t *unw_cursor = &(cursor->uc);
     if (unw_step(unw_cursor)) {

--- a/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
+++ b/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
@@ -422,7 +422,7 @@ hpcrun_unw_step(hpcrun_unw_cursor_t *cursor)
       libunw_finalize_cursor(cursor);
     }
 
-    if (unw_res == STEP_STOP || unw_res == STEP_ERROR) {
+    if (unw_res == STEP_STOP || unw_res == STEP_OK) {
       return unw_res;
     }
   }

--- a/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
+++ b/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
@@ -244,7 +244,7 @@ hpcrun_unw_init_cursor(hpcrun_unw_cursor_t* cursor, void* context)
   unw_get_reg(&cursor->uc, UNW_TDEP_BP, (unw_word_t *)&bp);
   save_registers(cursor, pc, bp, sp, NULL);
 
-  if (cursor->libunw_status == LIBUNW_OK)
+  if (cursor->libunw_status == LIBUNW_READY)
     return;
 
   bool found = uw_recipe_map_lookup(pc, NATIVE_UNWINDER, &cursor->unwr_info);
@@ -400,7 +400,6 @@ hpcrun_retry_libunw_find_step(hpcrun_unw_cursor_t *cursor,
   LV_MCONTEXT_SP(&uc.uc_mcontext) = (intptr_t)sp;
   LV_MCONTEXT_BP(&uc.uc_mcontext) = (intptr_t)bp;
   unw_init_local(&cursor->uc, &uc);
-  cursor->libunw_status = LIBUNW_OK;
   return libunw_finalize_cursor(cursor);
 }
 
@@ -409,7 +408,7 @@ hpcrun_unw_step(hpcrun_unw_cursor_t *cursor)
 {
   step_state unw_res;
 
-  if (cursor->libunw_status == LIBUNW_OK) {
+  if (cursor->libunw_status == LIBUNW_READY) {
     unw_res = libunw_take_step(cursor);
 
     void *pc, **bp, *sp;


### PR DESCRIPTION

- Report a successful libunwind step even if the resulting PC is in code that lacks EH or debug frames.
- Adjust reporting of libunwind handling available for the cursor PC in the cursor.
- Recognize when the current PC is in libmonitor's "bottom frame" even if unwinding information is not available.