### PR TITLE
Fix a regression in doc/www/software.html.  It looks like the link to

### DIFF
--- a/doc/www/software.html
+++ b/doc/www/software.html
@@ -27,6 +27,8 @@
 
 <h2><a href="software-instructions.html">Build Instructions</a></h2>
 
+<h2><a href="spack-issues.html">Current Spack Issues</a></h2>
+
 
 <h2>Source code for HPCToolkit</h2>
 


### PR DESCRIPTION
'spack-issues.html' was removed in a recent merge.