### PR TITLE
Fix unassociated memcpy cct nodes

### DIFF
--- a/src/tool/hpcrun/gpu/gpu-activity-process.c
+++ b/src/tool/hpcrun/gpu/gpu-activity-process.c
@@ -112,25 +112,31 @@ gpu_memcpy_process
     if (host_op_entry != NULL) {
       gpu_placeholder_type_t mct;
       switch (activity->details.memcpy.copyKind) {
-      case GPU_MEMCPY_H2D: 
-	mct = gpu_placeholder_type_copyin;
-	break;
-      case GPU_MEMCPY_D2H: 
-	mct = gpu_placeholder_type_copyout;
-	break;
-      default: 
-	mct = gpu_placeholder_type_copy;
-	break;
+        case GPU_MEMCPY_H2D: 
+          mct = gpu_placeholder_type_copyin;
+          break;
+        case GPU_MEMCPY_D2H: 
+          mct = gpu_placeholder_type_copyout;
+          break;
+        default: 
+          mct = gpu_placeholder_type_copy;
+          break;
       }
       cct_node_t *host_op_node =
-	gpu_host_correlation_map_entry_op_cct_get(host_op_entry, mct);
+        gpu_host_correlation_map_entry_op_cct_get(host_op_entry, mct);
+      if (host_op_node == NULL) {
+        // If we cannot find a perfect match for the operation
+        // e.g. cuMemcpy
+        host_op_node = gpu_host_correlation_map_entry_op_cct_get(host_op_entry,
+          gpu_placeholder_type_copy);
+      }
 
       gpu_trace_item_t entry_trace;
       trace_item_set(&entry_trace, activity, host_op_entry, host_op_node);
 
       gpu_context_stream_trace
-	(activity->details.memcpy.context_id, activity->details.memcpy.stream_id, 
-	 &entry_trace);
+        (activity->details.memcpy.context_id, activity->details.memcpy.stream_id, 
+         &entry_trace);
 
       attribute_activity(host_op_entry, activity, host_op_node);
       //FIXME(keren): In OpenMP, an external_id may maps to multiple cct_nodes

--- a/src/tool/hpcrun/gpu/nvidia/cupti-activity-translate.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-activity-translate.c
@@ -196,6 +196,28 @@ convert_memcpy
 
 
 static void
+convert_memcpy2
+(
+ gpu_activity_t *ga,
+ CUpti_ActivityMemcpy2 *activity
+)
+{
+  PRINT("Memcpy2 copy CorrelationId %u\n", activity->correlationId);
+  PRINT("Memcpy2 copy kind %u\n", activity->copyKind);
+  PRINT("Memcpy2 copy bytes %lu\n", activity->bytes);
+
+  ga->kind = GPU_ACTIVITY_KIND_MEMCPY;
+  ga->details.memcpy.correlation_id = activity->correlationId;
+  ga->details.memcpy.context_id = activity->contextId;
+  ga->details.memcpy.stream_id = activity->streamId;
+  ga->details.memcpy.copyKind = convert_memcpy_type(activity->copyKind);
+  ga->details.memcpy.bytes = activity->bytes;
+
+  set_gpu_activity_interval(&ga->details.interval, activity->start, activity->end);  
+}
+
+
+static void
 convert_kernel
 (
   gpu_activity_t *ga,
@@ -449,8 +471,11 @@ cupti_activity_translate
       (ga, (CUpti_ActivityPCSamplingRecordInfo *)activity);
     break;
 
-  case CUPTI_ACTIVITY_KIND_MEMCPY:
   case CUPTI_ACTIVITY_KIND_MEMCPY2:
+    convert_memcpy2(ga, (CUpti_ActivityMemcpy2 *) activity);
+    break;
+
+  case CUPTI_ACTIVITY_KIND_MEMCPY:
     convert_memcpy(ga, (CUpti_ActivityMemcpy *) activity);
     break;
 


### PR DESCRIPTION
1. It is safer to have a separate routine to handle memcpy2.

2. In some cases, if we leave the system to figure out a dtoh or a htod copy, the api callback itself does not specify the copy direction. Therefore by default we assign a <gpu copy> placeholder to these apis, such as `cuMemcpy`.