### PR TITLE
Suppress samples during dlopen and dlclose

### DIFF
--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -200,8 +200,8 @@ int lush_metrics = 0; // FIXME: global variable for now
 /******************************************************************************
  * (public declaration) thread-local variables
  *****************************************************************************/
- __thread bool hpcrun_thread_suppress_sample = true;
- __thread int hpcrun_thread_dl_operation = 0;
+ static __thread bool hpcrun_thread_suppress_sample = true;
+ static __thread int hpcrun_thread_dl_operation = 0;
 
 
 //***************************************************************************
@@ -224,6 +224,31 @@ static spinlock_t hpcrun_aux_cleanup_lock = SPINLOCK_UNLOCKED;
 static hpcrun_aux_cleanup_t * hpcrun_aux_cleanup_list_head = NULL;
 static hpcrun_aux_cleanup_t * hpcrun_aux_cleanup_free_list_head = NULL;
 static char execname[PATH_MAX] = {'\0'};
+
+//***************************************************************************
+// Interface functions for suppressing samples
+//***************************************************************************
+
+void hpcrun_dlfunction_begin()
+{
+  hpcrun_thread_dl_operation += 1;
+}
+
+void hpcrun_dlfunction_end()
+{
+  hpcrun_thread_dl_operation -= 1;
+}
+
+bool hpcrun_dlfunction_is_active()
+{
+  return hpcrun_thread_dl_operation > 0;
+}
+
+bool hpcrun_suppress_sample()
+{
+  return hpcrun_dlfunction_is_active() || hpcrun_thread_suppress_sample;
+}
+
 
 //
 // Local functions
