### PR TITLE
Adapt fnbounds to the upcoming Dyninst 10.2.0 release with openmp

### DIFF
--- a/configure
+++ b/configure
@@ -673,6 +673,8 @@ MPI_PROTO_FILE
 MPI_INC
 MPIF77
 MPICC
+OPT_ENABLE_OPENMP_SYMTAB_FALSE
+OPT_ENABLE_OPENMP_SYMTAB_TRUE
 OPT_ENABLE_OPENMP_FALSE
 OPT_ENABLE_OPENMP_TRUE
 OPT_ENABLE_HPCSERVER_FALSE
@@ -1734,8 +1736,8 @@ Optional Features:
   --enable-hpcrun-static  build hpcrun for statically linked executables
                           (default yes)
   --enable-hpcserver      build hpcserver and hpcserver-mpi (default no)
-  --enable-openmp         enable openmp support in hpcstruct (default is to
-                          test dyninst)
+  --enable-openmp         enable openmp support in hpcstruct, requires support
+                          from dyninst
   --enable-mpi-wrapper    enable MPI wrapper support, requires MPICC, MPIF77
                           and MPI_INC (default no)
   --enable-lush           use lush backtrace in hpcrun
@@ -22196,35 +22198,55 @@ fi
 
 #-------------------------------------------------
 
-# Test if dyninst was built with openmp support.
+# Test if symtab and parseapi were built with openmp support.
 # Again, not really a good test.
 
-dyninst_openmp=no
+parse_openmp=no
+symtab_openmp=no
 
 if test "$DYNINST" != no ; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if dyninst built with openmp" >&5
-$as_echo_n "checking if dyninst built with openmp... " >&6; }
-
-  parseapi="${DYNINST_LIB_DIR}/libparseAPI.so"
-
   ORIG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
   LD_LIBRARY_PATH=
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if parseapi built with openmp" >&5
+$as_echo_n "checking if parseapi built with openmp... " >&6; }
+
+  parseapi="${DYNINST_LIB_DIR}/libparseAPI.so"
 
   if test -f "$parseapi" ; then
     for lib in $openmp_lib_list ; do
       ldd "$parseapi" 2>/dev/null | $AWK '{print $1}' | grep -e "$lib" >/dev/null
       if test $? -eq 0 ; then
-        dyninst_openmp=yes
+        parse_openmp=yes
 	dyninst_features="$dyninst_features openmp"
 	break
       fi
     done
   fi
 
-  LD_LIBRARY_PATH="$ORIG_LD_LIBRARY_PATH"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $parse_openmp" >&5
+$as_echo "$parse_openmp" >&6; }
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $dyninst_openmp" >&5
-$as_echo "$dyninst_openmp" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if symtab built with openmp" >&5
+$as_echo_n "checking if symtab built with openmp... " >&6; }
+
+  symtabapi="${DYNINST_LIB_DIR}/libsymtabAPI.so"
+
+  if test -f "$symtabapi" ; then
+    for lib in $openmp_lib_list ; do
+      ldd "$symtabapi" 2>/dev/null | $AWK '{print $1}' | grep -e "$lib" >/dev/null
+      if test $? -eq 0 ; then
+        symtab_openmp=yes
+	dyninst_features="$dyninst_features par-symtab"
+	break
+      fi
+    done
+  fi
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $symtab_openmp" >&5
+$as_echo "$symtab_openmp" >&6; }
+
+  LD_LIBRARY_PATH="$ORIG_LD_LIBRARY_PATH"
 fi
 
 ac_ext=cpp
@@ -22541,51 +22563,67 @@ fi
 # enable-openmp
 #-------------------------------------------------
 
-# Enable openmp support in hpcstruct.  Default is to do what ParseAPI
-# does.
+# Enable openmp support in hpcstruct and fnbounds.  Requires support
+# from ParseAPI and Symtab, so all this really does is disable it, if
+# desired.
+#
+# Note: this only controls openmp pragmas in hpctoolkit.  If dyninst
+# is compiled with openmp, then those pragmas still exist.
 
 # Check whether --enable-openmp was given.
 if test "${enable_openmp+set}" = set; then :
   enableval=$enable_openmp;
 else
