### PR TITLE
Fix incorrect use of hpcrun_set_new_metric_info_and_period and missing hpcrun_close_kind

### DIFF
--- a/src/tool/hpcrun/sample-sources/cuda.c
+++ b/src/tool/hpcrun/sample-sources/cuda.c
@@ -329,16 +329,19 @@ METHOD_FN(process_event_list, int lush_metrics)
 
   hpcrun_pre_allocate_metrics(nevents + num_lush_metrics);
 
+  kind_info_t *cuda_kind = hpcrun_metrics_new_kind();
+
   for (i = 0; i < nevents; i++) {
     char buffer[PAPI_MAX_STR_LEN];
     PAPI_event_code_to_name(self->evl.events[i].event, buffer);
     TMSG(CUDA, "metric for event %d = %s", i, buffer);
     int metric_id = /* weight */
-      hpcrun_set_new_metric_info_and_period(strdup(buffer),
-					    MetricFlags_ValFmt_Int,
-					    self->evl.events[i].thresh);
+      hpcrun_set_new_metric_info_and_period(cuda_kind, strdup(buffer),
+        MetricFlags_ValFmt_Int, self->evl.events[i].thresh, metric_property_none);
     METHOD_CALL(self, store_metric_id, i, metric_id);
   }
+
+  hpcrun_close_kind(cuda_kind);
 }
 
 static void

--- a/src/tool/hpcrun/sample-sources/generic.c
+++ b/src/tool/hpcrun/sample-sources/generic.c
@@ -367,6 +367,8 @@ METHOD_FN(process_event_list, int lush_metrics)
     local_event[n_events].code   = YOUR_NAME_TO_CODE(event);
     local_event[n_events].thresh = thresh;
 
+    kind_info_t *metric_kind = hpcrun_metrics_new_kind();
+
     // for each event, process metrics for that event
     // If there is only 1 metric for each event, then the loop is unnecessary
     //
@@ -381,9 +383,9 @@ METHOD_FN(process_event_list, int lush_metrics)
       // For a standard updating metric (add some counts at each sample time), use
       // hpcrun_set_metric_info_and_period routine, as shown below
       //
-        metric_id = hpcrun_set_new_metric_info_and_period(name,
-                                          HPCRUN_MetricFlag_Async, // This is the correct flag value for almost all events
-                                          thresh, metric_property_none);
+        metric_id = hpcrun_set_new_metric_info_and_period(
+          metric_kind, name, HPCRUN_MetricFlag_Async, // This is the correct flag value for almost all events
+          thresh, metric_property_none);
       }
       else { // NON STANDARD METRIC
         // For a metric that updates in a NON standard fashion, use
@@ -393,10 +395,10 @@ METHOD_FN(process_event_list, int lush_metrics)
       }
       metrics[n_events++][i] = metric_id;
     }
-  }
-  
-  // NOTE: some lush-aware event list processing may need to be done here ...
 
+    hpcrun_close_kind(metric_kind);
+  }
+  // NOTE: some lush-aware event list processing may need to be done here ...
 }
 
 static void

--- a/src/tool/hpcrun/sample-sources/gpu_blame.c
+++ b/src/tool/hpcrun/sample-sources/gpu_blame.c
@@ -230,7 +230,7 @@ static void METHOD_FN(process_event_list, int lush_metrics)
     // Accumulates the time between last kernel end to current Sync point as a potential GPU overload factor
     gpu_overload_potential_metric_id = hpcrun_set_new_metric_info(blame_kind, "GPU_OVERLOAD_POTENTIAL");
 
-    blame_kind = hpcrun_close_kind(blame_kind);
+    hpcrun_close_kind(blame_kind);
     
     bs_entry.fn = dlsym(RTLD_DEFAULT, "gpu_blame_shifter");
     bs_entry.next = 0;

--- a/src/tool/hpcrun/sample-sources/gpu_blame.c
+++ b/src/tool/hpcrun/sample-sources/gpu_blame.c
@@ -229,6 +229,8 @@ static void METHOD_FN(process_event_list, int lush_metrics)
     uva_data_xfer_metric_id = hpcrun_set_new_metric_info(blame_kind, "UVA_BYTES");
     // Accumulates the time between last kernel end to current Sync point as a potential GPU overload factor
     gpu_overload_potential_metric_id = hpcrun_set_new_metric_info(blame_kind, "GPU_OVERLOAD_POTENTIAL");
+
+    blame_kind = hpcrun_close_kind(blame_kind);
     
     bs_entry.fn = dlsym(RTLD_DEFAULT, "gpu_blame_shifter");
     bs_entry.next = 0;

--- a/src/tool/hpcrun/sample-sources/mpi.c
+++ b/src/tool/hpcrun/sample-sources/mpi.c
@@ -150,7 +150,9 @@ METHOD_FN(supports_event,const char *ev_str)
 static void
 METHOD_FN(process_event_list,int lush_metrics)
 {
-  hpmpi_metric_id = hpcrun_set_new_metric_info("MPI_MSG(B)");
+  kind_info_t *mpi_kind = hpcrun_metrics_new_kind();
+  hpmpi_metric_id = hpcrun_set_new_metric_info(mpi_kind, "MPI_MSG(B)");
+  hpcrun_close_kind(mpi_kind);
   TMSG(MPI, "Setting up metrics for MPI: %d", hpmpi_metric_id);
 }
 

--- a/src/tool/hpcrun/sample-sources/papi-c.c
+++ b/src/tool/hpcrun/sample-sources/papi-c.c
@@ -569,6 +569,8 @@ METHOD_FN(process_event_list, int lush_metrics)
     }
   }
 