@@ -1597,7 +1622,7 @@ MONITOR_EXT_WRAP_NAME(pthread_cond_broadcast)(pthread_cond_t* cond)
 void
 monitor_pre_dlopen(const char* path, int flags)
 {
-  hpcrun_thread_dl_operation += 1;
+  hpcrun_dlfunction_begin();
   if (! hpcrun_dlopen_forced) {
     if (! hpcrun_is_initialized()) {
       hpcrun_dlopen_flags_push(false);
@@ -1617,7 +1642,7 @@ monitor_pre_dlopen(const char* path, int flags)
 void
 monitor_dlopen(const char *path, int flags, void* handle)
 {
-  hpcrun_thread_dl_operation -= 1;
+  hpcrun_dlfunction_end();
   if (!hpcrun_dlopen_flags_pop()) {
     return;
   }
@@ -1637,7 +1662,7 @@ monitor_dlopen(const char *path, int flags, void* handle)
 void
 monitor_dlclose(void* handle)
 {
-  hpcrun_thread_dl_operation += 1;
+  hpcrun_dlfunction_begin();
   if (! hpcrun_is_initialized()) {
     hpcrun_dlclose_flags_push(false);
     return;
@@ -1652,7 +1677,7 @@ monitor_dlclose(void* handle)
 void
 monitor_post_dlclose(void* handle, int ret)
 {
-  hpcrun_thread_dl_operation -= 1;
+  hpcrun_dlfunction_end();
   if (! hpcrun_dlclose_flags_pop()) {
     return;
   }

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -201,6 +201,7 @@ int lush_metrics = 0; // FIXME: global variable for now
  * (public declaration) thread-local variables
  *****************************************************************************/
  __thread bool hpcrun_thread_suppress_sample = true;
+ __thread int hpcrun_thread_dl_operation = 0;
 
 
 //***************************************************************************
@@ -1596,6 +1597,7 @@ MONITOR_EXT_WRAP_NAME(pthread_cond_broadcast)(pthread_cond_t* cond)
 void
 monitor_pre_dlopen(const char* path, int flags)
 {
+  hpcrun_thread_dl_operation += 1;
   if (! hpcrun_dlopen_forced) {
     if (! hpcrun_is_initialized()) {
       hpcrun_dlopen_flags_push(false);
@@ -1615,6 +1617,7 @@ monitor_pre_dlopen(const char* path, int flags)
 void
 monitor_dlopen(const char *path, int flags, void* handle)
 {
+  hpcrun_thread_dl_operation -= 1;
   if (!hpcrun_dlopen_flags_pop()) {
     return;
   }
@@ -1634,6 +1637,7 @@ monitor_dlopen(const char *path, int flags, void* handle)
 void
 monitor_dlclose(void* handle)
 {
+  hpcrun_thread_dl_operation += 1;
   if (! hpcrun_is_initialized()) {
     hpcrun_dlclose_flags_push(false);
     return;
@@ -1648,6 +1652,7 @@ monitor_dlclose(void* handle)
 void
 monitor_post_dlclose(void* handle, int ret)
 {
+  hpcrun_thread_dl_operation -= 1;
   if (! hpcrun_dlclose_flags_pop()) {
     return;
   }

--- a/src/tool/hpcrun/main.h
+++ b/src/tool/hpcrun/main.h
@@ -80,4 +80,9 @@ void hpcrun_process_aux_cleanup_remove(hpcrun_aux_cleanup_t * node);
 
 extern void special_cuda_ctxt_actions(bool enable);
 
+extern void hpcrun_dlfunction_begin();
+extern void hpcrun_dlfunction_end();
+extern bool hpcrun_dlfunction_is_active();
+extern bool hpcrun_suppress_sample();
+
 #endif  // ! main_h

--- a/src/tool/hpcrun/sample-sources/itimer.c
+++ b/src/tool/hpcrun/sample-sources/itimer.c
@@ -210,6 +210,7 @@ static __thread bool wallclock_ok = false;
  * external thread-local variables
  *****************************************************************************/
 extern __thread bool hpcrun_thread_suppress_sample;
+extern __thread int hpcrun_thread_dl_operation;
 
 // ****************************************************************************
 // * public helper function
@@ -690,7 +691,7 @@ itimer_signal_handler(int sig, siginfo_t* siginfo, void* context)
   sample_source_t *self = &_itimer_obj;
 
   // if sampling is suppressed for this thread, restart timer, & exit
-  if (hpcrun_thread_suppress_sample || sample_filters_apply()) {
+  if (hpcrun_thread_dl_operation > 0 || hpcrun_thread_suppress_sample || sample_filters_apply()) {
     TMSG(ITIMER_HANDLER, "thread sampling suppressed");
     hpcrun_restart_timer(self, 1);
 

--- a/src/tool/hpcrun/sample-sources/itimer.c
+++ b/src/tool/hpcrun/sample-sources/itimer.c
@@ -206,12 +206,6 @@ static sigset_t timer_mask;
 
 static __thread bool wallclock_ok = false;
 
-/******************************************************************************
- * external thread-local variables
- *****************************************************************************/
-extern __thread bool hpcrun_thread_suppress_sample;
-extern __thread int hpcrun_thread_dl_operation;
-
 // ****************************************************************************
 // * public helper function
 // ****************************************************************************
@@ -691,7 +685,7 @@ itimer_signal_handler(int sig, siginfo_t* siginfo, void* context)
   sample_source_t *self = &_itimer_obj;
 
   // if sampling is suppressed for this thread, restart timer, & exit
-  if (hpcrun_thread_dl_operation > 0 || hpcrun_thread_suppress_sample || sample_filters_apply()) {
+  if (hpcrun_suppress_sample() || sample_filters_apply()) {
     TMSG(ITIMER_HANDLER, "thread sampling suppressed");
     hpcrun_restart_timer(self, 1);
 

--- a/src/tool/hpcrun/sample-sources/itimer.c
+++ b/src/tool/hpcrun/sample-sources/itimer.c
@@ -91,6 +91,7 @@
 #include <hpcrun/hpcrun_options.h>
 #include <hpcrun/hpcrun_stats.h>
 
+#include <hpcrun/main.h>
 #include <hpcrun/metrics.h>
 #include <hpcrun/safe-sampling.h>
 #include <hpcrun/sample_event.h>

--- a/src/tool/hpcrun/sample-sources/papi-c.c
+++ b/src/tool/hpcrun/sample-sources/papi-c.c
@@ -82,6 +82,7 @@
 #include "papi-c-extended-info.h"
 #include "sample-filters.h"
 
+#include <hpcrun/main.h>
 #include <hpcrun/hpcrun_options.h>
 #include <hpcrun/hpcrun_stats.h>
 #include <hpcrun/metrics.h>

--- a/src/tool/hpcrun/sample-sources/papi-c.c
+++ b/src/tool/hpcrun/sample-sources/papi-c.c
@@ -198,12 +198,6 @@ thread_count_scaling_for_component(int cidx)
 static int derived[MAX_EVENTS];
 static int some_overflow;
 
-
-/******************************************************************************
- * external thread-local variables
- *****************************************************************************/
-extern __thread bool hpcrun_thread_suppress_sample;
-
 /******************************************************************************
  * method functions
  *****************************************************************************/
@@ -842,7 +836,7 @@ papi_event_handler(int event_set, void *pc, long long ovec,
   int my_event_codes_count = MAX_EVENTS;
 
   // if sampling disabled explicitly for this thread, skip all processing
-  if (hpcrun_thread_suppress_sample || sample_filters_apply()) return;
+  if (hpcrun_suppress_sample() || sample_filters_apply()) return;
 
   if (!ovec) {
     TMSG(PAPI_SAMPLE, "papi overflow event: event set %d ovec = %ld",

--- a/src/tool/hpcrun/sample-sources/papi.c
+++ b/src/tool/hpcrun/sample-sources/papi.c
@@ -81,6 +81,7 @@
 #include "sample_source_obj.h"
 #include "common.h"
 
+#include <hpcrun/main.h>
 #include <hpcrun/hpcrun_options.h>
 #include <hpcrun/hpcrun_stats.h>
 #include <hpcrun/metrics.h>

--- a/src/tool/hpcrun/sample-sources/papi.c
+++ b/src/tool/hpcrun/sample-sources/papi.c
@@ -141,11 +141,6 @@ static int some_derived;
 static int some_overflow;
 
 /******************************************************************************
- * external thread-local variables
- *****************************************************************************/
-extern __thread bool hpcrun_thread_suppress_sample;
-
-/******************************************************************************
  * method functions
  *****************************************************************************/
 
@@ -677,7 +672,7 @@ papi_event_handler(int event_set, void *pc, long long ovec,
   int i, ret;
 
   // if sampling disabled explicitly for this thread, skip all processing
-  if (hpcrun_thread_suppress_sample) return;
+  if (hpcrun_suppress_sample()) return;
 
 
   // If the interrupt came from inside our code, then drop the sample

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -211,13 +211,6 @@ static struct event_threshold_s default_threshold = {DEFAULT_THRESHOLD, FREQUENC
 
 static kind_info_t *lnux_kind;
 
-
-/******************************************************************************
- * external thread-local variables
- *****************************************************************************/
-extern __thread bool hpcrun_thread_suppress_sample;
-
-
 //******************************************************************************
 // private operations 
 //******************************************************************************
@@ -1087,7 +1080,7 @@ perf_event_handler(
   // check #2:
   // if sampling disabled explicitly for this thread, skip all processing
   // ----------------------------------------------------------------------------
-  if (hpcrun_thread_suppress_sample) {
+  if (hpcrun_suppress_sample()) {
     HPCTOOLKIT_APPLICATION_ERRNO_RESTORE();
 
     return 0; // tell monitor that the signal has been handled

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -90,6 +90,7 @@
 #include "sample-sources/common.h"
 #include "sample-sources/ss-errno.h"
  
+#include <hpcrun/main.h>
 #include <hpcrun/cct_insert_backtrace.h>
 #include <hpcrun/files.h>
 #include <hpcrun/hpcrun_stats.h>

--- a/src/tool/hpcrun/sample-sources/upc.c
+++ b/src/tool/hpcrun/sample-sources/upc.c
@@ -117,11 +117,6 @@
 #include <lib/prof-lean/hpcrun-fmt.h>
 
 /******************************************************************************
- * external thread-local variables
- *****************************************************************************/
-extern __thread bool hpcrun_thread_suppress_sample;
-
-/******************************************************************************
  * local variables
  *****************************************************************************/
 
@@ -195,7 +190,7 @@ hpcrun_upc_handler(int sig, siginfo_t *info, void *context)
   
 
   // if sampling disabled explicitly for this thread, skip all processing
-  if (hpcrun_thread_suppress_sample) {
+  if (hpcrun_suppress_sample()) {
     HPCTOOLKIT_APPLICATION_ERRNO_RESTORE();
 
     return 0; // tell monitor that the signal has been handled

--- a/src/tool/hpcrun/sample-sources/upc.c
+++ b/src/tool/hpcrun/sample-sources/upc.c
@@ -103,6 +103,7 @@
 #include "common.h"
 #include "ss-errno.h"
  
+#include <hpcrun/main.h>
 #include <hpcrun/hpcrun_options.h>
 #include <hpcrun/hpcrun_stats.h>
 #include <hpcrun/metrics.h>


### PR DESCRIPTION
Use a thread local counter to suppress samples during dlopen and dlclose