### PR TITLE
stack trolling for dyninst instrumentation frame 

### DIFF
--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -613,7 +613,7 @@ makeStructure(string filename,
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < modVec.size(); i++) {
 	    Module * mod = modVec[i];
-	    auto lineinfo = mod->parseLineInformation();
+	    mod->parseLineInformation();
       }
     }  // end parallel
 
@@ -696,7 +696,6 @@ makeStructure(string filename,
 
       delete code_obj;
       delete code_src;
-      cout << "close symtab " << endl;
       Inline::closeSymtab();
     }
   }
@@ -1034,7 +1033,6 @@ addProc(FileMap * fileMap, ProcInfo * pinfo, string & filenm,
     ginfo = new GroupInfo(sym_func, start, end, alt_file);
     finfo->groupMap[start] = ginfo;
   }
-  cout << "ProcInfo - entry vma: " << hex << pinfo->entry_vma << dec << endl;
   ginfo->procMap[pinfo->entry_vma] = pinfo;
 
 #if DEBUG_MAKE_SKEL
@@ -1135,9 +1133,8 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	    filenm = svec[0]->getFile();
 	    line = svec[0]->getLine();
 	    RealPathMgr::singleton().realpath(filenm);
-     } else {
-          cerr << " getProcLineMap returns empty statement symbol start:  " << hex << sym_start << dec << endl;
-      }
+      } 
+
       if (vma == sym_start) {
 	//
 	// case 1 -- group leader of a valid symtab func.  take proc
@@ -1150,8 +1147,8 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 
 	if (mangled_it != sym_func->mangled_names_end()) {
 	  linknm = *mangled_it;
-      auto p = linknm.find("_dyninst");
-      if (p != string::npos) {
+      auto p = linknm.find("_dyninst"); // find if the link name contains _dyninst suffix
+      if (p != string::npos) { // if found the _dyninst suffix, remove it before demangling
          linknm.erase(p, string::npos);
       }
 	  //if (opts.ourDemangle) {
@@ -1228,7 +1225,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       // this normally only happens for plt funcs.
       //
       string linknm = func->name();
-      auto p = linknm.find("_dyninst");
+      auto p = linknm.find("_dyninst"); 
       if (p != string::npos) {
          linknm.erase(p, string::npos);
       }

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -511,12 +511,10 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
 
   // a known file and unknown line is now legal, but we require that
   // any line map must contain a file name
-   /*
   if (! svec.empty() && svec[0]->getFile() == "") {
     cout << "clearing svec for empty file name " << endl;
     svec.clear();
   }
-  */
   cout << "end get statement " << hex << vma << dec << endl;
 }
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -618,8 +618,8 @@ makeStructure(string filename,
 	    Module * mod = modVec[i];
         cout << "parse line information for mod: " << mod->fullName() << endl;
 	    auto lineinfo = mod->parseLineInformation();
-        auto stringTblPtr = lineinfo->getStrings();
-        cout << *stringTblPtr << endl;
+       // auto stringTblPtr = lineinfo->getStrings();
+       //cout << *stringTblPtr << endl;
       }
     }  // end parallel
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -484,6 +484,7 @@ LoopInfoLessThan(LoopInfo * l1, LoopInfo * l2)
 static void
 getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
 {
+    cout << "getStatement called " << hex << vma << dec << endl;
   svec.clear();
 
   // try the Module in sym_func first as a hint
@@ -514,6 +515,7 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
     cout << "clearing svec for empty file name " << endl;
     svec.clear();
   }
+  cout << "end get statement " << hex << vma << dec << endl;
 }
 
 //----------------------------------------------------------------------

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -500,7 +500,7 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
     for (auto mit = modSet.begin(); mit != modSet.end(); ++mit) {
       (*mit)->getSourceLines(svec, vma);
       if (! svec.empty()) {
-	break;
+	    break;
       }
     }
   }
@@ -508,6 +508,7 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
   // a known file and unknown line is now legal, but we require that
   // any line map must contain a file name
   if (! svec.empty() && svec[0]->getFile() == "") {
+      cout << "clearning svec for emtpy file name " << endl;
     svec.clear();
   }
 }

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -615,7 +615,9 @@ makeStructure(string filename,
       for (uint i = 0; i < modVec.size(); i++) {
 	    Module * mod = modVec[i];
         cout << "parse line information for mod: " << mod->fullName() << endl;
-	    mod->parseLineInformation();
+	    auto lineinfo = mod->parseLineInformation();
+        auto stringTblPtr = lineinfo->getStrings();
+        cout << *stringTblPtr << endl;
       }
     }  // end parallel
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1157,7 +1157,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
      } else {
           cerr << " getProcLineMap returns empty statement symbol start:  " << hex << sym_start << dec << endl;
       }
