### PR TITLE
fix handling of vdso on arm

### DIFF
--- a/src/tool/hpcrun/os/linux/dylib.c
+++ b/src/tool/hpcrun/os/linux/dylib.c
@@ -127,10 +127,12 @@ dylib_find_module_containing_addr_callback(struct dl_phdr_info *info,
 void 
 dylib_map_open_dsos()
 {
-  dl_iterate_phdr(dylib_map_open_dsos_callback, (void *)0);
   char *vdso_start = (char *) vdso_segment_addr();
+  dl_iterate_phdr(dylib_map_open_dsos_callback, (void *) vdso_start);
   if (vdso_start) {
     char *vdso_end = vdso_start + vdso_segment_len();
+    // create a real file for vdso in our measurements directory and
+    // process bounds on that
     fnbounds_ensure_mapped_dso(get_saved_vdso_path(), vdso_start, vdso_end);
   }
 }
@@ -284,12 +286,18 @@ dylib_get_segment_bounds(struct dl_phdr_info *info,
 
 static int
 dylib_map_open_dsos_callback(struct dl_phdr_info *info, size_t size, 
-			     void *unused)
+			     void *vdso_start)
 {
   if (strcmp(info->dlpi_name,"") != 0) {
     struct dylib_seg_bounds_s bounds;
     dylib_get_segment_bounds(info, &bounds);
-    fnbounds_ensure_mapped_dso(info->dlpi_name, bounds.start, bounds.end);
+
+    // the file name provided by dl_iterate_phdr for the vdso segment 
+    // is a pseudo-file, so we can't process it directly below, which 
+    // expects a real file
+    if (bounds.start != vdso_start) {
+      fnbounds_ensure_mapped_dso(info->dlpi_name, bounds.start, bounds.end);
+    }
   }
 
   return 0;


### PR DESCRIPTION
we observed Linux reporting a name for the VDSO shared object.
it is the empty string on other platforms. avoid trying to
compute function bounds for vdso using a bogus file name.