-  enable_openmp="$dyninst_openmp"
+  enable_openmp="$parse_openmp"
 fi
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable openmp in hpcstruct" >&5
-$as_echo_n "checking whether to enable openmp in hpcstruct... " >&6; }
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_openmp" >&5
-$as_echo "$enable_openmp" >&6; }
+if test "x$enable_openmp" != xyes ; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: disable openmp support in hpcstruct and hpcfnbounds" >&5
+$as_echo "$as_me: disable openmp support in hpcstruct and hpcfnbounds" >&6;}
+  parse_openmp=no
+  symtab_openmp=no
+fi
 
-case "$enable_openmp" in
-  yes | no ) ;;
-  * ) { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: bad value for enable-openmp: $enable_openmp" >&5
-$as_echo "$as_me: WARNING: bad value for enable-openmp: $enable_openmp" >&2;}
-    enable_openmp="$dyninst_openmp"
-    ;;
-esac
+hpcstruct_mesg=serial
+ans=no
 
-if test "$enable_openmp" = yes ; then
+if test "$parse_openmp" = yes ; then
 
 $as_echo "#define ENABLE_OPENMP 1" >>confdefs.h
 
   hpcstruct_mesg=openmp
+  ans=hpcstruct
 else
   OPENMP_FLAG=
-  hpcstruct_mesg=serial
+  symtab_openmp=no
 fi
 
-if test "x$DYNINST" = xno || test "x$BOOST" = xno || test "x$LIBELF" = xno
-then
-  hpcstruct_mesg=no
+if test "$symtab_openmp" = yes ; then
+
+$as_echo "#define ENABLE_OPENMP_SYMTAB 1" >>confdefs.h
+
+  hpcstruct_mesg="$hpcstruct_mesg + fnbounds"
+  ans="$ans + fnbounds"
 fi
 
- if test "$enable_openmp" = yes; then
+{ $as_echo "$as_me:${as_lineno-$LINENO}: openmp support from dyninst: $ans" >&5
+$as_echo "$as_me: openmp support from dyninst: $ans" >&6;}
+
+ if test "$parse_openmp" = yes; then
   OPT_ENABLE_OPENMP_TRUE=
   OPT_ENABLE_OPENMP_FALSE='#'
 else
   OPT_ENABLE_OPENMP_TRUE='#'
   OPT_ENABLE_OPENMP_FALSE=
+fi
+
+ if test "$symtab_openmp" = yes; then
+  OPT_ENABLE_OPENMP_SYMTAB_TRUE=
+  OPT_ENABLE_OPENMP_SYMTAB_FALSE='#'
+else
+  OPT_ENABLE_OPENMP_SYMTAB_TRUE='#'
+  OPT_ENABLE_OPENMP_SYMTAB_FALSE=
 fi
 
 
@@ -23785,6 +23823,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${OPT_ENABLE_OPENMP_TRUE}" && test -z "${OPT_ENABLE_OPENMP_FALSE}"; then
   as_fn_error $? "conditional \"OPT_ENABLE_OPENMP\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${OPT_ENABLE_OPENMP_SYMTAB_TRUE}" && test -z "${OPT_ENABLE_OPENMP_SYMTAB_FALSE}"; then
+  as_fn_error $? "conditional \"OPT_ENABLE_OPENMP_SYMTAB\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${OPT_ENABLE_MPI_WRAP_TRUE}" && test -z "${OPT_ENABLE_MPI_WRAP_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -3732,33 +3732,51 @@ fi
 
 #-------------------------------------------------
 
-# Test if dyninst was built with openmp support.
+# Test if symtab and parseapi were built with openmp support.
 # Again, not really a good test.
 
-dyninst_openmp=no
+parse_openmp=no
+symtab_openmp=no
 
 if test "$DYNINST" != no ; then
