### PR TITLE
Exporting metric description into the database

### DIFF
--- a/src/lib/prof/CallPath-Profile.cpp
+++ b/src/lib/prof/CallPath-Profile.cpp
@@ -779,6 +779,7 @@ Profile::writeXML_hdr(std::ostream& os, uint metricBeg, uint metricEnd,
     os << "    <Metric i" << MakeAttrNum(i)
        << " n" << MakeAttrStr(m->name())
        << " v=\"" << m->toValueTyStringXML() << "\""
+       << " md=\"" << m->description()      << "\""
        << " em=\"" << m->isMultiplexed()    << "\""
        << " es=\"" << m->num_samples()      << "\""
        << " ep=\"" << long(m->periodMean())       << "\""

--- a/src/tool/hpcrun/gpu/gpu-activity-process.c
+++ b/src/tool/hpcrun/gpu/gpu-activity-process.c
@@ -356,13 +356,7 @@ gpu_kernel_process
 
   gpu_correlation_id_map_entry_t *cid_map_entry =
     gpu_correlation_id_map_lookup(correlation_id);
-  // TODO: how to refactor this device map
   if (cid_map_entry != NULL) {
-#if 0
-    if (cuda_device_map_lookup(activity->deviceId) == NULL) {
-      cuda_device_map_insert(activity->deviceId);
-    }
-#endif
     gpu_correlation_id_map_kernel_update
       (correlation_id, activity->details.kernel.device_id, 
        activity->details.interval.start, activity->details.interval.end);

--- a/src/tool/hpcrun/gpu/gpu-metrics.c
+++ b/src/tool/hpcrun/gpu/gpu-metrics.c
@@ -94,7 +94,7 @@
 //------------------------------------------------------------------------------
 
 // macros for counting entries in a FORALL macro
-#define COUNT_FORALL_CLAUSE(a,b) + 1
+#define COUNT_FORALL_CLAUSE(a,b,c) + 1
 #define NUM_CLAUSES(forall_macro) 0 forall_macro(COUNT_FORALL_CLAUSE)
 
 #define METRIC_KIND(name)			\
@@ -106,10 +106,10 @@ name ## _metric_kind
 #define METRIC_ID(name) \
   name ## _metric_id
 
-#define INITIALIZE_INDEXED_METRIC(name, value)			\
+#define INITIALIZE_INDEXED_METRIC(name, value)		\
   static int METRIC_ID(name)[NUM_CLAUSES( FORALL_ ## name)];
 
-#define INITIALIZE_SCALAR_METRIC(string, name)	\
+#define INITIALIZE_SCALAR_METRIC(string, name, desc)	\
   static int METRIC_ID(name);
 
 #define INITIALIZE_SCALAR_METRIC_KIND(kind, value)	\
@@ -130,27 +130,31 @@ name ## _metric_kind
   hpcrun_close_kind(APPLY(METRIC_KIND,CURRENT_METRIC))
 
 
-#define INITIALIZE_INDEXED_METRIC_INT(metric_desc, index) \
+#define INITIALIZE_INDEXED_METRIC_INT(metric_name, index, metric_desc)	\
    APPLY(METRIC_ID,CURRENT_METRIC)[index] =				\
-    hpcrun_set_new_metric_info(APPLY(METRIC_KIND,CURRENT_METRIC), metric_desc);
+     hpcrun_set_new_metric_desc_and_period				\
+     (APPLY(METRIC_KIND,CURRENT_METRIC), metric_name, metric_desc,	\
+     MetricFlags_ValFmt_Int, 1, metric_property_none);
 
 
-#define INITIALIZE_INDEXED_METRIC_REAL(metric_desc, index)	\
-   APPLY(METRIC_ID,CURRENT_METRIC)[index] =		\
-    hpcrun_set_new_metric_info_and_period		\
-    (APPLY(METRIC_KIND,CURRENT_METRIC), metric_desc,	\
+#define INITIALIZE_INDEXED_METRIC_REAL(metric_name, index, metric_desc)	\
+  APPLY(METRIC_ID,CURRENT_METRIC)[index] =				\
+    hpcrun_set_new_metric_desc_and_period				\
+    (APPLY(METRIC_KIND,CURRENT_METRIC), metric_name, metric_desc,	\
      MetricFlags_ValFmt_Real, 1, metric_property_none);
 
 
-#define INITIALIZE_SCALAR_METRIC_INT(metric_desc, metric_name) \
-   METRIC_ID(metric_name) =				\
-    hpcrun_set_new_metric_info(APPLY(METRIC_KIND,CURRENT_METRIC), metric_desc);
+#define INITIALIZE_SCALAR_METRIC_INT(metric_name, metric_var, metric_desc) \
+  METRIC_ID(metric_var) =						\
+    hpcrun_set_new_metric_desc_and_period				\
+    (APPLY(METRIC_KIND,CURRENT_METRIC), metric_name, metric_desc,	\
+     MetricFlags_ValFmt_Int, 1, metric_property_none);
 
 
-#define INITIALIZE_SCALAR_METRIC_REAL(metric_desc, metric_name)	\
-  METRIC_ID(metric_name) =				\
-    hpcrun_set_new_metric_info_and_period			\
-    (APPLY(METRIC_KIND,CURRENT_METRIC), metric_desc,	\
+#define INITIALIZE_SCALAR_METRIC_REAL(metric_name, metric_var, metric_desc) \
+  METRIC_ID(metric_var) =						\
+    hpcrun_set_new_metric_desc_and_period				\
+    (APPLY(METRIC_KIND,CURRENT_METRIC), metric_name, metric_desc,	\
      MetricFlags_ValFmt_Real, 1, metric_property_none);
 
 
@@ -239,7 +243,7 @@ gpu_metrics_attribute_pc_sampling
 
   if (sinfo->stallReason != GPU_INST_STALL_INVALID) {
     int stall_summary_metric_index = 
-      METRIC_ID(GPU_INST_STALL)[GPU_INST_STALL_ALL];
+      METRIC_ID(GPU_INST_STALL)[GPU_INST_STALL_ANY];
 
     int stall_kind_metric_index = METRIC_ID(GPU_INST_STALL)[sinfo->stallReason];
 

--- a/src/tool/hpcrun/gpu/gpu-metrics.h
+++ b/src/tool/hpcrun/gpu/gpu-metrics.h
@@ -59,30 +59,30 @@
 //*****************************************************************************
 
 enum {
-  GPU_INST_STALL_ALL = 0
+  GPU_INST_STALL_ANY                   = 0
 } gpu_inst_stall_all_t;
 
 
 typedef enum {
-  GPU_GMEM_LD_CACHED_BYTES = 0,
-  GPU_GMEM_LD_UNCACHED_BYTES = 1,
-  GPU_GMEM_ST_BYTES = 2,
-  GPU_GMEM_LD_CACHED_L2TRANS = 3,
-  GPU_GMEM_LD_UNCACHED_L2TRANS = 4,
-  GPU_GMEM_ST_L2TRANS = 5,
-  GPU_GMEM_LD_CACHED_L2TRANS_THEOR = 6,
-  GPU_GMEM_LD_UNCACHED_L2TRANS_THEOR = 7,
-  GPU_GMEM_ST_L2TRANS_THEOR = 8
+  GPU_GMEM_LD_CACHED_BYTES             = 0,
+  GPU_GMEM_LD_UNCACHED_BYTES           = 1,
+  GPU_GMEM_ST_BYTES                    = 2,
+  GPU_GMEM_LD_CACHED_L2TRANS           = 3,
+  GPU_GMEM_LD_UNCACHED_L2TRANS         = 4,
+  GPU_GMEM_ST_L2TRANS                  = 5,
+  GPU_GMEM_LD_CACHED_L2TRANS_THEOR     = 6,
+  GPU_GMEM_LD_UNCACHED_L2TRANS_THEOR   = 7,
+  GPU_GMEM_ST_L2TRANS_THEOR            = 8
 } gpu_gmem_ops_t;
 
 
 typedef enum {
-  GPU_LMEM_LD_BYTES = 0,
-  GPU_LMEM_ST_BYTES = 1,
-  GPU_LMEM_LD_TRANS = 2,
-  GPU_LMEM_ST_TRANS = 3,
-  GPU_LMEM_LD_TRANS_THEOR = 4,
-  GPU_LMEM_ST_TRANS_THEOR = 5
+  GPU_LMEM_LD_BYTES                    = 0,
+  GPU_LMEM_ST_BYTES                    = 1,
+  GPU_LMEM_LD_TRANS                    = 2,
+  GPU_LMEM_ST_TRANS                    = 3,
+  GPU_LMEM_LD_TRANS_THEOR              = 4,
+  GPU_LMEM_ST_TRANS_THEOR              = 5
 } gpu_lmem_ops_t;
 
 
@@ -93,91 +93,159 @@ typedef enum {
 
 // gpu memory allocation/deallocation
 #define FORALL_GMEM(macro)					\
-  macro("GMEM:UNK (B)",           GPU_MEM_UNKNOWN)		\
-  macro("GMEM:PAG (B)",           GPU_MEM_PAGEABLE)		\
-  macro("GMEM:PIN (B)",           GPU_MEM_PINNED)		\
-  macro("GMEM:DEV (B)",           GPU_MEM_DEVICE)		\
-  macro("GMEM:ARY (B)",           GPU_MEM_ARRAY)		\
-  macro("GMEM:MAN (B)",           GPU_MEM_MANAGED)		\
-  macro("GMEM:DST (B)",           GPU_MEM_DEVICE_STATIC)	\
-  macro("GMEM:MST (B)",           GPU_MEM_MANAGED_STATIC)
+  macro("GMEM:UNK (B)",           GPU_MEM_UNKNOWN,		\
+	"GPU memory alloc/free: unknown memory kind (bytes)")	\
+  macro("GMEM:PAG (B)",           GPU_MEM_PAGEABLE,		\
+	"GPU memory alloc/free: pageable memory (bytes)")	\
+  macro("GMEM:PIN (B)",           GPU_MEM_PINNED,		\
+	"GPU memory alloc/free: pinned memory (bytes)")		\
+  macro("GMEM:DEV (B)",           GPU_MEM_DEVICE,		\
+	"GPU memory alloc/free: device memory (bytes)")		\
+  macro("GMEM:ARY (B)",           GPU_MEM_ARRAY,		\
+	"GPU memory alloc/free: array memory (bytes)")		\
+  macro("GMEM:MAN (B)",           GPU_MEM_MANAGED,		\
+	"GPU memory alloc/free: managed memory (bytes)")	\
+  macro("GMEM:DST (B)",           GPU_MEM_DEVICE_STATIC,	\
+	"GPU memory alloc/free: device static memory (bytes)")	\
+  macro("GMEM:MST (B)",           GPU_MEM_MANAGED_STATIC,	\
+	"GPU memory alloc/free: managed static memory (bytes)")
 
 
 // gpu memory set
 #define FORALL_GMSET(macro)					\
-  macro("GMSET:UNK (B)",          GPU_MEM_UNKNOWN)		\
-  macro("GMSET:PAG (B)",          GPU_MEM_PAGEABLE)		\
-  macro("GMSET:PIN (B)",          GPU_MEM_PINNED)		\
-  macro("GMSET:DEV (B)",          GPU_MEM_DEVICE)		\
-  macro("GMSET:ARY (B)",          GPU_MEM_ARRAY)		\
-  macro("GMSET:MAN (B)",          GPU_MEM_MANAGED)		\
-  macro("GMSET:DST (B)",          GPU_MEM_DEVICE_STATIC)	\
-  macro("GMSET:MST (B)",          GPU_MEM_MANAGED_STATIC)
+  macro("GMSET:UNK (B)",          GPU_MEM_UNKNOWN,		\
+	"GPU memory set: unknown memory kind (bytes)")		\
+  macro("GMSET:PAG (B)",          GPU_MEM_PAGEABLE,		\
+	"GPU memory set: pageable memory (bytes)")		\
+  macro("GMSET:PIN (B)",          GPU_MEM_PINNED,		\
+	"GPU memory set: pinned memory (bytes)")		\
+  macro("GMSET:DEV (B)",          GPU_MEM_DEVICE,		\
+	"GPU memory set: device memory (bytes)")		\
+  macro("GMSET:ARY (B)",          GPU_MEM_ARRAY,		\
+	"GPU memory set: array memory (bytes)")			\
+  macro("GMSET:MAN (B)",          GPU_MEM_MANAGED,		\
+	"GPU memory set: managed memory (bytes)")		\
+  macro("GMSET:DST (B)",          GPU_MEM_DEVICE_STATIC,	\
+	"GPU memory set: device static memory (bytes)")		\
+  macro("GMSET:MST (B)",          GPU_MEM_MANAGED_STATIC,	\
+	"GPU memory set: managed static memory (bytes)")
 
 
 #define FORALL_GPU_INST_STALL(macro)					\
-  macro("GINS:STL_ALL",           GPU_INST_STALL_ALL)			\
-  macro("GINS:STL_NONE",          GPU_INST_STALL_NONE)			\
-  macro("GINS:STL_IFET",          GPU_INST_STALL_IFETCH)		\
-  macro("GINS:STL_IDEP",          GPU_INST_STALL_IDEPEND)		\
-  macro("GINS:STL_GMEM",          GPU_INST_STALL_GMEM)			\
-  macro("GINS:STL_TMEM",          GPU_INST_STALL_TMEM)			\
-  macro("GINS:STL_CMEM",          GPU_INST_STALL_CMEM)			\
-  macro("GINS:STL_SYNC",          GPU_INST_STALL_SYNC)			\
-  macro("GINS:STL_MTHR",          GPU_INST_STALL_MEM_THROTTLE)		\
-  macro("GINS:STL_NSEL",          GPU_INST_STALL_NOT_SELECTED)		\
-  macro("GINS:STL_OTHR",          GPU_INST_STALL_OTHER)			\
-  macro("GINS:STL_SLP",           GPU_INST_STALL_SLEEP)			\
-  macro("GINS:STL_INV",           GPU_INST_STALL_INVALID)		
+  macro("GINS:STL_ANY",           GPU_INST_STALL_ANY,			\
+	"GPU instruction stalls: any")					\
+  macro("GINS:STL_NONE",          GPU_INST_STALL_NONE,			\
+	"GPU instruction stalls: no stall")				\
+  macro("GINS:STL_IFET",          GPU_INST_STALL_IFETCH,		\
+	"GPU instruction stalls: await availability of next "		\
+	"instruction (fetch or branch delay)")				\
+  macro("GINS:STL_IDEP",          GPU_INST_STALL_IDEPEND,		\
+	"GPU instruction stalls: await satisfaction of instruction "	\
+	"input dependence") \
+  macro("GINS:STL_GMEM",          GPU_INST_STALL_GMEM,			\
+	"GPU instruction stalls: await completion of global memory "	\
+	"access")							\
+  macro("GINS:STL_TMEM",          GPU_INST_STALL_TMEM,			\
+	"GPU instruction stalls: texture memory request queue full")	\
+  macro("GINS:STL_CMEM",          GPU_INST_STALL_CMEM,			\
+	"GPU instruction stalls: await completion of constant or "	\
+	"immediate memory access")					\
+  macro("GINS:STL_SYNC",          GPU_INST_STALL_SYNC,			\
+	"GPU instruction stalls: await completion of thread or "	\
+	"memory synchronization")					\
+  macro("GINS:STL_MTHR",          GPU_INST_STALL_MEM_THROTTLE,		\
+	"GPU instruction stalls: global memory request queue full")	\
+  macro("GINS:STL_NSEL",          GPU_INST_STALL_NOT_SELECTED,		\
+	"GPU instruction stalls: not selected for issue but ready")	\
+  macro("GINS:STL_OTHR",          GPU_INST_STALL_OTHER,			\
+	"GPU instruction stalls: other")				\
+  macro("GINS:STL_SLP",           GPU_INST_STALL_SLEEP,			\
+	"GPU instruction stalls: sleep")				\
+  macro("GINS:STL_INV",           GPU_INST_STALL_INVALID,		\
+	"GPU instruction stalls: invalid")
 
 
 // gpu explicit copy
 #define FORALL_GXCOPY(macro)					\
-  macro("GXCOPY:UNK (B)",         GPU_MEMCPY_UNK)		\
-  macro("GXCOPY:H2D (B)",         GPU_MEMCPY_H2D)		\
-  macro("GXCOPY:D2H (B)",         GPU_MEMCPY_D2H)		\
-  macro("GXCOPY:H2A (B)",         GPU_MEMCPY_H2A)		\
-  macro("GXCOPY:A2H (B)",         GPU_MEMCPY_A2H)		\
-  macro("GXCOPY:A2A (B)",         GPU_MEMCPY_A2A)		\
-  macro("GXCOPY:A2D (B)",         GPU_MEMCPY_A2D)		\
-  macro("GXCOPY:D2A (B)",         GPU_MEMCPY_D2A)		\
-  macro("GXCOPY:D2D (B)",         GPU_MEMCPY_D2D)		\
-  macro("GXCOPY:H2H (B)",         GPU_MEMCPY_H2H)		\
-  macro("GXCOPY:P2P (B)",         GPU_MEMCPY_P2P)
+  macro("GXCOPY:UNK (B)",         GPU_MEMCPY_UNK,		\
+	"GPU explicit memory copy: unknown kind (bytes)")	\
+  macro("GXCOPY:H2D (B)",         GPU_MEMCPY_H2D,		\
+	"GPU explicit memory copy: host to device (bytes)")	\
+  macro("GXCOPY:D2H (B)",         GPU_MEMCPY_D2H,		\
+	"GPU explicit memory copy: device to host (bytes)")	\
+  macro("GXCOPY:H2A (B)",         GPU_MEMCPY_H2A,		\
+	"GPU explicit memory copy: host to array (bytes)")	\
+  macro("GXCOPY:A2H (B)",         GPU_MEMCPY_A2H,		\
+	"GPU explicit memory copy: array to host (bytes)")	\
+  macro("GXCOPY:A2A (B)",         GPU_MEMCPY_A2A,		\
+	"GPU explicit memory copy: array to array (bytes)")	\
+  macro("GXCOPY:A2D (B)",         GPU_MEMCPY_A2D,		\
+	"GPU explicit memory copy: array to device (bytes)")	\
+  macro("GXCOPY:D2A (B)",         GPU_MEMCPY_D2A,		\
+	"GPU explicit memory copy: device to array (bytes)")	\
+  macro("GXCOPY:D2D (B)",         GPU_MEMCPY_D2D,		\
+	"GPU explicit memory copy: device to device (bytes)")	\
+  macro("GXCOPY:H2H (B)",         GPU_MEMCPY_H2H,		\
+	"GPU explicit memory copy: host to host (bytes)")	\
+  macro("GXCOPY:P2P (B)",         GPU_MEMCPY_P2P,		\
+	"GPU explicit memory copy: peer to peer (bytes)")
 
 
 #define FORALL_GSYNC(macro)					\
-  macro("GSYNC:UNK (us)",         GPU_SYNC_UNKNOWN)		\
-  macro("GSYNC:EVT (us)",         GPU_SYNC_EVENT)		\
-  macro("GSYNC:STRE (us)",        GPU_SYNC_STREAM_EVENT_WAIT)	\
-  macro("GSYNC:STR (us)",         GPU_SYNC_STREAM)		\
-  macro("GSYNC:CTX (us)",         GPU_SYNC_CONTEXT)
+  macro("GSYNC:UNK (us)",         GPU_SYNC_UNKNOWN,		\
+	"GPU synchronizations: unknown kind")			\
+  macro("GSYNC:EVT (us)",         GPU_SYNC_EVENT,		\
+	"GPU synchronizations: event")				\
+  macro("GSYNC:STRE (us)",        GPU_SYNC_STREAM_EVENT_WAIT,	\
+	"GPU synchronizations: stream event wait")		\
+  macro("GSYNC:STR (us)",         GPU_SYNC_STREAM,		\
+	"GPU synchronizations: stream")				\
+  macro("GSYNC:CTX (us)",         GPU_SYNC_CONTEXT,		\
+	"GPU synchronizations: context")
 
 // gpu global memory access
 #define FORALL_GGMEM(macro)						\
-  macro("GGMEM:LDC (B)",          GPU_GMEM_LD_CACHED_BYTES)		\
-  macro("GGMEM:LDU (B)",          GPU_GMEM_LD_UNCACHED_BYTES)		\
-  macro("GGMEM:ST (B)",           GPU_GMEM_ST_BYTES)			\
+  macro("GGMEM:LDC (B)",          GPU_GMEM_LD_CACHED_BYTES,		\
+	"GPU global memory: load cacheable memory (bytes)")		\
+  macro("GGMEM:LDU (B)",          GPU_GMEM_LD_UNCACHED_BYTES,		\
+	"GPU global memory: load uncacheable memory (bytes)")		\
+  macro("GGMEM:ST (B)",           GPU_GMEM_ST_BYTES,			\
+	"GPU global memory: store (bytes)")				\
   									\
-  macro("GGMEM:LDC (L2T)",        GPU_GMEM_LD_CACHED_L2TRANS)		\
-  macro("GGMEM:LDU (L2T)",        GPU_GMEM_LD_UNCACHED_L2TRANS)		\
-  macro("GGMEM:ST (L2T)",         GPU_GMEM_ST_L2TRANS)			\
+  macro("GGMEM:LDC (L2T)",        GPU_GMEM_LD_CACHED_L2TRANS,		\
+	"GPU global memory: load cacheable (L2 cache transactions)")	\
+  macro("GGMEM:LDU (L2T)",        GPU_GMEM_LD_UNCACHED_L2TRANS,		\
+	"GPU global memory: load uncacheable (L2 cache transactions)")	\
+  macro("GGMEM:ST (L2T)",         GPU_GMEM_ST_L2TRANS,			\
+	"GPU global memory: store (L2 cache transactions)")		\
   				  					\
-  macro("GGMEM:LDCT (L2T)",       GPU_GMEM_LD_CACHED_L2TRANS_THEOR)	\
-  macro("GGMEM:LDUT (L2T)",       GPU_GMEM_LD_UNCACHED_L2TRANS_THEOR)	\
-  macro("GGMEM:STT (L2T)",        GPU_GMEM_ST_L2TRANS_THEOR)
+  macro("GGMEM:LDCT (L2T)",       GPU_GMEM_LD_CACHED_L2TRANS_THEOR,	\
+	"GPU global memory: load cacheable "				\
+	"(L2 cache transactions, theoretical)")				\
+  macro("GGMEM:LDUT (L2T)",       GPU_GMEM_LD_UNCACHED_L2TRANS_THEOR,	\
+	"GPU global memory: load uncacheable "				\
+	"(L2 cache transactions, theoretical)")				\
+  macro("GGMEM:STT (L2T)",        GPU_GMEM_ST_L2TRANS_THEOR,		\
+	"GPU global memory: store "					\
+	"(L2 cache transactions, theoretical)")
 
 
 // gpu local memory access
 #define FORALL_GLMEM(macro)					\
-  macro("GLMEM:LD (B)",           GPU_LMEM_LD_BYTES)		\
-  macro("GLMEM:ST (B)",           GPU_LMEM_ST_BYTES)		\
+  macro("GLMEM:LD (B)",           GPU_LMEM_LD_BYTES,		\
+	"GPU local memory: load (bytes)")			\
+  macro("GLMEM:ST (B)",           GPU_LMEM_ST_BYTES,		\
+	"GPU local memory: store (bytes)")			\
 								\
-  macro("GLMEM:LD (T)",           GPU_LMEM_LD_TRANS)		\
-  macro("GLMEM:ST (T)",           GPU_LMEM_ST_TRANS)		\
+  macro("GLMEM:LD (T)",           GPU_LMEM_LD_TRANS,		\
+	"GPU local memory: load (transactions)")		\
+  macro("GLMEM:ST (T)",           GPU_LMEM_ST_TRANS,		\
+	"GPU local memory: store (transactions)")		\
 								\
-  macro("GLMEM:LDT (T)",          GPU_LMEM_LD_TRANS_THEOR)	\
-  macro("GLMEM:STT (T)",          GPU_LMEM_ST_TRANS_THEOR)
+  macro("GLMEM:LDT (T)",          GPU_LMEM_LD_TRANS_THEOR,	\
+	"GPU local memory: load (transactions, theoretical)")	\
+  macro("GLMEM:STT (T)",          GPU_LMEM_ST_TRANS_THEOR,	\
+	"GPU local memory: store (transactions, theoretical)")
 
 //--------------------------------------------------------------------------
 // scalar metrics 
@@ -186,61 +254,98 @@ typedef enum {
 
 // gpu activity times
 #define FORALL_GTIMES(macro)					\
-  macro("GKER (s)",               GPU_TIME_KER)			\
-  macro("GMEM (s)",               GPU_TIME_MEM)			\
-  macro("GMSET (s)",              GPU_TIME_MSET)		\
-  macro("GXCOPY (s)",             GPU_TIME_XCOPY)		\
-  macro("GICOPY (s)",             GPU_TIME_ICOPY)		\
-  macro("GSYNC (s)",              GPU_TIME_SYNC)		\
+  macro("GKER (s)",               GPU_TIME_KER,			\
+	"GPU time: kernel execution (seconds)")			\
+  macro("GMEM (s)",               GPU_TIME_MEM,			\
+	"GPU time: memory allocation/deallocation (seconds)")	\
+  macro("GMSET (s)",              GPU_TIME_MSET,		\
+	"GPU time: memory set (seconds)")			\
+  macro("GXCOPY (s)",             GPU_TIME_XCOPY,		\
+	"GPU time: explicit data copy (seconds)")		\
+  macro("GICOPY (s)",             GPU_TIME_ICOPY,		\
+	"GPU time: implicit data copy (seconds)")		\
+  macro("GSYNC (s)",              GPU_TIME_SYNC,		\
+	"GPU time: synchronization (seconds)")
 
 
 // gpu instruction count
 #define FORALL_GPU_INST(macro)			\
-  macro("GINS",                   GPU_INST_ALL)
+  macro("GINS",                   GPU_INST_ALL,	\
+	"GPU instructions executed")
 
 
 // gpu kernel characteristics
 #define FORALL_KINFO(macro)					\
-  macro("GKER:STMEM (B)",         GPU_KINFO_STMEM)		\
-  macro("GKER:DYMEM (B)",         GPU_KINFO_DYMEM)		\
-  macro("GKER:LMEM (B)",          GPU_KINFO_LMEM)		\
-  macro("GKER:FGP_ACT",           GPU_KINFO_FGP_ACT)		\
-  macro("GKER:FGP_MAX",           GPU_KINFO_FGP_MAX)		\
-  macro("GKER:THR_REG",           GPU_KINFO_REGISTERS)		\
-  macro("GKER:BLK_THR",           GPU_KINFO_BLK_THREADS)	\
-  macro("GKER:BLK_SM",            GPU_KINFO_BLK_SMEM)		\
-  macro("GKER:COUNT",             GPU_KINFO_COUNT)		\
-  macro("GKER:OCC",               GPU_KINFO_OCCUPANCY)
+  macro("GKER:STMEM (B)",         GPU_KINFO_STMEM,		\
+	"GPU kernel: static memory (bytes)")			\
+  macro("GKER:DYMEM (B)",         GPU_KINFO_DYMEM,		\
+	"GPU kernel: dynamic memory (bytes)")			\
+  macro("GKER:LMEM (B)",          GPU_KINFO_LMEM,		\
+	"GPU kernel: local memory (bytes)")			\
+  macro("GKER:FGP_ACT",           GPU_KINFO_FGP_ACT,		\
+	"GPU kernel: fine-grain parallelism, actual")		\
+  macro("GKER:FGP_MAX",           GPU_KINFO_FGP_MAX,		\
+	"GPU kernel: fine-grain parallelism, maximum")		\
+  macro("GKER:THR_REG",           GPU_KINFO_REGISTERS,		\
+	"GPU kernel: thread register count")			\
+  macro("GKER:BLK_THR",           GPU_KINFO_BLK_THREADS,	\
+	"GPU kernel: thread count")				\
+  macro("GKER:BLK_SM",            GPU_KINFO_BLK_SMEM,		\
+	"GPU kernel: block local memory (bytes)")		\
+  macro("GKER:COUNT",             GPU_KINFO_COUNT,		\
+	"GPU kernel: launch count")				\
+  macro("GKER:OCC",               GPU_KINFO_OCCUPANCY,		\
+	"GPU kernel: occupancy")
 
 
 // gpu implicit copy
 #define FORALL_GICOPY(macro)					\
-  macro("GICOPY:INV",             GPU_ICOPY_INVALID)		\
-  macro("GICOPY:H2D (B)",         GPU_ICOPY_H2D_BYTES)		\
-  macro("GICOPY:D2H (B)",         GPU_ICOPY_D2H_BYTES)		\
-  macro("GICOPY:D2D (B)",         GPU_ICOPY_D2D_BYTES)		\
-  macro("GICOPY:CPU_PF",          GPU_ICOPY_CPU_PF)		\
-  macro("GICOPY:GPU_PF",          GPU_ICOPY_GPU_PF)		\
-  macro("GICOPY:THRASH",          GPU_ICOPY_THRASH)		\
-  macro("GICOPY:THROT",           GPU_ICOPY_THROT)		\
-  macro("GICOPY:RMAP",            GPU_ICOPY_RMAP)		
+  macro("GICOPY:UNK (B)",         GPU_ICOPY_UNKNOWN,		\
+	"GPU implicit copy: unknown kind (bytes)")		\
+  macro("GICOPY:H2D (B)",         GPU_ICOPY_H2D_BYTES,		\
+	"GPU implicit copy: host to device (bytes)")		\
+  macro("GICOPY:D2H (B)",         GPU_ICOPY_D2H_BYTES,		\
+	"GPU implicit copy: device to host (bytes)")		\
+  macro("GICOPY:D2D (B)",         GPU_ICOPY_D2D_BYTES,		\
+	"GPU implicit copy: device to device (bytes)")		\
+  macro("GICOPY:CPU_PF",          GPU_ICOPY_CPU_PF,		\
+	"GPU implicit copy: CPU page faults")			\
+  macro("GICOPY:GPU_PF",          GPU_ICOPY_GPU_PF,		\
+	"GPU implicit copy: GPU page faults")			\
+  macro("GICOPY:THRASH",          GPU_ICOPY_THRASH,		\
+	"GPU implicit copy: CPU thrashing page faults "		\
+	"(data frequently migrating between processors)")	\
+  macro("GICOPY:THROT",           GPU_ICOPY_THROT,		\
+	"GPU implicit copy: throttling "			\
+	"(prevent thrashing by delaying page fault service)")	\
+  macro("GICOPY:RMAP",            GPU_ICOPY_RMAP,		\
+	"GPU implicit copy: remote maps "			\
+	"(prevent thrashing by pinning memory for a time with "	\
+	"some processor mapping and accessing it remotely)")
 
 
 // gpu branch
 #define FORALL_GBR(macro)					\
-  macro("GBR:DIV",                GPU_BR_DIVERGED)		\
-  macro("GBR:EXE",                GPU_BR_EXECUTED)
+    macro("GBR:DIV",                GPU_BR_DIVERGED,		\
+	  "GPU branches: diverged")				\
+  macro("GBR:EXE",                GPU_BR_EXECUTED,		\
+	"GPU branches: executed")
 
 
 // gpu sampling information
 #define FORALL_GSAMP_INT(macro)					\
-  macro("GSAMP:DRP",              GPU_SAMPLE_DROPPED)		\
-  macro("GSAMP:EXP",              GPU_SAMPLE_EXPECTED)		\
-  macro("GSAMP:TOT",              GPU_SAMPLE_TOTAL)		\
-  macro("GSAMP:PER (cyc)",        GPU_SAMPLE_PERIOD)
+  macro("GSAMP:DRP",              GPU_SAMPLE_DROPPED,		\
+	"GPU PC samples: dropped")				\
+  macro("GSAMP:EXP",              GPU_SAMPLE_EXPECTED,		\
+	"GPU PC samples: expected")				\
+  macro("GSAMP:TOT",              GPU_SAMPLE_TOTAL,		\
+	"GPU PC samples: measured")				\
+  macro("GSAMP:PER (cyc)",        GPU_SAMPLE_PERIOD,		\
+	"GPU PC samples: period (GPU cycles)")
 
 #define FORALL_GSAMP_REAL(macro)				\
-  macro("GSAMP:UTIL",             GPU_SAMPLE_UTILIZATION)
+  macro("GSAMP:UTIL",             GPU_SAMPLE_UTILIZATION,	\
+    "GPU utilization computed using PC sampling")
 
 #define FORALL_GSAMP(macro)			\
   FORALL_GSAMP_INT(macro)			\

--- a/src/tool/hpcrun/gpu/nvidia/cupti-activity-translate.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-activity-translate.c
@@ -72,6 +72,7 @@
 #include <hpcrun/gpu/gpu-correlation-id-map.h>
 #include <hpcrun/gpu/gpu-host-correlation-map.h>
 
+#include "cuda-device-map.h"
 #include "cupti-activity-translate.h"
 #include "cupti-analysis.h"
 

--- a/src/tool/hpcrun/gpu/nvidia/cupti-activity-translate.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-activity-translate.c
@@ -326,6 +326,10 @@ convert_kernel
   CUpti_ActivityKernel4 *activity
 )
 {
+  if (cuda_device_map_lookup(activity->deviceId) == NULL) {
+    cuda_device_map_insert(activity->deviceId);
+  }
+
   ga->kind = GPU_ACTIVITY_KERNEL;
 
   ga->details.kernel.correlation_id = activity->correlationId;

--- a/src/tool/hpcrun/metrics.c
+++ b/src/tool/hpcrun/metrics.c
@@ -342,6 +342,19 @@ hpcrun_get_metric_proc(int metric_id)
 //
 int
 hpcrun_set_new_metric_info_w_fn(kind_info_t *kind, const char* name,
+        MetricFlags_ValFmt_t valFmt, size_t period,
+        metric_upd_proc_t upd_fn, metric_desc_properties_t prop)
+{
+  return hpcrun_set_new_metric_desc(kind, name, name, valFmt, period, upd_fn, prop);
+}
+
+//
+// create a new metric description
+// returns the new metric ID
+//
+int
+hpcrun_set_new_metric_desc(kind_info_t *kind, const char* name,
+        			const char *description,
 				MetricFlags_ValFmt_t valFmt, size_t period,
 				metric_upd_proc_t upd_fn, metric_desc_properties_t prop)
 {
@@ -380,7 +393,7 @@ hpcrun_set_new_metric_info_w_fn(kind_info_t *kind, const char* name,
   mdesc->flags = hpcrun_metricFlags_NULL;
 
   mdesc->name = (char*) name;
-  mdesc->description = (char*) name; // TODO
+  mdesc->description = (char*) description; 
   mdesc->period = period;
   mdesc->flags.fields.ty     = MetricFlags_Ty_Raw; // FIXME
   mdesc->flags.fields.valFmt = valFmt;
@@ -390,6 +403,14 @@ hpcrun_set_new_metric_info_w_fn(kind_info_t *kind, const char* name,
   return metric_id;
 }
 
+
+int
+hpcrun_set_new_metric_desc_and_period(kind_info_t *kind, const char* name, const char *description,
+				      MetricFlags_ValFmt_t valFmt, size_t period, metric_desc_properties_t prop)
+{
+  return hpcrun_set_new_metric_desc(kind, name, description, valFmt, period,
+					 hpcrun_metric_std_inc, prop);
+}
 
 int
 hpcrun_set_new_metric_info_and_period(kind_info_t *kind, const char* name,

--- a/src/tool/hpcrun/metrics.h
+++ b/src/tool/hpcrun/metrics.h
@@ -136,6 +136,14 @@ int hpcrun_set_new_metric_info_w_fn(kind_info_t *kind, const char* name,
 				    MetricFlags_ValFmt_t valFmt, size_t period,
 				    metric_upd_proc_t upd_fn, metric_desc_properties_t prop);
 
+int hpcrun_set_new_metric_desc(kind_info_t *kind, const char* name,
+		        const char *description,
+				MetricFlags_ValFmt_t valFmt, size_t period,
+				metric_upd_proc_t upd_fn, metric_desc_properties_t prop);
+
+int hpcrun_set_new_metric_desc_and_period(kind_info_t *kind, const char* name, const char *description,
+				      MetricFlags_ValFmt_t valFmt, size_t period, metric_desc_properties_t prop);
+
 int hpcrun_set_new_metric_info_and_period(kind_info_t *kind, const char* name,
 					  MetricFlags_ValFmt_t valFmt, size_t period, metric_desc_properties_t prop);
 

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -888,9 +888,11 @@ METHOD_FN(process_event_list, int lush_metrics)
 
     char *name_dup = strdup(name); // we need to duplicate the name of the metric until the end
                                    // since the OS will free it, we don't have to do it in hpcrun
+    const char *desc = pfmu_getEventDescription(name);
+
     // set the metric for this perf event
-    event_desc[i].hpcrun_metric_id = hpcrun_set_new_metric_info_and_period(lnux_kind, name_dup,
-            MetricFlags_ValFmt_Real, threshold, prop);
+    event_desc[i].hpcrun_metric_id = hpcrun_set_new_metric_desc_and_period(lnux_kind, name_dup,
+            desc, MetricFlags_ValFmt_Real, threshold, prop);
    
     // ------------------------------------------------------------
     // if we use frequency (event_type=1) then the period is not deterministic,

--- a/src/tool/hpcrun/sample-sources/perf/perfmon-util.c
+++ b/src/tool/hpcrun/sample-sources/perf/perfmon-util.c
@@ -304,6 +304,38 @@ show_info(char *event )
 // Supported operations
 //******************************************************************************
 
+
+const char *
+pfmu_getEventDescription(const char *event_name)
+{
+  if (event_name == NULL) return NULL;
+
+  pfm_perf_encode_arg_t arg;
+  char *fqstr = NULL;
+
+  arg.fstr = &fqstr;
+  arg.size = sizeof(pfm_perf_encode_arg_t);
+  struct perf_event_attr attr;
+  memset(&attr, 0, sizeof(struct perf_event_attr));
+
+  arg.attr = &attr;
+  int ret = pfm_get_os_event_encoding(event_name, PFM_PLM0|PFM_PLM3, PFM_OS_PERF_EVENT_EXT, &arg);
+
+  if (ret == PFM_SUCCESS) {
+    pfm_event_info_t info;
+    memset(&info, 0, sizeof(info));
+    info.size = sizeof(info);
+    
+    ret = pfm_get_event_info(arg.idx, PFM_OS_NONE, &info);
+
+    if (ret == PFM_SUCCESS) {
+      return info.desc;
+    }
+  }
+  return event_name;
+}
+
+
 /**
  * get the complete perf event attribute for a given pmu
  * @return 1 if successful

--- a/src/tool/hpcrun/sample-sources/perf/perfmon-util.h
+++ b/src/tool/hpcrun/sample-sources/perf/perfmon-util.h
@@ -53,6 +53,7 @@ int pfmu_showEventList();
 int pfmu_isSupported(const char *eventname);
 int pfmu_getEventType(const char *eventname, u64 *code, u64 *type);
 int pfmu_getEventAttribute(const char *eventname, struct perf_event_attr *event_attr);
+const char* pfmu_getEventDescription(const char *event_name);
 
 void pfmu_fini();
 


### PR DESCRIPTION
The current hpcrun is already equipped with metric description, but it doesn't gather description from the sample-source. Hence, the content of the description is not used in hpcprof.
This patch includes:
- hpcrun: gathering metric description from perf_events sample-source.
- hpcrun: writing the description into hpcrun file
- hpcprof: exporting it to experiment.xml

Caveat: due to XML limitation, a metric description cannot include special charaters (need to convert to escape sequence).