+  hpcrun_close_kind(papi_kind);
+
   if (! some_overflow) {
     hpcrun_ssfail_all_derived("PAPI");
   }

--- a/src/tool/hpcrun/sample-sources/papi.c
+++ b/src/tool/hpcrun/sample-sources/papi.c
@@ -401,6 +401,8 @@ METHOD_FN(process_event_list, int lush_metrics)
 
   hpcrun_pre_allocate_metrics(nevents + num_lush_metrics);
 
+  kind_info_t *papi_kind = hpcrun_metrics_new_kind();
+
   some_derived = 0;
   some_overflow = 0;
   for (i = 0; i < nevents; i++) {
@@ -431,23 +433,29 @@ METHOD_FN(process_event_list, int lush_metrics)
     }
 
     int metric_id = /* weight */
-      hpcrun_set_new_metric_info_and_period(strdup(buffer),
-					    MetricFlags_ValFmt_Int,
-					    self->evl.events[i].thresh, prop);
+      hpcrun_set_new_metric_info_and_period(
+        papi_kind,
+        strdup(buffer),
+        MetricFlags_ValFmt_Int,
+        self->evl.events[i].thresh, prop);
     METHOD_CALL(self, store_metric_id, i, metric_id);
 
     // FIXME:LUSH: need a more flexible metric interface
     if (num_lush_metrics > 0 && strcmp(buffer, "PAPI_TOT_CYC") == 0) {
       // there should be one lush metric; its source is the last event
       int mid_idleness =
-	hpcrun_set_new_metric_info_and_period("idleness",
-					      MetricFlags_ValFmt_Real,
-					      self->evl.events[i].thresh, prop);
+        hpcrun_set_new_metric_info_and_period(
+          papi_kind,
+          "idleness",
+          MetricFlags_ValFmt_Real,
+          self->evl.events[i].thresh, prop);
       assert(num_lush_metrics == 1 && (i == (nevents - 1)));
       lush_agents->metric_time = metric_id;
       lush_agents->metric_idleness = mid_idleness;
     }
   }
+
+  hpcrun_close_kind(papi_kind);
 
   if (! some_overflow) {
     hpcrun_ssfail_all_derived("PAPI");

--- a/src/tool/hpcrun/sample-sources/tst.c
+++ b/src/tool/hpcrun/sample-sources/tst.c
@@ -306,19 +306,21 @@ METHOD_FN(process_event_list, int lush_metrics)
 # define sample_period period
 #endif
 
-  int metric_id = hpcrun_set_new_metric_info_and_period("_TST",
-							MetricFlags_ValFmt_Int,
-							sample_period, metric_property_none);
+  kind_info_t *tst_kind = hpcrun_metrics_new_kind();
+
+  int metric_id = hpcrun_set_new_metric_info_and_period(,
+    tst_kind, "_TST", MetricFlags_ValFmt_Int, sample_period, metric_property_none);
   METHOD_CALL(self, store_metric_id, _TST_EVENT, metric_id);
   TMSG(_TST_CTL, "setting metric _TST, period = %ld", sample_period);
   if (lush_metrics == 1) {
     int mid_idleness = 
-      hpcrun_set_new_metric_info_and_period("idleness (ms)",
-					    MetricFlags_ValFmt_Real,
-					    sample_period, metric_property_none);
+      hpcrun_set_new_metric_info_and_period(tst_kind, "idleness (ms)",
+        MetricFlags_ValFmt_Real, sample_period, metric_property_none);
     lush_agents->metric_idleness = mid_idleness;
     lush_agents->metric_time = metric_id;
   }
+
+  hpcrun_close_kind(tst_kind);
 
   event = next_tok();
   if (more_tok()) {

--- a/src/tool/hpcrun/sample-sources/upc.c
+++ b/src/tool/hpcrun/sample-sources/upc.c
@@ -298,17 +298,21 @@ METHOD_FN(process_event_list, int lush_metrics)
   nevents = self->evl.nevents;
   hpcrun_pre_allocate_metrics(nevents);
 
+  kind_info_t *upc_kind = hpcrun_metrics_new_kind();
+
   for (k = 0; k < nevents; k++) {
     code = self->evl.events[k].event;
     threshold = self->evl.events[k].thresh;
     BGP_UPC_Get_Event_Name(code, EVENT_NAME_SIZE, name);
     metric_id = 
-      hpcrun_set_new_metric_info_and_period(strdup(name),
-					    MetricFlags_ValFmt_Int, threshold, (metric_desc_properties_t){} );
+      hpcrun_set_new_metric_info_and_period(upc_kind, strdup(name),
+        MetricFlags_ValFmt_Int, threshold, metric_property_none);
     self->evl.events[k].metric_id = metric_id;
     TMSG(UPC, "add event %s(%d), threshold %ld, metric %d",
 	 name, code, threshold, metric_id);
   }
+
+  hpcrun_close_kind(upc_kind);
 }
 
 static void


### PR DESCRIPTION
`hpcrun/metrics.h` declares `kind_info_t *` as the first arg.

```
int hpcrun_set_new_metric_info_and_period(kind_info_t *kind, const char* name,
                                          MetricFlags_ValFmt_t valFmt, size_t period, 
					  metric_desc_properties_t prop);
```

But there are files such as  `cuda.c`, `generic.c`, `papi.c`, and `tst.c` that use it without the kind pointer.

Besides, `hpcrun_close_kind` is not called in some places after `hpcrun_metrics_new_kind` is used.