-  AC_MSG_CHECKING([if dyninst built with openmp])
-
-  parseapi="${DYNINST_LIB_DIR}/libparseAPI.so"
-
   ORIG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
   LD_LIBRARY_PATH=
+
+  AC_MSG_CHECKING([if parseapi built with openmp])
+
+  parseapi="${DYNINST_LIB_DIR}/libparseAPI.so"
 
   if test -f "$parseapi" ; then
     for lib in $openmp_lib_list ; do
       ldd "$parseapi" 2>/dev/null | $AWK '{print $1}' | grep -e "$lib" >/dev/null
       if test $? -eq 0 ; then
-        dyninst_openmp=yes
+        parse_openmp=yes
 	dyninst_features="$dyninst_features openmp"
 	break
       fi
     done
   fi
 
-  LD_LIBRARY_PATH="$ORIG_LD_LIBRARY_PATH"
+  AC_MSG_RESULT([$parse_openmp])
 
-  AC_MSG_RESULT([$dyninst_openmp])
+  AC_MSG_CHECKING([if symtab built with openmp])
+
+  symtabapi="${DYNINST_LIB_DIR}/libsymtabAPI.so"
+
+  if test -f "$symtabapi" ; then
+    for lib in $openmp_lib_list ; do
+      ldd "$symtabapi" 2>/dev/null | $AWK '{print $1}' | grep -e "$lib" >/dev/null
+      if test $? -eq 0 ; then
+        symtab_openmp=yes
+	dyninst_features="$dyninst_features par-symtab"
+	break
+      fi
+    done
+  fi
+
+  AC_MSG_RESULT([$symtab_openmp])
+
+  LD_LIBRARY_PATH="$ORIG_LD_LIBRARY_PATH"
 fi
 
 AC_LANG_POP
@@ -3980,39 +3998,47 @@ AM_CONDITIONAL([OPT_ENABLE_HPCSERVER], [test "$enable_hpcserver" = yes])
 # enable-openmp
 #-------------------------------------------------
 
-# Enable openmp support in hpcstruct.  Default is to do what ParseAPI
-# does.
+# Enable openmp support in hpcstruct and fnbounds.  Requires support
+# from ParseAPI and Symtab, so all this really does is disable it, if
+# desired.
+#
+# Note: this only controls openmp pragmas in hpctoolkit.  If dyninst
+# is compiled with openmp, then those pragmas still exist.
 
 AC_ARG_ENABLE([openmp],
   [AS_HELP_STRING([--enable-openmp],
-      [enable openmp support in hpcstruct (default is to test dyninst)])],
+      [enable openmp support in hpcstruct, requires support from dyninst])],
   [],
-  [enable_openmp="$dyninst_openmp"])
+  [enable_openmp="$parse_openmp"])
 
-AC_MSG_CHECKING([whether to enable openmp in hpcstruct])
-AC_MSG_RESULT([$enable_openmp])
+if test "x$enable_openmp" != xyes ; then
+  AC_MSG_NOTICE([disable openmp support in hpcstruct and hpcfnbounds])
+  parse_openmp=no
+  symtab_openmp=no
+fi
 
-case "$enable_openmp" in
-  yes | no ) ;;
-  * ) AC_MSG_WARN([bad value for enable-openmp: $enable_openmp])
-    enable_openmp="$dyninst_openmp"
-    ;;
-esac
+hpcstruct_mesg=serial
+ans=no
 
-if test "$enable_openmp" = yes ; then
-  AC_DEFINE([ENABLE_OPENMP], [1], [Build with openmp support])
+if test "$parse_openmp" = yes ; then
+  AC_DEFINE([ENABLE_OPENMP], [1], [ParseAPI supports openmp (for hpcstruct)])
   hpcstruct_mesg=openmp
+  ans=hpcstruct
 else
   OPENMP_FLAG=
-  hpcstruct_mesg=serial
+  symtab_openmp=no
 fi
 
