### PR TITLE
hpcrun: fix issue #189 (BLOCKTIME event crashes)

### DIFF
--- a/src/tool/hpcrun/sample-sources/perf/event_custom.h
+++ b/src/tool/hpcrun/sample-sources/perf/event_custom.h
@@ -54,7 +54,7 @@ struct event_thread_s;
 struct perf_mmap_data_s;
 
 // callback functions
-typedef void (*register_event_t)(struct event_info_s *);
+typedef void (*register_event_t)(kind_info_t *kb_kind, struct event_info_s *);
 typedef void (*event_handler_t)(struct event_thread_s*, sample_val_t , struct perf_mmap_data_s* );
 
 

--- a/src/tool/hpcrun/sample-sources/perf/kernel_blocking.c
+++ b/src/tool/hpcrun/sample-sources/perf/kernel_blocking.c
@@ -210,12 +210,8 @@ kernel_block_handler( event_thread_t *current_event, sample_val_t sv,
  * - context switch metric to store the number of context switches
  ****************************************************************/
 static void
-register_blocking(event_info_t *event_desc)
+register_blocking(kind_info_t *kb_kind, event_info_t *event_desc)
 {
-  static kind_info_t *kb_kind;
-
-  kb_kind = hpcrun_metrics_new_kind();
-
   // ------------------------------------------
   // create metric to compute blocking time
   // ------------------------------------------
@@ -257,8 +253,6 @@ register_blocking(event_info_t *event_desc)
       1           /* sample every context switch*/,
       sample_type /* need additional info for sample type */
   );
-
-  hpcrun_close_kind(kb_kind);
 
   event_desc->attr.context_switch = 1;
   event_desc->attr.sample_id_all = 1;

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -851,7 +851,7 @@ METHOD_FN(process_event_list, int lush_metrics)
     if (event_desc[i].metric_custom != NULL) {
       if (event_desc[i].metric_custom->register_fn != NULL) {
     	// special registration for customized event
-        event_desc[i].metric_custom->register_fn( &event_desc[i] );
+        event_desc[i].metric_custom->register_fn( lnux_kind, &event_desc[i] );
         METHOD_CALL(self, store_event, event_desc[i].attr.config, threshold);
         continue;
       }


### PR DESCRIPTION
Quick fix for issue #189 where profiling with -e BLOCKTIME causes segmentation fault in some cases, and memory corruption (but doesn't crash) in other cases.

Current solution: All linux_perf's custom-based events should be based on perf_event metric kind. Otherwise linux perf_event manager doesn't know how many metrics (or events) are there.
Long term solution: Linux perf_event custom-based events should be ideally more independent (ideally it should be a plugin).