### PR TITLE
Merge irreducible loops.

### DIFF
--- a/src/lib/banal/Struct-Inline.hpp
+++ b/src/lib/banal/Struct-Inline.hpp
@@ -273,9 +273,10 @@ public:
   long  file_index;
   long  base_index;
   long  line_num;
+  bool  irred;
 
   LoopInfo(TreeNode *nd, FLPSeqn &pth, const std::string &nm, VMA vma,
-	   long file, long base, long line)
+	   long file, long base, long line, bool ir = false)
   {
     node = nd;
     path = pth;
@@ -284,6 +285,7 @@ public:
     file_index = file;
     base_index = base;
     line_num = line;
+    irred = ir;
   }
 
   // delete the subtree 'node' in ~TreeNode(), not here.


### PR DESCRIPTION
If L1 is an irreducible loop and L2 is an irreducible subloop and L1
and L2 have the same file and line attribution, then merge L2 into L1.
It's likely there is really only one loop in the source code.

This only applies to irreducible loops.  Natural (reducible) loops are
assumed to be correct.