-if test "x$DYNINST" = xno || test "x$BOOST" = xno || test "x$LIBELF" = xno
-then
-  hpcstruct_mesg=no
+if test "$symtab_openmp" = yes ; then
+  AC_DEFINE([ENABLE_OPENMP_SYMTAB], [1], [Symtab supports openmp (for fnbounds)])
+  hpcstruct_mesg="$hpcstruct_mesg + fnbounds"
+  ans="$ans + fnbounds"
 fi
 
-AM_CONDITIONAL([OPT_ENABLE_OPENMP], [test "$enable_openmp" = yes])
+AC_MSG_NOTICE([openmp support from dyninst: $ans])
+
+AM_CONDITIONAL([OPT_ENABLE_OPENMP], [test "$parse_openmp" = yes])
+AM_CONDITIONAL([OPT_ENABLE_OPENMP_SYMTAB], [test "$symtab_openmp" = yes])
 
 
 #-------------------------------------------------

--- a/src/include/hpctoolkit-config.h.in
+++ b/src/include/hpctoolkit-config.h.in
@@ -21,8 +21,11 @@
 /* Support for CLOCK_REALTIME and SIGEV_THREAD_ID */
 #undef ENABLE_CLOCK_REALTIME
 
-/* Build with openmp support */
+/* ParseAPI supports openmp (for hpcstruct) */
 #undef ENABLE_OPENMP
+
+/* Symtab supports openmp (for fnbounds) */
+#undef ENABLE_OPENMP_SYMTAB
 
 /* Support for AMD XOP instructions */
 #undef ENABLE_XOP

--- a/src/tool/hpcfnbounds/Makefile.am
+++ b/src/tool/hpcfnbounds/Makefile.am
@@ -103,18 +103,16 @@ MYCPPFLAGS = $(HPC_IFLAGS) $(BOOST_IFLAGS) -I$(LIBELF_INC) -I$(LIBDWARF_INC) \
 
 MYCXXFLAGS = @HOST_CXXFLAGS@
 
-# MYLDADD = $(HPCLIB_SupportLean) \
-#         $(HPCLIB_ProfLean) \
-# 	-L$(SYMTABAPI_LIB) $(SYMTABAPI_LIB_LIST) \
-# 	-L$(LIBDWARF_LIB) -ldwarf \
-# 	-L$(LIBELF_LIB) -lelf
-
 MYLDADD = libeh_frames.a  \
 	$(HPCLIB_SupportLean) \
         $(HPCLIB_ProfLean) \
 	$(DYNINST_LFLAGS)  \
 	$(BOOST_LFLAGS) \
 	$(TBB_LFLAGS)
+
+if OPT_ENABLE_OPENMP_SYMTAB
+  MYCXXFLAGS += $(OPENMP_FLAG)
+endif
 
 if OPT_DYNINST_LIBDW
   MYLDADD += -L$(LIBELF_LIB) -ldw -lelf -ldl

--- a/src/tool/hpcfnbounds/Makefile.in
+++ b/src/tool/hpcfnbounds/Makefile.in
@@ -119,15 +119,16 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-@OPT_DYNINST_LIBDW_TRUE@am__append_1 = -L$(LIBELF_LIB) -ldw -lelf -ldl
-@OPT_DYNINST_LIBDW_FALSE@am__append_2 = -L$(LIBDWARF_LIB) -ldwarf -L$(LIBELF_LIB) -lelf
-@OPT_USE_ZLIB_TRUE@am__append_3 = -L$(ZLIB_LIB) -lz
+@OPT_ENABLE_OPENMP_SYMTAB_TRUE@am__append_1 = $(OPENMP_FLAG)
+@OPT_DYNINST_LIBDW_TRUE@am__append_2 = -L$(LIBELF_LIB) -ldw -lelf -ldl
+@OPT_DYNINST_LIBDW_FALSE@am__append_3 = -L$(LIBDWARF_LIB) -ldwarf -L$(LIBELF_LIB) -lelf
+@OPT_USE_ZLIB_TRUE@am__append_4 = -L$(ZLIB_LIB) -lz
 pkglibexec_PROGRAMS = hpcfnbounds-bin$(EXEEXT)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_4 = x86-process-ranges.cpp amd-xop.c
