### PR TITLE
1. Add RELA relocation for .debug_line section; 2. Do not relocate fa…

### DIFF
--- a/src/lib/binutils/InputFile.cpp
+++ b/src/lib/binutils/InputFile.cpp
@@ -167,7 +167,7 @@ InputFile::openFile
   if (result) {
     filevector = new ElfFileVector;
     filevector->push_back(elfFile);
-    findCubins(elfFile, filevector);
+    //findCubins(elfFile, filevector);
   } else {
     DIAG_EMsg("not an ELF binary: " << filename);
     delete elfFile;

--- a/src/lib/binutils/RelocateCubin.cpp
+++ b/src/lib/binutils/RelocateCubin.cpp
@@ -228,7 +228,7 @@ applyRELArelocation
 
 
 static void
-applyLineMapRelocations
+applyRELrelocations
 (
  Elf_SymbolVector *symbol_values,
  char *line_map,
@@ -248,7 +248,7 @@ applyLineMapRelocations
 
 
 static void
-applyDebugInfoRelocations
+applyRELArelocations
 (
  Elf_SymbolVector *symbol_values,
  char *debug_info,
@@ -341,10 +341,10 @@ relocateLineMap
               if (n_relocations > 0) {
                 Elf_Data *relocations_data = elf_getdata(scn, NULL);
                 if (shdr.sh_type == SHT_RELA) {
-                  applyDebugInfoRelocations(symbol_values, line_map,
+                  applyRELArelocations(symbol_values, line_map,
                     n_relocations, relocations_data);
                 } else {
-                  applyLineMapRelocations(symbol_values, line_map,
+                  applyRELrelocations(symbol_values, line_map,
                     n_relocations, relocations_data);
                 }
               }
@@ -427,7 +427,7 @@ relocateDebugInfo
               int n_relocations = shdr.sh_size / shdr.sh_entsize;
               if (n_relocations > 0) {
                 Elf_Data *relocations_data = elf_getdata(scn, NULL);
-                applyDebugInfoRelocations(symbol_values, debug_info,
+                applyRELArelocations(symbol_values, debug_info,
                   n_relocations, relocations_data);
               }
             }


### PR DESCRIPTION
@jmellorcrummey , @mxz297 

Two problems are fixed in this commit.

1. Previously, our code intended to handle both cubins and fatbins. However, it appears that we handled cubins incorrectly. We first use `elfFile->open` to relocate the specified cubin, then in `findCubins` we get another cubin and relocate it again. 
  You may think we just relocate the cubin twice, but somehow, mysteriously, we relocate a cubin four times and cause a segment fault in the last time. I was not able to figure out why this happened. The bottom line is that we can stub out the code for fatbin as we can only handle separated cubins dumped by hpcrun.

https://github.com/HPCToolkit/hpctoolkit/blob/53ed9dd383dcd5dc908b033e9b717eda58fcc8b0/src/lib/binutils/InputFile.cpp#L165

https://github.com/HPCToolkit/hpctoolkit/blob/53ed9dd383dcd5dc908b033e9b717eda58fcc8b0/src/lib/binutils/Fatbin.cpp#L192

https://github.com/HPCToolkit/hpctoolkit/blob/53ed9dd383dcd5dc908b033e9b717eda58fcc8b0/src/lib/binutils/Fatbin.cpp#L153

2. Optimized cubins usually only contain a `.debug_line` section with `REL` relocation info. However, we have got a cubin---not sure how it was compiled, that has a `.debug_line` section with `RELA` relocation. Therefore, I added another path to deal with it.