-
+      cout << "where is bad alloc " << endl;
       if (vma == sym_start) {
 	//
 	// case 1 -- group leader of a valid symtab func.  take proc

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1127,6 +1127,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
     if (found && sym_func != NULL && region != NULL
 	&& reg_start <= vma && vma < reg_end)
     {
+      cout << "for vma " << hex << vma << dec << " we found the containing function " << endl;
       string filenm = unknown_base;
       string linknm = unknown_link + vma_str;
       string prettynm = unknown_proc + " " + vma_str + " [" + basename + "]";
@@ -1192,6 +1193,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	  parse_filenm = pvec[0]->getFile();
 	  parse_line = pvec[0]->getLine();
 	  RealPathMgr::singleton().realpath(parse_filenm);
+      cout << "parse_filenm: " << parse_filenm << " parse_line " << parse_line << endl;
 	}
 
 	string parse_base = FileUtil::basename(parse_filenm.c_str());

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -660,7 +660,7 @@ makeStructure(string filename,
     makeWorkList(fileMap, wlPrint, wlLaunch);
 
     Output::printLoadModuleBegin(outFile, elfFile->getFileName());
-
+    
 #pragma omp parallel  default(none)				\
     shared(wlPrint, wlLaunch, num_done, output_mtx)		\
     firstprivate(outFile, gapsFile, search_path, gaps_filenm, cuda_file)
@@ -756,6 +756,7 @@ doWorkItem(WorkItem * witem, string & search_path, bool cuda_file,
 static void
 makeWorkList(FileMap * fileMap, WorkList & wlPrint, WorkList & wlLaunch)
 {
+    cout << "makeWorkList " << endl;
   double total_cost = 0.0;
 
   wlPrint.clear();
@@ -1060,7 +1061,7 @@ addProc(FileMap * fileMap, ProcInfo * pinfo, string & filenm,
 static FileMap *
 makeSkeleton(CodeObject * code_obj, const string & basename)
 {
-    
+  cout << "start of make skeleton\n" << endl;    
   FileMap * fileMap = new FileMap;
   string unknown_base = unknown_file + " [" + basename + "]";
   bool is_shared = ! (the_symtab->isExec());

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -664,7 +664,7 @@ makeStructure(string filename,
     {
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < wlLaunch.size(); i++) {
-         cout << "do work item " << i << endl; 
+          std::cout << "do work item " << i << std::endl; 
 	doWorkItem(wlLaunch[i], search_path, cuda_file, gapsFile != NULL);
 
 	// the printing must be single threaded

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -611,6 +611,7 @@ makeStructure(string filename,
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < modVec.size(); i++) {
 	Module * mod = modVec[i];
+    cout << "parse line information for mod: " << mod->fullName() << endl;
 	mod->parseLineInformation();
       }
     }  // end parallel
@@ -640,6 +641,7 @@ makeStructure(string filename,
 #endif
 
     string basename = FileUtil::basename(cfilename);
+    cout << "ready to make skeleton " << endl;
     FileMap * fileMap = makeSkeleton(code_obj, basename);
 
     //
@@ -1056,6 +1058,7 @@ addProc(FileMap * fileMap, ProcInfo * pinfo, string & filenm,
 static FileMap *
 makeSkeleton(CodeObject * code_obj, const string & basename)
 {
+    
   FileMap * fileMap = new FileMap;
   string unknown_base = unknown_file + " [" + basename + "]";
   bool is_shared = ! (the_symtab->isExec());

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -93,6 +93,7 @@
 #include <Instruction.h>
 #include <Module.h>
 #include <Region.h>
+#include <StringTable.h>
 #include <Symtab.h>
 
 #include <include/hpctoolkit-config.h>

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -511,10 +511,12 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
 
   // a known file and unknown line is now legal, but we require that
   // any line map must contain a file name
+   /*
   if (! svec.empty() && svec[0]->getFile() == "") {
     cout << "clearing svec for empty file name " << endl;
     svec.clear();
   }
+  */
   cout << "end get statement " << hex << vma << dec << endl;
 }
 
@@ -988,7 +990,6 @@ getProcLineMap(StatementVector & svec, Offset vma, Offset end,
   for (;;) {
     // invariant: vma does not have line info, but next might
     Offset next = vma + step;
-    cout << "stepping vma: " << hex << next << dec << endl;
     if (next >= end) {
       break;
     }
@@ -1154,12 +1155,12 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       if (! svec.empty()) {
           cout << " getProcLineMap: svec size: " << svec.size() << hex << " vma: " << sym_start << dec << endl;
 	    filenm = svec[0]->getFile();
+        cout << "* filename: " << filenm << endl;
 	    line = svec[0]->getLine();
 	    RealPathMgr::singleton().realpath(filenm);
      } else {
           cerr << " getProcLineMap returns empty statement symbol start:  " << hex << sym_start << dec << endl;
       }
-      cout << "where is bad alloc " << endl;
       if (vma == sym_start) {
 	//
 	// case 1 -- group leader of a valid symtab func.  take proc

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1174,12 +1174,12 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
          linknm.erase(p, string::npos);
          cout << "after erasing " << linknm << endl;
       }
-	  if (opts.ourDemangle) {
+	  //if (opts.ourDemangle) {
 	    prettynm = BinUtil::demangleProcName(linknm);
-	  }
-	  else if (pretty_it != sym_func->pretty_names_end()) {
-	    prettynm = *pretty_it;
-	 }
+	 // }
+	  //else if (pretty_it != sym_func->pretty_names_end()) {
+	  //  prettynm = *pretty_it;
+	// }
 	}
 	if (is_shared) {
 	  prettynm += " (" + basename + ")";

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -639,14 +639,8 @@ makeStructure(string filename,
 #ifdef ENABLE_OPENMP
     omp_set_num_threads(opts.jobs);
 #endif
-    vector<Address> dyn_reloc_addr; 
-    Module* mod = modVec[0];
-    mod->getDyninstRelocateFunc(dyn_reloc_addr);
-    cout << "reloc size: " << dyn_reloc_addr.size() << endl; 
     string basename = FileUtil::basename(cfilename);
-    cout << "ready to make skeleton " << endl;
     FileMap * fileMap = makeSkeleton(code_obj, basename);
-
     //
     // make two work lists:
     //  wlPrint -- the output order in the struct file as determined

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -665,7 +665,6 @@ makeStructure(string filename,
     {
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < wlLaunch.size(); i++) {
-          printf(" do work item %d\n", i);
 	    doWorkItem(wlLaunch[i], search_path, cuda_file, gapsFile != NULL);
 
 	// the printing must be single threaded
@@ -1355,7 +1354,6 @@ static void
 doFunctionList(WorkEnv & env, FileInfo * finfo, GroupInfo * ginfo, bool fullGaps)
 {
   long num_funcs = ginfo->procMap.size();
-  printf("doFunctionList called %lu\n", num_funcs);
   set <Address> coveredFuncs;
   VMAIntervalSet covered;
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1039,7 +1039,7 @@ addProc(FileMap * fileMap, ProcInfo * pinfo, string & filenm,
     ginfo = new GroupInfo(sym_func, start, end, alt_file);
     finfo->groupMap[start] = ginfo;
   }
-  cout << "ProcInfo - entry vma: " << pinfo->entry_vma << endl;
+  cout << "ProcInfo - entry vma: " << hex << pinfo->entry_vma << dec << endl;
   ginfo->procMap[pinfo->entry_vma] = pinfo;
 
 #if DEBUG_MAKE_SKEL
@@ -1150,7 +1150,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	    line = svec[0]->getLine();
 	    RealPathMgr::singleton().realpath(filenm);
      } else {
-          cerr << " getProcLineMap returns empty statement vma:  " << hex << sym_start << dec << endl;
+          cerr << " getProcLineMap returns empty statement symbol start:  " << hex << sym_start << dec << endl;
       }
 
       if (vma == sym_start) {
@@ -1172,12 +1172,12 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
          linknm.erase(p, string::npos);
          cout << "after erasing " << linknm << endl;
       }
-	  if (opts.ourDemangle) {
+	  //if (opts.ourDemangle) {
 	    prettynm = BinUtil::demangleProcName(linknm);
-	  }
-	  else if (pretty_it != sym_func->pretty_names_end()) {
-	    prettynm = *pretty_it;
-	  }
+	 // }
+	//  else if (pretty_it != sym_func->pretty_names_end()) {
+	 //   prettynm = *pretty_it;
+	  //}
 	}
 	if (is_shared) {
 	  prettynm += " (" + basename + ")";

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -508,8 +508,8 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
   // a known file and unknown line is now legal, but we require that
   // any line map must contain a file name
   if (! svec.empty() && svec[0]->getFile() == "") {
-      cout << "clearning svec for emtpy file name " << endl;
-    svec.clear();
+    //  cout << "clearing svec for emtpy file name " << endl;
+    //svec.clear();
   }
 }
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -665,7 +665,7 @@ makeStructure(string filename,
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < wlLaunch.size(); i++) {
           printf(" do work item %d\n", i);
-	doWorkItem(wlLaunch[i], search_path, cuda_file, gapsFile != NULL);
+	    doWorkItem(wlLaunch[i], search_path, cuda_file, gapsFile != NULL);
 
 	// the printing must be single threaded
 	if (output_mtx.try_lock()) {
@@ -846,7 +846,7 @@ printWorkList(WorkList & workList, uint & num_done, ostream * outFile,
       ProcInfo * pinfo = pit->second;
 
       if (! pinfo->gap_only) {
-	Output::printProc(outFile, gapsFile, gaps_filenm, finfo, ginfo, pinfo, *strTab);
+	      Output::printProc(outFile, gapsFile, gaps_filenm, finfo, ginfo, pinfo, *strTab);
       }
       delete pinfo->root;
       pinfo->root = NULL;
@@ -1039,7 +1039,7 @@ addProc(FileMap * fileMap, ProcInfo * pinfo, string & filenm,
     ginfo = new GroupInfo(sym_func, start, end, alt_file);
     finfo->groupMap[start] = ginfo;
   }
-
+  cout << "ProcInfo - entry vma: " << pinfo->entry_vma << endl;
   ginfo->procMap[pinfo->entry_vma] = pinfo;
 
 #if DEBUG_MAKE_SKEL
@@ -1129,7 +1129,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
     if (found && sym_func != NULL && region != NULL
 	&& reg_start <= vma && vma < reg_end)
     {
-      cout << "for vma " << hex << vma << dec << " we found the containing function " << endl;
+      cout << "for vma " << hex << vma << dec << " we found the containing function in symtab api " << endl;
       string filenm = unknown_base;
       string linknm = unknown_link + vma_str;
       string prettynm = unknown_proc + " " + vma_str + " [" + basename + "]";
@@ -1137,7 +1137,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 
       // symtab lets some funcs (_init) spill into the next region
       if (sym_start < reg_end && reg_end < sym_end) {
-	sym_end = reg_end;
+	    sym_end = reg_end;
       }
 
       // line map for symtab func
@@ -1160,13 +1160,18 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	// cases are also valid).
 	//
 	DEBUG_SKEL("(case 1)\n");
-
+    cout << "ParseAPI func start address matches SymtabAPI func start address " << hex << vma << dec << endl;
 	auto mangled_it = sym_func->mangled_names_begin();
 	auto pretty_it = sym_func->pretty_names_begin();
 
 	if (mangled_it != sym_func->mangled_names_end()) {
 	  linknm = *mangled_it;
-
+      auto p = linknm.find("_dyninst");
+      if (linknm.find("_dyninst") != string::npos) {
+         cout << "link name contains _dyninst " << linknm << endl;  
+         linknm.erase(p, string::npos);
+         cout << "after erasing " << linknm << endl;
+      }
 	  if (opts.ourDemangle) {
 	    prettynm = BinUtil::demangleProcName(linknm);
 	  }
@@ -1213,6 +1218,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	  // case 2 -- outline func inside symtab func with same file
 	  // name.  use 'outline 0xxxxxx' proc name.
 	  //
+      
 	  DEBUG_SKEL("(case 2)\n");
 
 	  ProcInfo * pinfo = new ProcInfo(func, NULL, linknm, prettynm, parse_line);
@@ -1242,6 +1248,11 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       //
       cout << "no symtab symbol claiming this vma " << hex << vma << dec << endl;
       string linknm = func->name();
+      if (linknm.find("_dyninst") != string::npos) {
+         cout << "link name contains _dyninst " << linknm << endl;  
+         linknm.erase(p, string::npos);
+         cout << "after erasing " << linknm << endl;
+      }
       string prettynm = BinUtil::demangleProcName(linknm);
       VMA end = 0;
 
@@ -1366,6 +1377,7 @@ static void
 doFunctionList(WorkEnv & env, FileInfo * finfo, GroupInfo * ginfo, bool fullGaps)
 {
   long num_funcs = ginfo->procMap.size();
+  printf("doFunctionList called %lu\n", num_funcs);
   set <Address> coveredFuncs;
   VMAIntervalSet covered;
 
@@ -1502,7 +1514,7 @@ doFunctionList(WorkEnv & env, FileInfo * finfo, GroupInfo * ginfo, bool fullGaps
     for (auto bit = bvec.begin(); bit != bvec.end(); ++bit) {
       Block * block = *bit;
       if (! visited[block]) {
-	doBlock(env, ginfo, func, visited, block, root);
+	    doBlock(env, ginfo, func, visited, block, root);
       }
     }
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -815,6 +815,7 @@ makeWorkList(FileMap * fileMap, WorkList & wlPrint, WorkList & wlLaunch)
       wlLaunch.push_back(witem);
     }
   }
+  cout << "end make work list " << endl;
 }
 
 //----------------------------------------------------------------------

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -949,6 +949,7 @@ static void
 getProcLineMap(StatementVector & svec, Offset vma, Offset end,
 	       SymtabAPI::Function * sym_func)
 {
+  cout << "getProcLineMap called " << hex << vma << dec << endl;
   svec.clear();
 
   // try a full module lookup first
@@ -978,6 +979,7 @@ getProcLineMap(StatementVector & svec, Offset vma, Offset end,
   for (;;) {
     // invariant: vma does not have line info, but next might
     Offset next = vma + step;
+    cout << "stepping vma: " << hex << next << dec << endl;
     if (next >= end) {
       break;
     }
@@ -1090,7 +1092,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
     string  vma_str = buf.str();
 
     DEBUG_SKEL("\nskel:    " << vma_str << "  " << func->name() << "\n");
-
+    cout << "skel:    " << vma_str << "  " << func->name() << "\n";
     // see if entry vma lies within a valid symtab function
     bool found = the_symtab->getContainingFunction(vma, sym_func);
     VMA  sym_start = 0;
@@ -1114,6 +1116,10 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
     DEBUG_SKEL("symbol:  0x" << hex << sym_start << "--0x" << sym_end
 	       << "  next:  0x" << next_vma
 	       << "  region:  0x" << reg_start << "--0x" << reg_end << dec << "\n");
+
+    cout << "symbol:  0x" << hex << sym_start << "--0x" << sym_end
+	       << "  next:  0x" << next_vma
+	       << "  region:  0x" << reg_start << "--0x" << reg_end << dec << "\n" << endl;
 
     // symtab doesn't recognize plt funcs and puts them in the wrong
     // region.  to be a valid symbol, the func entry must lie within

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1695,6 +1695,7 @@ static void
 doBlock(WorkEnv & env, GroupInfo * ginfo, ParseAPI::Function * func,
 	BlockSet & visited, Block * block, TreeNode * root)
 {
+    cout << "do block in for function " << func->name() << endl;
   if (block == NULL || visited[block]) {
     return;
   }
@@ -1713,6 +1714,7 @@ doBlock(WorkEnv & env, GroupInfo * ginfo, ParseAPI::Function * func,
   block->getInsns(imap);
 
   for (auto iit = imap.begin(); iit != imap.end(); ++iit) {
+     cout << "iterating instructions in the block of func " << func->name() << hex << " instr addr: " << vma << dec << endl;
     Offset vma = iit->first;
     string filenm = "";
     uint line = 0;

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1073,6 +1073,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 
   for (auto flit = funcList.begin(); flit != funcList.end(); ++flit) {
     ParseAPI::Function * func = *flit;
+    cout << "func addr: " << hex << func->addr() << dec << endl;   
     funcMap[func->addr()] = func;
   }
 
@@ -1229,6 +1230,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       // line map).  make a fake group at the parseapi entry vma.
       // this normally only happens for plt funcs.
       //
+      cout << "no symtab symbol claiming this vma " << hex << vma << dec << endl;
       string linknm = func->name();
       string prettynm = BinUtil::demangleProcName(linknm);
       VMA end = 0;
@@ -1275,6 +1277,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	prettynm += " (" + basename + ")";
       }
 
+      cout << "add linknm: " << linknm << " prettynm " << prettynm << endl;
       ProcInfo * pinfo = new ProcInfo(func, NULL, linknm, prettynm, 0);
       addProc(fileMap, pinfo, unknown_base, NULL, vma, end);
     }

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -610,9 +610,9 @@ makeStructure(string filename,
     {
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < modVec.size(); i++) {
-	Module * mod = modVec[i];
-    cout << "parse line information for mod: " << mod->fullName() << endl;
-	mod->parseLineInformation();
+	    Module * mod = modVec[i];
+        cout << "parse line information for mod: " << mod->fullName() << endl;
+	    mod->parseLineInformation();
       }
     }  // end parallel
 
@@ -664,6 +664,7 @@ makeStructure(string filename,
     {
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < wlLaunch.size(); i++) {
+         cout << "do work item " << i << endl; 
 	doWorkItem(wlLaunch[i], search_path, cuda_file, gapsFile != NULL);
 
 	// the printing must be single threaded
@@ -695,6 +696,7 @@ makeStructure(string filename,
 
       delete code_obj;
       delete code_src;
+      cout << "close symtab " << endl;
       Inline::closeSymtab();
     }
   }
@@ -1108,8 +1110,8 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 
       region = sym_func->getRegion();
       if (region != NULL) {
-	reg_start = region->getMemOffset();
-	reg_end = reg_start + region->getMemSize();
+	    reg_start = region->getMemOffset();
+	    reg_end = reg_start + region->getMemSize();
       }
     }
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -396,6 +396,7 @@ public:
     }
 
     // no line info available
+    cout << "no line info available for address: " << hex << vma << dec << endl;
     filenm = "";
     line = 0;
     return false;
@@ -1714,10 +1715,10 @@ doBlock(WorkEnv & env, GroupInfo * ginfo, ParseAPI::Function * func,
   block->getInsns(imap);
 
   for (auto iit = imap.begin(); iit != imap.end(); ++iit) {
-     cout << "iterating instructions in the block of func " << func->name() << hex << " instr addr: " << vma << dec << endl;
     Offset vma = iit->first;
     string filenm = "";
     uint line = 0;
+     cout << "iterating instructions in the block of func " << func->name() << hex << " instr addr: " << vma << dec << endl;
 
 #ifdef DYNINST_INSTRUCTION_PTR
     int  len = iit->second->size();

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1290,6 +1290,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       addProc(fileMap, pinfo, unknown_base, NULL, vma, end);
     }
   }
+  cout << "end of iteration makeskeleton\n" << endl;
 
 #if DEBUG_SKEL_SUMMARY
   // print the skeleton map

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -664,7 +664,7 @@ makeStructure(string filename,
     {
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < wlLaunch.size(); i++) {
-          std::cout << "do work item " << i << std::endl; 
+          printf(" do work item %d\n", i);
 	doWorkItem(wlLaunch[i], search_path, cuda_file, gapsFile != NULL);
 
 	// the printing must be single threaded

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -375,7 +375,6 @@ public:
   {
     // try cache first
     if (start <= vma && vma < end) {
-      cout << hex << "[start = " << start << " <= " << vma << " < " << end << "]" << dec << endl;
       filenm = cache_filenm;
       line = cache_line;
       return true;
@@ -399,7 +398,6 @@ public:
     }
 
     // no line info available
-    cout << "no line info available for address: " << hex << vma << dec << endl;
     filenm = "";
     line = 0;
     return false;
@@ -484,7 +482,6 @@ LoopInfoLessThan(LoopInfo * l1, LoopInfo * l2)
 static void
 getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
 {
-    cout << "getStatement called " << hex << vma << dec << endl;
   svec.clear();
 
   // try the Module in sym_func first as a hint
@@ -512,10 +509,8 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
   // a known file and unknown line is now legal, but we require that
   // any line map must contain a file name
   if (! svec.empty() && svec[0]->getFile() == "") {
-    cout << "clearing svec for empty file name " << endl;
     svec.clear();
   }
-  cout << "end get statement " << hex << vma << dec << endl;
 }
 
 //----------------------------------------------------------------------
@@ -618,7 +613,6 @@ makeStructure(string filename,
 #pragma omp for  schedule(dynamic, 1)
       for (uint i = 0; i < modVec.size(); i++) {
 	    Module * mod = modVec[i];
-        cout << "parse line information for mod: " << mod->fullName() << endl;
 	    auto lineinfo = mod->parseLineInformation();
       }
     }  // end parallel
@@ -762,7 +756,6 @@ doWorkItem(WorkItem * witem, string & search_path, bool cuda_file,
 static void
 makeWorkList(FileMap * fileMap, WorkList & wlPrint, WorkList & wlLaunch)
 {
-    cout << "makeWorkList " << endl;
   double total_cost = 0.0;
 
   wlPrint.clear();
@@ -794,7 +787,6 @@ makeWorkList(FileMap * fileMap, WorkList & wlPrint, WorkList & wlLaunch)
   // if single-threaded, then order doesn't matter
   if (opts.jobs == 1) {
     wlLaunch = wlPrint;
-    cout << "end work list single \n" << endl;
     return;
   }
 
@@ -822,7 +814,6 @@ makeWorkList(FileMap * fileMap, WorkList & wlPrint, WorkList & wlLaunch)
       wlLaunch.push_back(witem);
     }
   }
-  cout << "end make work list " << endl;
 }
 
 //----------------------------------------------------------------------
@@ -958,7 +949,6 @@ static void
 getProcLineMap(StatementVector & svec, Offset vma, Offset end,
 	       SymtabAPI::Function * sym_func)
 {
-  cout << "getProcLineMap called " << hex << vma << dec << endl;
   svec.clear();
 
   // try a full module lookup first
@@ -1068,7 +1058,6 @@ addProc(FileMap * fileMap, ProcInfo * pinfo, string & filenm,
 static FileMap *
 makeSkeleton(CodeObject * code_obj, const string & basename)
 {
-  cout << "start of make skeleton\n" << endl;    
   FileMap * fileMap = new FileMap;
   string unknown_base = unknown_file + " [" + basename + "]";
   bool is_shared = ! (the_symtab->isExec());
@@ -1083,7 +1072,6 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 
   for (auto flit = funcList.begin(); flit != funcList.end(); ++flit) {
     ParseAPI::Function * func = *flit;
-    cout << "func addr: " << hex << func->addr() << dec << endl;   
     funcMap[func->addr()] = func;
   }
 
@@ -1100,7 +1088,6 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
     string  vma_str = buf.str();
 
     DEBUG_SKEL("\nskel:    " << vma_str << "  " << func->name() << "\n");
-    cout << "skel:    " << vma_str << "  " << func->name() << "\n";
     // see if entry vma lies within a valid symtab function
     bool found = the_symtab->getContainingFunction(vma, sym_func);
     VMA  sym_start = 0;
@@ -1125,17 +1112,12 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	       << "  next:  0x" << next_vma
 	       << "  region:  0x" << reg_start << "--0x" << reg_end << dec << "\n");
 
-    cout << "symbol:  0x" << hex << sym_start << "--0x" << sym_end
-	       << "  next:  0x" << next_vma
-	       << "  region:  0x" << reg_start << "--0x" << reg_end << dec << "\n" << endl;
-
     // symtab doesn't recognize plt funcs and puts them in the wrong
     // region.  to be a valid symbol, the func entry must lie within
     // the symbol's region.
     if (found && sym_func != NULL && region != NULL
 	&& reg_start <= vma && vma < reg_end)
     {
-      cout << "for vma " << hex << vma << dec << " we found the containing function in symtab api " << endl;
       string filenm = unknown_base;
       string linknm = unknown_link + vma_str;
       string prettynm = unknown_proc + " " + vma_str + " [" + basename + "]";
@@ -1151,9 +1133,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       getProcLineMap(svec, sym_start, sym_end, sym_func);
 
       if (! svec.empty()) {
-          cout << " getProcLineMap: svec size: " << svec.size() << hex << " vma: " << sym_start << dec << endl;
 	    filenm = svec[0]->getFile();
-        cout << "* filename: " << filenm << endl;
 	    line = svec[0]->getLine();
 	    RealPathMgr::singleton().realpath(filenm);
      } else {
@@ -1166,7 +1146,6 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	// cases are also valid).
 	//
 	DEBUG_SKEL("(case 1)\n");
-    cout << "ParseAPI func start address matches SymtabAPI func start address " << hex << vma << dec << endl;
 	auto mangled_it = sym_func->mangled_names_begin();
 	auto pretty_it = sym_func->pretty_names_begin();
 
@@ -1174,9 +1153,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	  linknm = *mangled_it;
       auto p = linknm.find("_dyninst");
       if (p != string::npos) {
-         cout << "link name contains _dyninst " << linknm << endl;  
          linknm.erase(p, string::npos);
-         cout << "after erasing " << linknm << endl;
       }
 	  //if (opts.ourDemangle) {
 	    prettynm = BinUtil::demangleProcName(linknm);
@@ -1206,7 +1183,6 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	  parse_filenm = pvec[0]->getFile();
 	  parse_line = pvec[0]->getLine();
 	  RealPathMgr::singleton().realpath(parse_filenm);
-      cout << "parse_filenm: " << parse_filenm << " parse_line " << parse_line << endl;
 	}
 
 	string parse_base = FileUtil::basename(parse_filenm.c_str());
@@ -1252,13 +1228,10 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       // line map).  make a fake group at the parseapi entry vma.
       // this normally only happens for plt funcs.
       //
-      cout << "no symtab symbol claiming this vma " << hex << vma << dec << endl;
       string linknm = func->name();
       auto p = linknm.find("_dyninst");
       if (p != string::npos) {
-         cout << "link name contains _dyninst " << linknm << endl;  
          linknm.erase(p, string::npos);
-         cout << "after erasing " << linknm << endl;
       }
       string prettynm = BinUtil::demangleProcName(linknm);
       VMA end = 0;
@@ -1305,12 +1278,10 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	prettynm += " (" + basename + ")";
       }
 
-      cout << "add linknm: " << linknm << " prettynm " << prettynm << endl;
       ProcInfo * pinfo = new ProcInfo(func, NULL, linknm, prettynm, 0);
       addProc(fileMap, pinfo, unknown_base, NULL, vma, end);
     }
   }
-  cout << "end of iteration makeskeleton\n" << endl;
 
 #if DEBUG_SKEL_SUMMARY
   // print the skeleton map
@@ -1701,7 +1672,6 @@ static void
 doBlock(WorkEnv & env, GroupInfo * ginfo, ParseAPI::Function * func,
 	BlockSet & visited, Block * block, TreeNode * root)
 {
-    cout << "do block in for function " << func->name() << endl;
   if (block == NULL || visited[block]) {
     return;
   }
@@ -1723,7 +1693,6 @@ doBlock(WorkEnv & env, GroupInfo * ginfo, ParseAPI::Function * func,
     Offset vma = iit->first;
     string filenm = "";
     uint line = 0;
-     cout << "iterating instructions in the block of func " << func->name() << hex << " instr addr: " << vma << dec << endl;
 
 #ifdef DYNINST_INSTRUCTION_PTR
     int  len = iit->second->size();

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -493,6 +493,7 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
 
   // else look for other modules
   if (svec.empty()) {
+    printf("get source lines return empty vector\n");
     set <Module *> modSet;
     the_symtab->findModuleByOffset(modSet, vma);
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -511,8 +511,8 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
   // a known file and unknown line is now legal, but we require that
   // any line map must contain a file name
   if (! svec.empty() && svec[0]->getFile() == "") {
-    //  cout << "clearing svec for emtpy file name " << endl;
-    //svec.clear();
+    cout << "clearing svec for empty file name " << endl;
+    svec.clear();
   }
 }
 
@@ -618,8 +618,6 @@ makeStructure(string filename,
 	    Module * mod = modVec[i];
         cout << "parse line information for mod: " << mod->fullName() << endl;
 	    auto lineinfo = mod->parseLineInformation();
-       // auto stringTblPtr = lineinfo->getStrings();
-       //cout << *stringTblPtr << endl;
       }
     }  // end parallel
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1174,12 +1174,12 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
          linknm.erase(p, string::npos);
          cout << "after erasing " << linknm << endl;
       }
-	  //if (opts.ourDemangle) {
+	  if (opts.ourDemangle) {
 	    prettynm = BinUtil::demangleProcName(linknm);
-	 // }
-	//  else if (pretty_it != sym_func->pretty_names_end()) {
-	 //   prettynm = *pretty_it;
-	  //}
+	  }
+	  else if (pretty_it != sym_func->pretty_names_end()) {
+	    prettynm = *pretty_it;
+	 }
 	}
 	if (is_shared) {
 	  prettynm += " (" + basename + ")";

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1133,12 +1133,11 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 
       if (! svec.empty()) {
           cout << " getProcLineMap: svec size: " << svec.size() << hex << " vma: " << sym_start << dec << endl;
-      } else {
+	    filenm = svec[0]->getFile();
+	    line = svec[0]->getLine();
+	    RealPathMgr::singleton().realpath(filenm);
+     } else {
           cerr << " getProcLineMap returns empty statement vma:  " << hex << sym_start << dec << endl;
-      }
-	filenm = svec[0]->getFile();
-	line = svec[0]->getLine();
-	RealPathMgr::singleton().realpath(filenm);
       }
 
       if (vma == sym_start) {

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -639,7 +639,10 @@ makeStructure(string filename,
 #ifdef ENABLE_OPENMP
     omp_set_num_threads(opts.jobs);
 #endif
-
+    vector<Address> dyn_reloc_addr; 
+    Module* mod = modVec[0];
+    mod->getDyninstRelocateFunc(dyn_reloc_addr);
+    cout << "reloc size: " << dyn_reloc_addr.size() << endl; 
     string basename = FileUtil::basename(cfilename);
     cout << "ready to make skeleton " << endl;
     FileMap * fileMap = makeSkeleton(code_obj, basename);
@@ -784,10 +787,11 @@ makeWorkList(FileMap * fileMap, WorkList & wlPrint, WorkList & wlLaunch)
       wlPrint.push_back(witem);
     }
   }
-
+ 
   // if single-threaded, then order doesn't matter
   if (opts.jobs == 1) {
     wlLaunch = wlPrint;
+    cout << "end work list single \n" << endl;
     return;
   }
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -1167,7 +1167,7 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
 	if (mangled_it != sym_func->mangled_names_end()) {
 	  linknm = *mangled_it;
       auto p = linknm.find("_dyninst");
-      if (linknm.find("_dyninst") != string::npos) {
+      if (p != string::npos) {
          cout << "link name contains _dyninst " << linknm << endl;  
          linknm.erase(p, string::npos);
          cout << "after erasing " << linknm << endl;
@@ -1248,7 +1248,8 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       //
       cout << "no symtab symbol claiming this vma " << hex << vma << dec << endl;
       string linknm = func->name();
-      if (linknm.find("_dyninst") != string::npos) {
+      auto p = linknm.find("_dyninst");
+      if (p != string::npos) {
          cout << "link name contains _dyninst " << linknm << endl;  
          linknm.erase(p, string::npos);
          cout << "after erasing " << linknm << endl;

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -493,7 +493,6 @@ getStatement(StatementVector & svec, Offset vma, SymtabAPI::Function * sym_func)
 
   // else look for other modules
   if (svec.empty()) {
-    printf("get source lines return empty vector\n");
     set <Module *> modSet;
     the_symtab->findModuleByOffset(modSet, vma);
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -91,6 +91,7 @@
 #include <CodeSource.h>
 #include <Function.h>
 #include <Instruction.h>
+#include <LineInformation.h>
 #include <Module.h>
 #include <Region.h>
 #include <StringTable.h>

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -986,7 +986,7 @@ getProcLineMap(StatementVector & svec, Offset vma, Offset end,
     if (! svec.empty()) {
       // rescan the range [vma, next) but start over with a small step
       if (step <= init_step) {
-	break;
+	    break;
       }
       svec.clear();
       step = init_step;
@@ -1132,6 +1132,10 @@ makeSkeleton(CodeObject * code_obj, const string & basename)
       getProcLineMap(svec, sym_start, sym_end, sym_func);
 
       if (! svec.empty()) {
+          cout << " getProcLineMap: svec size: " << svec.size() << hex << " vma: " << sym_start << dec << endl;
+      } else {
+          cerr << " getProcLineMap returns empty statement vma:  " << hex << sym_start << dec << endl;
+      }
 	filenm = svec[0]->getFile();
 	line = svec[0]->getLine();
 	RealPathMgr::singleton().realpath(filenm);

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -373,6 +373,7 @@ public:
   {
     // try cache first
     if (start <= vma && vma < end) {
+      cout << hex << "[start = " << start << " <= " << vma << " < " << end << "]" << dec << endl;
       filenm = cache_filenm;
       line = cache_line;
       return true;

--- a/src/lib/binutils/BinUtils.cpp
+++ b/src/lib/binutils/BinUtils.cpp
@@ -91,8 +91,12 @@ demangleProcName(const std::string& name)
   // demangle using the API for the C++ demangler
   //----------------------------------------------------------
   int status;
-  char *str = hpctoolkit_demangle(name.c_str(), 0, 0, &status);
+  if (name.find("dyninst") != string::npos) {
+     return bestname;
+  }
 
+  char *str = hpctoolkit_demangle(name.c_str(), 0, 0, &status);
+  
   if (str) {
     bestname = str;
     free(str);

--- a/src/lib/binutils/BinUtils.cpp
+++ b/src/lib/binutils/BinUtils.cpp
@@ -91,10 +91,6 @@ demangleProcName(const std::string& name)
   // demangle using the API for the C++ demangler
   //----------------------------------------------------------
   int status;
-  if (name.find("dyninst") != string::npos) {
-     printf("found dyninst in link name\n");
-     return bestname;
-  }
 
   char *str = hpctoolkit_demangle(name.c_str(), 0, 0, &status);
   

--- a/src/lib/binutils/BinUtils.cpp
+++ b/src/lib/binutils/BinUtils.cpp
@@ -92,6 +92,7 @@ demangleProcName(const std::string& name)
   //----------------------------------------------------------
   int status;
   if (name.find("dyninst") != string::npos) {
+     printf("found dyninst in link name\n");
      return bestname;
   }
 

--- a/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
+++ b/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
@@ -703,7 +703,6 @@ stack_troll_dyninst_frame(hpcrun_unw_cursor_t* cursor, int offset)
     // dyninst emits a magic word 'beefdead' to help locate the instrumentation frames
     memcpy((void*)&buffer, (void*)magicWordAddr, 8);
     if (buffer == magicWord) { // found the magic word 
-        printf("found magic word\n");
         uint64_t diff = (uint64_t)(framePtr) - (uint64_t)(stackPtr);
         if (diff >= 500 * 8) { // if the frame size is too large, it is not likely to be an instrumentation frame
             return false;


### PR DESCRIPTION
added stack_troll_dyninst_frame to allow hpcrun unwinder to walk through dyninst instrumentation frame. 
Also strips '_dyninst' suffix in link name before feeding to the name demangler. 