-@HOST_CPU_X86_FAMILY_TRUE@am__append_5 = -I$(XED2_INC)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_6 = $(XED2_LIB_FLAGS)
-@HOST_CPU_AARCH64_TRUE@@HOST_CPU_X86_FAMILY_FALSE@am__append_7 = arm-process-ranges.cpp
-@HOST_CPU_AARCH64_FALSE@@HOST_CPU_X86_FAMILY_FALSE@am__append_8 = generic-process-ranges.cpp
+@HOST_CPU_X86_FAMILY_TRUE@am__append_5 = x86-process-ranges.cpp amd-xop.c
+@HOST_CPU_X86_FAMILY_TRUE@am__append_6 = -I$(XED2_INC)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_7 = $(XED2_LIB_FLAGS)
+@HOST_CPU_AARCH64_TRUE@@HOST_CPU_X86_FAMILY_FALSE@am__append_8 = arm-process-ranges.cpp
+@HOST_CPU_AARCH64_FALSE@@HOST_CPU_X86_FAMILY_FALSE@am__append_9 = generic-process-ranges.cpp
 subdir = src/tool/hpcfnbounds
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/config/libtool.m4 \
@@ -603,27 +604,21 @@ MYSOURCES = \
 MYCPPFLAGS = $(HPC_IFLAGS) $(BOOST_IFLAGS) -I$(LIBELF_INC) -I$(LIBDWARF_INC) \
 	$(DYNINST_IFLAGS) $(TBB_IFLAGS)
 
-MYCXXFLAGS = @HOST_CXXFLAGS@
-
-# MYLDADD = $(HPCLIB_SupportLean) \
-#         $(HPCLIB_ProfLean) \
-# 	-L$(SYMTABAPI_LIB) $(SYMTABAPI_LIB_LIST) \
-# 	-L$(LIBDWARF_LIB) -ldwarf \
-# 	-L$(LIBELF_LIB) -lelf
+MYCXXFLAGS = @HOST_CXXFLAGS@ $(am__append_1)
 MYLDADD = libeh_frames.a $(HPCLIB_SupportLean) $(HPCLIB_ProfLean) \
 	$(DYNINST_LFLAGS) $(BOOST_LFLAGS) $(TBB_LFLAGS) \
-	$(am__append_1) $(am__append_2) $(am__append_3)
+	$(am__append_2) $(am__append_3) $(am__append_4)
 MYCLEAN = @HOST_LIBTREPOSITORY@
 noinst_LIBRARIES = libeh_frames.a
 pkglibexec_SCRIPTS = hpcfnbounds
 libeh_frames_a_SOURCES = eh-frames.cpp
 libeh_frames_a_CPPFLAGS = $(HPC_IFLAGS) $(BOOST_IFLAGS) -I$(LIBDWARF_INC)
 libeh_frames_a_CXXFLAGS = $(MYCXXFLAGS)
-hpcfnbounds_bin_SOURCES = $(MYSOURCES) $(am__append_4) $(am__append_7) \
-	$(am__append_8)
-hpcfnbounds_bin_CPPFLAGS = $(MYCPPFLAGS) $(am__append_5)
+hpcfnbounds_bin_SOURCES = $(MYSOURCES) $(am__append_5) $(am__append_8) \
+	$(am__append_9)
+hpcfnbounds_bin_CPPFLAGS = $(MYCPPFLAGS) $(am__append_6)
 hpcfnbounds_bin_CXXFLAGS = $(MYCXXFLAGS)
-hpcfnbounds_bin_LDADD = $(MYLDADD) $(am__append_6)
+hpcfnbounds_bin_LDADD = $(MYLDADD) $(am__append_7)
 MOSTLYCLEANFILES = $(MYCLEAN)
 
 # Assumes includer sets MYCXXFLAGS and MYCFLAGS

--- a/src/tool/hpcfnbounds/hpcfnbounds.in
+++ b/src/tool/hpcfnbounds/hpcfnbounds.in
@@ -43,58 +43,13 @@ esac
 
 @launch_early_options@
 
