### PR TITLE
Fix issue 68 (incorrect struct ID for single aliens)

### DIFF
--- a/src/lib/prof/CallPath-Profile.cpp
+++ b/src/lib/prof/CallPath-Profile.cpp
@@ -669,6 +669,18 @@ writeXML_help(std::ostream& os, const char* entry_nm,
         completProcName.append(file_key);
         completProcName.append(":");
 
+        if ((strct->type() == Prof::Struct::ANode::TyAlien) &&
+            strct->name().compare("<inline>")==0) 
+            {
+          Prof::Struct::ANode *parent = strct->parent();
+          if (parent) 
+          {
+            char buffer[128];
+            sprintf(buffer, "%d:", parent->id());
+            completProcName.append(buffer);
+          }
+        }
+
         const char *lnm;
 
         // a procedure name within the same file has to be unique.

--- a/src/lib/prof/CallPath-Profile.cpp
+++ b/src/lib/prof/CallPath-Profile.cpp
@@ -670,11 +670,9 @@ writeXML_help(std::ostream& os, const char* entry_nm,
         completProcName.append(":");
 
         if ((strct->type() == Prof::Struct::ANode::TyAlien) &&
-            strct->name().compare("<inline>")==0) 
-            {
+            strct->name().compare("<inline>")==0) {
           Prof::Struct::ANode *parent = strct->parent();
-          if (parent) 
-          {
+          if (parent) {
             char buffer[128];
             sprintf(buffer, "%d:", parent->id());
             completProcName.append(buffer);


### PR DESCRIPTION
**Symptom**: hpcprof generates the same flat ID (or struct ID) for the same inlined macro (single alien) from different contexts, which confuses the viewer when creating the flat view.

**Root cause**: Before writing experiment.xml, hpcprof removes redundant procedures by ensuring the tuple `<Load_module, Filename, Procedure, line_number>` is unique. However, for inline macros, we shouldn't remove redundancy. Or perhaps we should add `<Load_module, Filename, Procedure, line_number, "parent_id">` to be unique.

**Solution**: add "`parent_id`" in the tuple to make sure single alien is unique based on its context.

