### PR TITLE
Fix cfg parser for CUDA-9.2 nvdisasm changes

### DIFF
--- a/src/lib/analysis/CallPath-CudaCFG.cpp
+++ b/src/lib/analysis/CallPath-CudaCFG.cpp
@@ -430,7 +430,7 @@ copyPath(IncomingSamplesMap &incoming_samples,
     new_node->metric(i) *= adjust_factor;
   }
 
-  bool isCall = getCudaCallStmt(cur) == NULL ? isSCCNode(cur) : false;
+  bool isCall = getCudaCallStmt(cur) == NULL ? isSCCNode(cur) : true;
   if (isCall) {
     // Case 1: Call node or SCC node, skip to the procedure
     auto *n = cct_graph.outgoing_nodes(cur)->second[0];
@@ -441,8 +441,14 @@ copyPath(IncomingSamplesMap &incoming_samples,
     }
     double cur_samples = incoming_samples[n][cur];
     adjust_factor *= cur_samples / sum_samples;
+#ifdef DEBUG_CALLPATH_CUDACFG
+    std::cout << "Lay over a call" << std::endl;
+#endif
     copyPath(incoming_samples, cct_graph, n, new_node, adjust_factor);
   } else if (!cur->isLeaf()) {
+#ifdef DEBUG_CALLPATH_CUDACFG
+    std::cout << "Not a call" << std::endl;
+#endif
     // Case 2: Iterate through children
     Prof::CCT::ANodeChildIterator it(cur, NULL/*filter*/);
     for (Prof::CCT::ANode *n = NULL; (n = it.current()); ++it) {

--- a/src/lib/analysis/CallPath-CudaCFG.cpp
+++ b/src/lib/analysis/CallPath-CudaCFG.cpp
@@ -107,6 +107,9 @@ using std::string;
 
 
 #define DEBUG_CALLPATH_CUDACFG 1
+#define OUTPUT_SCC_FRAME 1
+#define SIMULATE_SCC_WITH_LOOP 1
+
 
 namespace Analysis {
 
@@ -127,10 +130,12 @@ static void
 findGPURoots(CCTGraph &cct_graph, std::vector<Prof::CCT::ANode *> &gpu_roots);
 
 static bool
-findRecursion(CCTGraph &cct_graph, std::unordered_map<Prof::CCT::ANode *, Prof::CCT::ANode *> &cct_groups);
+findRecursion(CCTGraph &cct_graph,
+  std::unordered_map<Prof::CCT::ANode *, std::vector<Prof::CCT::ANode *> > &cct_groups);
 
 static void
-mergeSCCNodes(CCTGraph &cct_graph, std::unordered_map<Prof::CCT::ANode *, Prof::CCT::ANode *> &cct_groups);
+mergeSCCNodes(CCTGraph &cct_graph, CCTGraph &old_cct_graph,
+  std::unordered_map<Prof::CCT::ANode *, std::vector<Prof::CCT::ANode *> > &cct_groups);
 
 static void
 gatherIncomingSamples(CCTGraph &cct_graph,
@@ -179,10 +184,36 @@ getCudaCallStmt(Prof::CCT::ANode *node) {
 }
 
 
+static inline Prof::Struct::Proc *
+getProcStmt(Prof::CCT::ANode *node) {
+  auto *strct = node->structure();
+  if (strct != NULL && strct->type() == Prof::Struct::ANode::TyProc) {
+    auto *proc = dynamic_cast<Prof::Struct::Proc *>(strct);
+    return proc;
+  }
+  return NULL;
+}
+
+
 static inline void
 debugCallGraph(CCTGraph &cct_graph) {
   for (auto it = cct_graph.edgeBegin(); it != cct_graph.edgeEnd(); ++it) {
-    std::cout << it->from->id() << "->" << it->to->id() << std::endl;
+    std::string from, to;
+    if (getProcStmt(it->from) != NULL) {
+      from = "(P)";
+    } else if (isSCCNode(it->from)) {
+      from = "(S)";
+    } else if (getCudaCallStmt(it->from)) {
+      from = "(C)";
+    }
+    if (getProcStmt(it->to) != NULL) {
+      to = "(P)";
+    } else if (isSCCNode(it->to)) {
+      to = "(S)";
+    } else if (getCudaCallStmt(it->to)) {
+      to = "(C)";
+    }
+    std::cout << it->from->id()  << from << "->" << it->to->id() << to << std::endl;
   }
 }
 
@@ -203,16 +234,18 @@ transformCudaCFGMain(Prof::CallPath::Profile& prof) {
   }
 
   // TODO(keren): Handle SCCs
-  std::unordered_map<Prof::CCT::ANode *, Prof::CCT::ANode *> cct_groups;
+  std::unordered_map<Prof::CCT::ANode *, std::vector<Prof::CCT::ANode *> > cct_groups;
   if (findRecursion(*cct_graph, cct_groups)) {
-#ifndef DEBUG_CALLPATH_CUDACFG
-    std::cout << "Find recursive calls" << std::endl;
-#endif
+    if (DEBUG_CALLPATH_CUDACFG) {
+      std::cout << "Find recursive calls" << std::endl;
+    }
     CCTGraph *old_cct_graph = cct_graph;
     cct_graph = new CCTGraph();
-    mergeSCCNodes(*cct_graph, cct_groups);
+    mergeSCCNodes(*cct_graph, *old_cct_graph, cct_groups);
     delete old_cct_graph;
-    return ; 
+    if (DEBUG_CALLPATH_CUDACFG) {
+      debugCallGraph(*cct_graph);
+    }
   }
 
   // Find gpu global functions
@@ -224,6 +257,9 @@ transformCudaCFGMain(Prof::CallPath::Profile& prof) {
   gatherIncomingSamples(*cct_graph, *(prof.metricMgr()), incoming_samples);
 
   // Copy from every gpu_root to leafs
+  if (DEBUG_CALLPATH_CUDACFG) {
+    std::cout << "Construct calling context tree" << std::endl;
+  }
   constructCallingContext(incoming_samples, *cct_graph, gpu_roots);
 
   delete cct_graph;
@@ -260,9 +296,8 @@ constructCCTGraph(Prof::CCT::ANode *root, CallMap &call_map,
   Prof::CCT::ANodeIterator it(root, NULL/*filter*/, false/*leavesOnly*/,
     IteratorStack::PreOrder);
   for (Prof::CCT::ANode *n = NULL; (n = it.current()); ++it) {
-    auto *strct = n->structure();
-    if (strct != NULL && strct->type() == Prof::Struct::ANode::TyProc) {
-      auto *proc = dynamic_cast<Prof::Struct::Proc *>(strct);
+    auto *proc = getProcStmt(n);
+    if (proc != NULL) {
       auto vma_set = *(proc->vmaSet().begin());
       VMA vma = vma_set.beg();
       if (call_map.find(vma) != call_map.end()) {
@@ -277,7 +312,8 @@ constructCCTGraph(Prof::CCT::ANode *root, CallMap &call_map,
 
 
 static bool
-findRecursion(CCTGraph &cct_graph, std::unordered_map<Prof::CCT::ANode *, Prof::CCT::ANode *> &cct_groups) {
+findRecursion(CCTGraph &cct_graph,
+  std::unordered_map<Prof::CCT::ANode *, std::vector<Prof::CCT::ANode *> > &cct_groups) {
   std::unordered_map<int, int> graph_index_converter;
   std::unordered_map<int, Prof::CCT::ANode *> graph_index_reverse_converter;
   int start_index = 0;
@@ -317,47 +353,65 @@ findRecursion(CCTGraph &cct_graph, std::unordered_map<Prof::CCT::ANode *, Prof::
     boost::make_iterator_property_map(c.begin(), boost::get(boost::vertex_index, G)));
 
   for (size_t i = 0; i < c.size(); ++i) {
-    cct_groups[graph_index_reverse_converter[i]] = graph_index_reverse_converter[c[i]];
+    cct_groups[graph_index_reverse_converter[c[i]]].push_back(graph_index_reverse_converter[i]);
   }
 
-#ifdef DEBUG_CALLPATH_CUDACFG
-  std::cout << "CCT graph vertices " << cct_graph.size() << std::endl;
-  std::cout << "Num vertices " << num_vertices(G) << std::endl;
-  std::cout << "Find scc " << num << std::endl;
-  for (size_t i = 0; i != c.size(); ++i) {
-    std::cout << "Vertex " << i
-      <<" is in component " << c[i] << std::endl;
+  if (DEBUG_CALLPATH_CUDACFG) {
+    std::cout << "CCT graph vertices " << cct_graph.size() << std::endl;
+    std::cout << "Num vertices " << num_vertices(G) << std::endl;
+    std::cout << "Find scc " << num << std::endl;
+    for (size_t i = 0; i != c.size(); ++i) {
+      std::cout << "Vertex " << i
+        <<" is in component " << c[i] << std::endl;
+    }
   }
-#endif
 
   return num != static_cast<int>(cct_graph.size());
 }
 
 
 void
-mergeSCCNodes(CCTGraph &cct_graph, std::unordered_map<Prof::CCT::ANode *, Prof::CCT::ANode *> &cct_groups) {
-  std::unordered_map<Prof::CCT::ANode *, int> cct_group_sizes;
-  // Count group size
+mergeSCCNodes(CCTGraph &cct_graph, CCTGraph &old_cct_graph,
+  std::unordered_map<Prof::CCT::ANode *, std::vector<Prof::CCT::ANode *> > &cct_groups) {
+  // Map node to group
+  std::unordered_map<Prof::CCT::ANode *, Prof::CCT::ANode *> cct_group_reverse_map;
   for (auto it = cct_groups.begin(); it != cct_groups.end(); ++it) {
-    cct_group_sizes[it->second]++;
+    auto &vec = it->second;
+    auto *group = it->first;
+    for (auto *n : vec) {
+      cct_group_reverse_map[n] = group;
+    }
   }
 
-  // Add SCC frame nodes into call graph
-  for (auto it = cct_graph.edgeBegin(); it != cct_graph.edgeEnd(); ++it) {
-    if (cct_group_sizes[cct_groups[it->to]] > 1) {  // Create a SCC frame node
-      // Init a SCC frame
-      if (!isSCCNode(cct_groups[it->to])) {
-        cct_groups[it->to] = new Prof::CCT::SCC(NULL);
+  // Add edges between SCCs
+  for (auto it = cct_groups.begin(); it != cct_groups.end(); ++it) {
+    Prof::CCT::ANode *scc_node = new Prof::CCT::SCC(NULL);
+    auto &vec = it->second;
+    for (auto *n : vec) {
+      if (getProcStmt(n) != NULL) {
+        // scc_node->proc
+        cct_graph.addEdge(scc_node, n);
+      } 
+    }
+    auto *group = it->first;
+    for (auto nit = old_cct_graph.edgeBegin(); nit != old_cct_graph.edgeEnd(); ++nit) {
+      // call->scc
+      if (cct_group_reverse_map[nit->from] != group && getCudaCallStmt(nit->from) != NULL) {
+        bool find = false;
+        for (auto *n : vec) {
+          if (nit->to == n) {
+            find = true;
+            break;
+          }
+        }
+        if (find) {
+          // from->scc_in_node
+          cct_graph.addEdge(nit->from, scc_node);
+        }
+      } else if (cct_group_reverse_map[nit->to] != group && getCudaCallStmt(nit->to) != NULL) {
+        // proc->call
+        cct_graph.addEdge(nit->from, nit->to);
       }
-      Prof::CCT::ANode *scc_frame = cct_groups[it->to];
-
-      // Add SCC frame into CCT graph
-      cct_graph.addEdge(it->from, scc_frame);
-      // Adjust CCT tree
-      it->to->unlink();
-      it->to->link(scc_frame);
-    } else {
-      cct_graph.addEdge(it->from, it->to);
     }
   }
 }
@@ -383,10 +437,10 @@ gatherIncomingSamples(CCTGraph &cct_graph,
       break;
     }
   }
+  // Gather call and scc samples
   for (auto it = cct_graph.nodeBegin(); it != cct_graph.nodeEnd(); ++it) {
     Prof::CCT::ANode *node = *it;
-    auto *strct = node->structure();
-    if (strct != NULL && strct->type() == Prof::Struct::ANode::TyProc) {
+    if (isSCCNode(node)) {
       if (cct_graph.incoming_nodes(node) != cct_graph.incoming_nodes_end()) {
         std::vector<Prof::CCT::ANode *> &vec = cct_graph.incoming_nodes(node)->second;
         if (sample_metric_idx == -1) {
@@ -409,9 +463,26 @@ static void
 constructCallingContext(IncomingSamplesMap &incoming_samples,
   CCTGraph &cct_graph, std::vector<Prof::CCT::ANode *> &gpu_roots) {
   for (auto *gpu_root : gpu_roots) {
-    auto *parent = gpu_root->parent();
-    gpu_root->unlink();
-    copyPath(incoming_samples, cct_graph, gpu_root, parent, 1.0);
+    auto edge_iterator = cct_graph.outgoing_nodes(gpu_root);  // must be an scc node
+    for (auto *n : edge_iterator->second) {
+      if (gpu_root->childCount() > 1 && OUTPUT_SCC_FRAME) {  // keep SCC frame
+        auto *new_node = gpu_root->clone();
+        auto *parent = n->parent();  
+        new_node->link(parent);
+        copyPath(incoming_samples, cct_graph, n, new_node, 1.0);
+      } else {
+        auto *parent = n->parent();  
+        copyPath(incoming_samples, cct_graph, n, parent, 1.0);
+      }
+    }
+  }
+  for (auto it = cct_graph.nodeBegin(); it != cct_graph.nodeEnd(); ++it) {
+    Prof::CCT::ANode *node = *it;
+    if (getProcStmt(node) != NULL) {
+      node->unlink();
+    }
+  }
+  for (auto *gpu_root : gpu_roots) {
     deleteTree(gpu_root);
   }
 }
@@ -422,34 +493,57 @@ copyPath(IncomingSamplesMap &incoming_samples,
   CCTGraph &cct_graph, 
   Prof::CCT::ANode *cur, Prof::CCT::ANode *prev,
   double adjust_factor) {
+  bool isSCC = isSCCNode(cur);
   // Copy node
-  auto *new_node = cur->clone();
-  new_node->link(prev);
+  Prof::CCT::ANode *new_node;
+  if (isSCC && SIMULATE_SCC_WITH_LOOP) {
+    new_node = new Prof::CCT::Loop(prev);
+  } else {
+    new_node = cur->clone();
+    new_node->link(prev);
+  }
   // Adjust metrics
   for (size_t i = 0; i < new_node->numMetrics(); ++i) {
     new_node->metric(i) *= adjust_factor;
   }
 
-  bool isCall = getCudaCallStmt(cur) == NULL ? isSCCNode(cur) : true;
+  bool isCall = getCudaCallStmt(cur) == NULL ? false : true;
   if (isCall) {
-    // Case 1: Call node or SCC node, skip to the procedure
-    auto *n = cct_graph.outgoing_nodes(cur)->second[0];
-    n->unlink();
-    double sum_samples = 0.0;
-    for (auto &neighor : incoming_samples[n]) {
-      sum_samples += neighor.second;
+    // Case 1: Call node, skip to the procedure
+    auto edge_iterator = cct_graph.outgoing_nodes(cur);
+    if (edge_iterator != cct_graph.outgoing_nodes_end()) {  // some calls won't have outgoing edges
+      for (auto *n : edge_iterator->second) {
+        double sum_samples = 0.0;
+        for (auto &neighor : incoming_samples[n]) {
+          sum_samples += neighor.second;
+        }
+        double cur_samples = incoming_samples[n][cur];
+        adjust_factor *= cur_samples / sum_samples;
+        if (DEBUG_CALLPATH_CUDACFG) {
+          std::cout << "Lay over a call" << std::endl;
+        }
+        copyPath(incoming_samples, cct_graph, n, new_node, adjust_factor);
+      }
     }
-    double cur_samples = incoming_samples[n][cur];
-    adjust_factor *= cur_samples / sum_samples;
-#ifdef DEBUG_CALLPATH_CUDACFG
-    std::cout << "Lay over a call" << std::endl;
-#endif
-    copyPath(incoming_samples, cct_graph, n, new_node, adjust_factor);
+  } else if (isSCC) {
+    // Case 2: SCC node
+    auto edge_iterator = cct_graph.outgoing_nodes(cur);
+    for (auto *n : edge_iterator->second) {
+      if (DEBUG_CALLPATH_CUDACFG) {
+        std::cout << "Lay over a SCC" << std::endl;
+      }
+      // Keep scc in frame
+      if (new_node->childCount() > 1 && OUTPUT_SCC_FRAME) {
+        copyPath(incoming_samples, cct_graph, n, new_node, adjust_factor);
+      } else {
+        copyPath(incoming_samples, cct_graph, n, prev, adjust_factor);
+      }
+    }
   } else if (!cur->isLeaf()) {
-#ifdef DEBUG_CALLPATH_CUDACFG
-    std::cout << "Not a call" << std::endl;
-#endif
-    // Case 2: Iterate through children
+    if (DEBUG_CALLPATH_CUDACFG) {
+      std::cout << "Not a call or SCC" << std::endl;
+    }
+    // Case 3: Iterate through children
     Prof::CCT::ANodeChildIterator it(cur, NULL/*filter*/);
     for (Prof::CCT::ANode *n = NULL; (n = it.current()); ++it) {
       copyPath(incoming_samples, cct_graph, n, new_node, adjust_factor);

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -119,7 +119,7 @@ using namespace std;
 #define SYMTAB_ARCH_CUDA(symtab) 0
 #endif
 
-#define DEBUG_CFG_SOURCE  0
+#define DEBUG_CFG_SOURCE  1
 #define DEBUG_MAKE_SKEL   1
 #define DEBUG_SHOW_GAPS   0
 #define DEBUG_SKEL_SUMMARY  1
@@ -1535,6 +1535,7 @@ findLoopHeader(FileInfo * finfo, GroupInfo * ginfo, ParseAPI::Function * func,
 
       if (type != ParseAPI::CALL && type != ParseAPI::CALL_FT) {
         if (bset.find(dest) != bset.end()) { in_loop = true; }
+
         else { out_loop = true; }
       }
     }

--- a/src/lib/banal/cuda/CFGParser.cpp
+++ b/src/lib/banal/cuda/CFGParser.cpp
@@ -28,7 +28,7 @@ TargetType CFGParser::get_target_type(const Inst *inst) {
     type = TargetType::COND_NOT_TAKEN;
   } else if (inst->predicate.find("@") != std::string::npos) {
     type = TargetType::COND_TAKEN;
-  } else if (inst->is_call()) {
+  } else if (inst->is_call) {
     type = TargetType::CALL;
   } else {
     type = TargetType::DIRECT;
@@ -39,7 +39,7 @@ TargetType CFGParser::get_target_type(const Inst *inst) {
 
 TargetType CFGParser::get_fallthrough_type(const Inst *inst) {
   TargetType type;
-  if (inst->is_call()) {
+  if (inst->is_call) {
     type = TargetType::CALL_FT;
   } else {
     type = TargetType::FALLTHROUGH;
@@ -96,7 +96,7 @@ void CFGParser::parse_calls(std::vector<Function *> &functions) {
   for (auto *function : functions) {
     for (auto *block : function->blocks) {
       for (auto *inst : block->insts) {
-        if (inst->is_call()) {
+        if (inst->is_call) {
           std::string &operand = inst->operands[0];
           Function *callee_function = 0;
           for (auto *ff : functions) {
@@ -291,7 +291,7 @@ void CFGParser::split_blocks(
     // Step 1: filter out all branch instructions
     for (size_t i = 0; i < block->insts.size(); ++i) {
       Inst *inst = block->insts[i];
-      if (inst->is_call()) {
+      if (inst->is_call) {
         split_inst_index.push_back(i);
         continue;
       }
@@ -381,16 +381,16 @@ void CFGParser::split_blocks(
             TargetType next_block_type = TargetType::CALL_FT;
             Block *next_block = new_blocks[i + 1];
             new_block->targets.push_back(new Target(
-                new_block->insts.back(), next_block, next_block_type));
+              new_block->insts.back(), next_block, next_block_type));
           } else {
             Block *next_block = new_blocks[i + 1];
             TargetType next_block_type = get_fallthrough_type(target->inst);
             TargetType target_block_type = get_target_type(target->inst);
 
             new_block->targets.push_back(new Target(
-                target->inst, next_block, next_block_type));
+              target->inst, next_block, next_block_type));
             new_block->targets.push_back(new Target(
-                target->inst, target->block, target_block_type));
+              target->inst, target->block, target_block_type));
           }
         }
       }

--- a/src/lib/banal/cuda/CFGParser.cpp
+++ b/src/lib/banal/cuda/CFGParser.cpp
@@ -13,20 +13,36 @@ static void debug_blocks(const std::vector<Block *> &blocks) {
       " , name: " << block->name << std::endl;
     std::cout << "Range: [" << block->insts[0]->offset <<
       ", " << block->insts.back()->offset << "]" << std::endl;
+    for (auto *target : block->targets) {
+      std::cout << "Target block id: " << target->block->id <<
+        " , name: " << target->block->name << std::endl;
+    }
+    std::cout << std::endl;
   }
 }
 
 
-TargetType CFGParser::get_target_type(const Block *source_block, Inst *inst) {
+TargetType CFGParser::get_target_type(const Inst *inst) {
   TargetType type;
   if (inst->predicate.find("!@") != std::string::npos) {
-    type = TargetType::COND_TAKEN;
-  } else if (inst->predicate.find("@") != std::string::npos) {
     type = TargetType::COND_NOT_TAKEN;
-  } else if (inst == source_block->insts.back()) {
-    type = TargetType::FALLTHROUGH;
+  } else if (inst->predicate.find("@") != std::string::npos) {
+    type = TargetType::COND_TAKEN;
+  } else if (inst->is_call()) {
+    type = TargetType::CALL;
   } else {
     type = TargetType::DIRECT;
+  }
+  return type;
+}
+
+
+TargetType CFGParser::get_fallthrough_type(const Inst *inst) {
+  TargetType type;
+  if (inst->is_call()) {
+    type = TargetType::CALL_FT;
+  } else {
+    type = TargetType::FALLTHROUGH;
   }
   return type;
 }
@@ -101,21 +117,36 @@ void CFGParser::parse_calls(std::vector<Function *> &functions) {
 }
 
 
-size_t CFGParser::find_block_parent(size_t node) {
-  size_t parent = _block_parent[node];
-  size_t block_size = _block_parent.size();
-  if (parent == block_size) {
-    return _block_parent[node] = node;
-  } else if (parent == node) {
-    return node;
-  } else {
-    return _block_parent[node] = find_block_parent(parent);
+void CFGParser::find_block_parent(const std::vector<Block *> &blocks) {
+  bool incoming_nodes[blocks.size()];
+  std::fill(incoming_nodes, incoming_nodes + blocks.size(), false);
+  for (auto *block : blocks) {
+    for (auto *target : block->targets) {
+      incoming_nodes[target->block->id] = true;
+    }
+  }
+  bool visited[blocks.size()];
+  std::fill(visited, visited + blocks.size(), false);
+  for (auto *block : blocks) {
+    if (visited[block->id] == false) {
+      if (incoming_nodes[block->id] == false) {
+        visited[block->id] = true;
+        _block_parent[block->id] = block->id;
+        unite_blocks(block, visited, block->id);
+      }
+    }
   }
 }
 
 
-void CFGParser::unite_blocks(size_t l, size_t r) {
-  _block_parent[l] = find_block_parent(r);
+void CFGParser::unite_blocks(const Block *block, bool *visited, size_t parent) {
+  for (auto *target : block->targets) {
+    if (visited[target->block->id] == false) {
+      visited[target->block->id] = true;
+      _block_parent[target->block->id] = parent;
+      unite_blocks(target->block, visited, parent);
+    }
+  }
 }
 
 
@@ -130,9 +161,9 @@ static bool compare_target_ptr(Target *l, Target *r) {
 
 
 void CFGParser::parse(const Graph &graph, std::vector<Function *> &functions) {
-  std::unordered_map<size_t, Block *> block_map;
+  std::unordered_map<size_t, Block *> block_id_map;
+  std::unordered_map<std::string, Block *> block_name_map;
   std::vector<Block *> blocks;
-  std::vector<std::pair<size_t, size_t> > edges;
 
   // Parse every vertex to build blocks
   for (auto *vertex : graph.vertices) {
@@ -145,53 +176,24 @@ void CFGParser::parse(const Graph &graph, std::vector<Function *> &functions) {
     }
 
     blocks.push_back(block);
-    block_map[block->id] = block;
+    block_id_map[block->id] = block;
+    block_name_map[block->name] = block;
   }
 
-  // Parse every edge to build block relations
-  for (auto *edge : graph.edges) {
-    edges.push_back(std::pair<size_t, size_t>(edge->source_id, edge->target_id));
-    Block *target_block = block_map[edge->target_id];
-    Block *source_block = block_map[edge->source_id];
-    
-    // Link blocks
-    for (size_t i = 0; i < source_block->insts.size(); ++i) {
-      Inst *inst = source_block->insts[i];
-      if (inst->port == edge->source_port[0]) {
-        if (inst->dual_first == true || inst->dual_second == true) {
-          Inst *dual_inst = NULL;
-          if (inst->dual_first) {
-            dual_inst = source_block->insts[i + 1];
-          } else if (inst->dual_second) {
-            dual_inst = source_block->insts[i - 1];
-          }
-          TargetType type = get_target_type(source_block, inst);
-          TargetType dual_type = get_target_type(source_block, dual_inst);
-          if (type == TargetType::COND_TAKEN || type == TargetType::COND_NOT_TAKEN) {
-            source_block->targets.push_back(new Target(inst, target_block, type));
-          } else if (dual_type == TargetType::COND_TAKEN || dual_type == TargetType::COND_NOT_TAKEN) {
-            source_block->targets.push_back(new Target(dual_inst, target_block, dual_type));
-          } else {
-            source_block->targets.push_back(new Target(inst, target_block, type));
-          }
-        } else {
-          TargetType type = get_target_type(source_block, inst);
-          source_block->targets.push_back(new Target(inst, target_block, type));
-        }
+  // Find target block labels by checking every instruction
+  for (auto *block : blocks) {
+    for (auto *inst : block->insts) {
+      if (inst->target.size() != 0) {
+        auto *target_block = block_name_map[inst->target];
+        TargetType type = get_target_type(inst);
+        auto *target = new Target(inst, target_block, type);
+        block->targets.push_back(target);
       }
-    }
-    // Some edges may not have port information
-    if (source_block->targets.size() == 0) {
-      Inst *inst = source_block->insts.back();
-      TargetType type;
-      if (inst->is_call()) {
-        type = TargetType::CALL_FT;
-      } else {
-        type = TargetType::FALLTHROUGH;
-      }
-      source_block->targets.push_back(new Target(inst, target_block, type));
     }
   }
+
+  // Link fallthrough edges at the end of blocks
+  link_fallthrough_edges(graph, blocks, block_id_map);
 
 #ifdef DEBUG_CUDA_CFGPARSER
   std::cout << "Before split" << std::endl;
@@ -200,40 +202,34 @@ void CFGParser::parse(const Graph &graph, std::vector<Function *> &functions) {
 
   // Split blocks for loop analysis ans CALL instructions
   // TODO(keren): identify RET edges?
-  split_blocks(edges, blocks, block_map);
+  split_blocks(blocks, block_id_map);
 
 #ifdef DEBUG_CUDA_CFGPARSER
   std::cout << "After split" << std::endl;
   debug_blocks(blocks);
 #endif
 
-  // Resize before union find
-  _block_parent.resize(blocks.size());
-  for (size_t i = 0; i < blocks.size(); ++i) {
-    _block_parent[i] = blocks.size();
-  }
-
   // Find toppest block
-  for (size_t i = 0; i < edges.size(); ++i) {
-    auto source_id = edges[i].first;
-    auto target_id = edges[i].second;
-    unite_blocks(target_id, source_id);
-  }
+  _block_parent.resize(blocks.size());
+  find_block_parent(blocks);
 
   // Build functions
   size_t function_id = 0;
   for (auto *block : blocks) {
     // Sort block targets according to inst offset
     std::sort(block->targets.begin(), block->targets.end(), compare_target_ptr);
-    if (find_block_parent(block->id) == block->id) {
+    if (_block_parent[block->id] == block->id) {
       // Filter out self contained useless loops. A normal function will not start with "."
-      if (block_map[block->id]->name[0] == '.') {
+      if (block_id_map[block->id]->name[0] == '.') {
         continue;
       }
-      Function *function = new Function(function_id, block_map[block->id]->name);
+      Function *function = new Function(function_id, block_id_map[block->id]->name);
       ++function_id;
       for (auto *bb : blocks) {
-        if (find_block_parent(bb->id) == block->id) {
+        if (_block_parent[bb->id] == block->id) {
+#ifdef DEBUG_CUDA_CFGPARSER
+          std::cout << "Link " << bb->name << " with " << block_id_map[_block_parent[block->id]]->name << std::endl;
+#endif
           function->blocks.push_back(bb);
         }
       }
@@ -252,10 +248,42 @@ void CFGParser::parse(const Graph &graph, std::vector<Function *> &functions) {
 }
 
 
+
+void CFGParser::link_fallthrough_edges(
+  const Graph &graph,
+  const std::vector<Block *> &blocks,
+  std::unordered_map<size_t, Block *> &block_id_map) {
+  std::map<std::pair<size_t, size_t>, size_t> edges;
+  for (auto *edge : graph.edges) {
+    edges[std::pair<size_t, size_t>(edge->source_id, edge->target_id)]++;
+  }
+
+  for (auto *block : blocks) {
+    for (auto *target : block->targets) {
+      auto source_id = block->id;
+      auto target_id = target->block->id;
+      edges[std::pair<size_t, size_t>(source_id, target_id)]--;
+    }
+  }
+
+  for (auto edge : edges) {
+    if (edge.second != 0) {
+      auto source_id = edge.first.first;
+      auto target_id = edge.first.second;
+      auto *block = block_id_map[source_id];
+      auto *target_block = block_id_map[target_id];
+      auto *inst = block->insts.back();
+      auto type = get_fallthrough_type(inst);
+      auto *target = new Target(inst, target_block, type);
+      block->targets.push_back(target);
+    }
+  }
+}
+
+
 void CFGParser::split_blocks(
-  std::vector<std::pair<size_t, size_t> > &edges,
   std::vector<Block *> &blocks,
-  std::unordered_map<size_t, Block *> &block_map) {
+  std::unordered_map<size_t, Block *> &block_id_map) {
   size_t extra_block_id = blocks.size();
   std::vector<Block *> candidate_blocks;
   for (auto *block : blocks) {
@@ -279,7 +307,8 @@ void CFGParser::split_blocks(
     std::cout << "Split index:" << std::endl;
     for (size_t i = 0; i < split_inst_index.size(); ++i) {
       std::cout << "Block: " << block->name <<
-        ", offset: " << block->insts[i]->offset << std::endl;
+        ", offset: " << block->insts[split_inst_index[i]]->offset <<
+        " " << block->insts[split_inst_index[i]]->opcode << std::endl;
     }
 #endif
 
@@ -316,7 +345,7 @@ void CFGParser::split_blocks(
           new_block = new Block(extra_block_id++, block_name);
           // Update block records
           candidate_blocks.push_back(new_block);
-          block_map[new_block->id] = new_block;
+          block_id_map[new_block->id] = new_block;
         }
         new_blocks.push_back(new_block);
         // Update instructions
@@ -338,7 +367,7 @@ void CFGParser::split_blocks(
             }
           }
         } else {
-          // A conditional call is treated by branch split, not call split
+          // A conditional call is treated as a branch split, not call split
           bool call_split = true;
           Target *target = NULL;
           for (size_t j = 0; j < targets.size(); ++j) {
@@ -353,30 +382,15 @@ void CFGParser::split_blocks(
             Block *next_block = new_blocks[i + 1];
             new_block->targets.push_back(new Target(
                 new_block->insts.back(), next_block, next_block_type));
-            // Push back new edge
-            edges.push_back(std::pair<size_t, size_t>(new_block->id, next_block->id));
           } else {
-            TargetType next_block_type;
-            TargetType target_block_type;
             Block *next_block = new_blocks[i + 1];
-
-            if (target->type == TargetType::COND_TAKEN) {
-              target_block_type = TargetType::COND_TAKEN;
-              next_block_type = TargetType::COND_NOT_TAKEN;
-            } else if (target->type == TargetType::COND_NOT_TAKEN) {
-              target_block_type = TargetType::COND_NOT_TAKEN;
-              next_block_type = TargetType::COND_TAKEN;
-            } else {
-              target_block_type = TargetType::DIRECT;
-              next_block_type = TargetType::INDIRECT;
-            }
+            TargetType next_block_type = get_fallthrough_type(target->inst);
+            TargetType target_block_type = get_target_type(target->inst);
 
             new_block->targets.push_back(new Target(
                 target->inst, next_block, next_block_type));
             new_block->targets.push_back(new Target(
                 target->inst, target->block, target_block_type));
-            // Push back new edge
-            edges.push_back(std::pair<size_t, size_t>(new_block->id, next_block->id));
           }
         }
       }

--- a/src/lib/banal/cuda/CFGParser.hpp
+++ b/src/lib/banal/cuda/CFGParser.hpp
@@ -22,14 +22,21 @@ class CFGParser {
 
   void parse_inst_strings(const std::string &label, std::deque<std::string> &inst_strings);
 
-  void split_blocks(std::vector<std::pair<size_t, size_t> > &edges,
-    std::vector<Block *> &blocks, std::unordered_map<size_t, Block *> &block_map);
+  void link_fallthrough_edges(
+    const Graph &graph,
+    const std::vector<Block *> &blocks,
+    std::unordered_map<size_t, Block *> &block_id_map);
 
-  size_t find_block_parent(size_t node);
+  void split_blocks(std::vector<Block *> &blocks,
+    std::unordered_map<size_t, Block *> &block_id_map);
 
-  void unite_blocks(size_t l, size_t r);
+  void find_block_parent(const std::vector<Block *> &blocks);
 
-  TargetType get_target_type(const Block *source_block, Inst *inst);
+  void unite_blocks(const Block *block, bool *visited, size_t parent);
+
+  TargetType get_target_type(const Inst *inst);
+
+  TargetType get_fallthrough_type(const Inst *inst);
 
  private:
   std::vector<size_t> _block_parent;

--- a/src/lib/banal/cuda/CudaCFGFactory.cpp
+++ b/src/lib/banal/cuda/CudaCFGFactory.cpp
@@ -2,6 +2,8 @@
 #include "CudaFunction.hpp"
 #include <iostream>
 
+#define DEBUG_CUDA_CFGFACTORY 1
+
 namespace Dyninst {
 namespace ParseAPI {
 
@@ -14,7 +16,14 @@ Function *CudaCFGFactory::mkfunc(Address addr, FuncSource src,
       CudaFunction *ret_func = new CudaFunction(addr, name, obj, region, isrc);
 
       bool first_entry = true;
+#ifdef DEBUG_CUDA_CFGFACTORY
+      std::cout << "function: " << function->name << std::endl;
+#endif
       for (auto *block : function->blocks) {
+#ifdef DEBUG_CUDA_CFGFACTORY
+        std::cout << "block: " << block->name << std::endl;
+#endif
+          
         CudaBlock *ret_block = NULL;
         if (_block_filter.find(block->id) == _block_filter.end()) {
           std::vector<Offset> inst_offsets;
@@ -50,6 +59,9 @@ Function *CudaCFGFactory::mkfunc(Address addr, FuncSource src,
           }
 
           Edge *ret_edge = new Edge(ret_block, ret_target_block, target->type);
+#ifdef DEBUG_CUDA_CFGFACTORY
+          std::cout << "edge: "<< " -> " << target->block->name << std::endl;
+#endif
           ret_edge->install();
           edges_.add(*ret_edge);
         }


### PR DESCRIPTION
Now it works for a simple sample, but I still need to do the following things.

- [x] Check why an unknown node exists when parsing sm_60 cubins.

- [x] Check why cuobjdump (cuda-9.2) fails to parse a cubin.

- [x] Conclude the exact differences between cfgs generated by different versions of cuda tools.

- [x] Find out what opcodes actually represent jumps or branches that have a edge in the control flow graph.

- [x] Refine my parser, probably turns it into a separate repository.

- [x] Confirm hpctoolkit works on creating SCCs with cuda-9.2.