-# If -v is one of the options, then print extra info about what files
-# hpcfnbounds is run on, whether it succeeds, etc, to go in hpcrun
-# logfile.
-#
-server=no
-verbose=no
-base=
-dir=
-for arg in "$@"
-do
-    case "$arg" in
-	-s ) server=yes ;;
-	-v ) verbose=yes ;;
-	-* ) ;;
-	* )
-	    if test "x$base" = x ; then
-		base=`basename "$arg"`
-	    elif test "x$dir" = x ; then
-		dir="$arg"
-	    fi
-	    ;;
-    esac
-done
-
-# FIXME: integrate server and verbose.
+#------------------------------------------------------------
+# Set environment and exec
+#------------------------------------------------------------
 
 # Tell fnbounds where to find libdwarf.so for dlopen.
 export HPCTOOLKIT_EXT_LIBS_DIR="$ext_libs_dir"
 
-if test "$server" = yes ; then
-    export LD_LIBRARY_PATH="${ext_libs_dir}:${libcxx_path}:${LD_LIBRARY_PATH}"
-    exec "${hpcfnbounds_dir}/hpcfnbounds-bin" "$@"
-fi
+export LD_LIBRARY_PATH="${ext_libs_dir}:${libcxx_path}:${LD_LIBRARY_PATH}"
+exec "${hpcfnbounds_dir}/hpcfnbounds-bin" "$@"
 
-if test "$verbose" = yes ; then
-    echo "hpcfnbounds $@"
-fi
-
-if test "x$dir" != x && test ! -d "$dir" ; then
-    mkdir -p "$dir"
-fi
-
-LD_LIBRARY_PATH="${ext_libs_dir}:${libcxx_path}:${LD_LIBRARY_PATH}" \
-    "${hpcfnbounds_dir}/hpcfnbounds-bin" "$@"
-
-ret=$?
-if test "$verbose" = yes ; then
-    if test $ret -ne 0 ; then
-	echo "hpcfnbounds $base FAILED"
-    fi
-    ls -l "${dir}/${base}"*
-    tail -1 "${dir}/${base}"*.txt
-fi
-
-exit $ret

--- a/src/tool/hpcfnbounds/main.cpp
+++ b/src/tool/hpcfnbounds/main.cpp
@@ -63,7 +63,15 @@
 #include <fcntl.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <stdlib.h>
 #include <unistd.h>
+
+#include <include/hpctoolkit-config.h>
+
+#ifdef ENABLE_OPENMP_SYMTAB
+#include <omp.h>
+#endif
+
 
 //*****************************************************************************
 // local includes
@@ -80,7 +88,6 @@
 #include "syserv-mesg.h"
 #include "Symtab.h"
 #include "Symbol.h"
-
 
 
 //*****************************************************************************
@@ -137,6 +144,13 @@ main(int argc, char* argv[])
   DiscoverFnTy fn_discovery = DiscoverFnTy_Aggressive;
   char *object_file;
   int n, fdin, fdout;
+  int jobs = 1;
+
+  // num threads may be specified via environ or -js arg
+  char *str = getenv("HPCFNBOUNDS_NUM_THREADS");
+  if (str != NULL) {
+    jobs = atoi(str);
+  }
 
   for (n = 1; n < argc; n++) {
     if (strcmp(argv[n], "-c") == 0) {
@@ -147,6 +161,13 @@ main(int argc, char* argv[])
     }
     else if (strcmp(argv[n], "-h") == 0 || strcmp(argv[n], "--help") == 0) {
       usage(argv[0], 0);
+    }
+    else if (strcmp(argv[n], "-js") == 0) {
+      if (argc < n + 2 || sscanf(argv[n+1], "%d", &jobs) < 1 || jobs < 1) {
+	fprintf(stderr, "hpcfnbounds: bad or missing number of threads for -js\n");
+	usage(argv[0], 1);
+      }
+      n += 1;
     }
     else if (strcmp(argv[n], "-s") == 0) {
       the_mode = MODE_SERVER;
@@ -176,6 +197,12 @@ main(int argc, char* argv[])
       break;
     }
   }
+
+  // If symtab supports openmp, then set num threads.
+#ifdef ENABLE_OPENMP_SYMTAB
+  if (jobs < 1) { jobs = 1; }
+  omp_set_num_threads(jobs);
+#endif
 
   // Run as the system server.
   if (server_mode()) {
@@ -249,6 +276,7 @@ usage(char *command, int status)
     "\t-c\twrite output in C source code\n"
     "\t-d\tdon't perform function discovery on stripped code\n"
     "\t-h\tprint this help message and exit\n"
+    "\t-js num \trun with num threads in symtab (default 1)\n"
     "\t-s fdin fdout\trun in server mode\n"
     "\t-t\twrite output in text format (default)\n"
     "\t-v\tturn on verbose output in hpcfnbounds script\n\n"

--- a/src/tool/hpcrun/scripts/hpcrun.in
+++ b/src/tool/hpcrun/scripts/hpcrun.in
@@ -146,7 +146,11 @@ Options: Profiling (Defaults shown in curly brackets {})
                        processes.  For each process, enable measurement
                        (of all threads) with probability <frac>; <frac> is a
                        real number (0.10) or a fraction (1/10) between 0 and 1.
-  
+
+  -js <num>, --jobs-symtab <num>
+                       Use <num> openmp threads for Symtab in hpcfnbounds,
+                       if Symtab supports openmp (default 1).
+
   -m, --merge-threads  Merge non-overlapped threads into one virtual thread.
                        This option is to reduce the number of generated
                        profile and trace files as each thread generates its own
@@ -223,7 +227,7 @@ do
 	    shift
 	    ;;
 
-  -ck | --control-knob )
+	-ck | --control-knob )
 	    arg_ok "$1" || die "missing argument for $arg"
 	    export HPCRUN_CONTROL_KNOBS="$HPCRUN_CONTROL_KNOBS $1"
 	    shift
@@ -273,7 +277,7 @@ do
 	# --------------------------------------------------
 
  	-c | --count )
- 	 	export HPCRUN_PERF_COUNT="$1"
+ 	    export HPCRUN_PERF_COUNT="$1"
 	    shift
 	    ;;
 
@@ -281,6 +285,13 @@ do
 
 	-t | --trace )
 	    export HPCRUN_TRACE=1
+	    ;;
+
+	# --------------------------------------------------
+
+	-js | --jobs-symtab )
+	    export HPCFNBOUNDS_NUM_THREADS="$1"
+	    shift
 	    ;;
 
 	# --------------------------------------------------
@@ -304,13 +315,13 @@ do
 	    export HPCRUN_RETAIN_RECURSION=1
 	    ;;
 
-  # --------------------------------------------------
+	# --------------------------------------------------
 
-  -m | --merge-threads )
-      arg_ok "$1" || die "missing argument for $arg"
-      export HPCRUN_MERGE_THREADS="$1"
-      shift
-      ;;
+	-m | --merge-threads )
+	    arg_ok "$1" || die "missing argument for $arg"
+	    export HPCRUN_MERGE_THREADS="$1"
+	    shift
+	    ;;
       
 	# --------------------------------------------------
 


### PR DESCRIPTION
support in Symtab.

 1. configure tests if libsymtabAPI.so is compiled with openmp.

 2. Makefile adds -fopenmp as needed.

 3. hpcrun and hpcfnbounds support a '-js num' option to specify the
 number of openmp threads for symtab in fnbounds (default 1).

 4. rip out the option processing in the fnbounds launch script and
 handle all options in the binary.  we haven't used this and it hasn't
 worked right for years.

To use threads in hpcfnbounds, use a recent dyninst pre-10.2.0 from
master and export HPCFNBOUNDS_NUM_THREADS=num, or else use
'hpcrun -js num ...'.  OMP_NUM_THREADS applies to the application.

Although this commit supports threads in fnbounds, the latest Symtab
will use threads whether we support it or not.  The real purpose is to
prevent fnbounds from consuming every available thread per process.