### PR TITLE
Add the intel-tbb checksums to the current spack issues page.

### DIFF
--- a/doc/texinfo/spack-issues.texi
+++ b/doc/texinfo/spack-issues.texi
@@ -41,11 +41,36 @@ on the hpctoolkit web site.
 @end example
 
 @noindent
-Last revised: Feb 28, 2020.
+Last revised: March 27, 2020.
 
 @c ------------------------------------------------------------
 
 @section Current Issues
+
+@subsection (2020-03-27) Intel-TBB checksums don't match
+
+Intel recently moved the TBB project on GitHub to a new repository,
+@code{oneAPI-SRC/oneTBB}.  When downloading the intel-tbb tar file,
+github makes the tar file on the fly, and this includes the new
+top-level directory name (oneTBB).  The contents of the tar file are the
+same, but the new directory name is enough to invalidate the spack
+checksum.
+
+@noindent
+@b{Fixed:} The new checksums were added to spack in commit
+@uref{https://github.com/spack/spack/pull/15675, 16f104aafe2b}
+on 2020-03-27.  So, if you update your spack repository after this
+commit, then the checksums will match.
+
+@noindent
+@b{Workaround:} If you have an older spack repository, then you will
+need to disable verifying checksums.
+
+@example
+spack install --no-checksum intel-tbb
+@end example
+
+@c ------------------------------------------------------------
 
 @subsection (2019-09-25) New micro-architecture targets
 

--- a/doc/www/spack-issues.html
+++ b/doc/www/spack-issues.html
@@ -47,8 +47,9 @@
 <li><a name="toc-Introduction" href="#Introduction">1 Introduction</a></li>
 <li><a name="toc-Current-Issues" href="#Current-Issues">2 Current Issues</a>
 <ul class="no-bullet">
-  <li><a name="toc-_00282019_002d09_002d25_0029-New-micro_002darchitecture-targets" href="#g_t_00282019_002d09_002d25_0029-New-micro_002darchitecture-targets">2.1 (2019-09-25) New micro-architecture targets</a></li>
-  <li><a name="toc-_00282019_002d08_002d28_0029-Cray-front_002dend-compilers" href="#g_t_00282019_002d08_002d28_0029-Cray-front_002dend-compilers">2.2 (2019-08-28) Cray front-end compilers</a></li>
+  <li><a name="toc-_00282020_002d03_002d27_0029-Intel_002dTBB-checksums-don_0027t-match" href="#g_t_00282020_002d03_002d27_0029-Intel_002dTBB-checksums-don_0027t-match">2.1 (2020-03-27) Intel-TBB checksums don&rsquo;t match</a></li>
+  <li><a name="toc-_00282019_002d09_002d25_0029-New-micro_002darchitecture-targets" href="#g_t_00282019_002d09_002d25_0029-New-micro_002darchitecture-targets">2.2 (2019-09-25) New micro-architecture targets</a></li>
+  <li><a name="toc-_00282019_002d08_002d28_0029-Cray-front_002dend-compilers" href="#g_t_00282019_002d08_002d28_0029-Cray-front_002dend-compilers">2.3 (2019-08-28) Cray front-end compilers</a></li>
 </ul></li>
 <li><a name="toc-Recently-Resolved-Issues" href="#Recently-Resolved-Issues">3 Recently Resolved Issues</a>
 <ul class="no-bullet">
@@ -95,14 +96,37 @@ on the hpctoolkit web site.
 <pre class="example"><a href="http://hpctoolkit.org/spack-issues.html">http://hpctoolkit.org/spack-issues.html</a>
 </pre></div>
 
-<p>Last revised: Feb 28, 2020.
+<p>Last revised: March 27, 2020.
 </p>
 
 <a name="Current-Issues"></a>
 <h3 class="section">2 Current Issues</h3>
 
+<a name="g_t_00282020_002d03_002d27_0029-Intel_002dTBB-checksums-don_0027t-match"></a>
+<h4 class="subsection">2.1 (2020-03-27) Intel-TBB checksums don&rsquo;t match</h4>
+
+<p>Intel recently moved the TBB project on GitHub to a new repository,
+<code>oneAPI-SRC/oneTBB</code>.  When downloading the intel-tbb tar file,
+github makes the tar file on the fly, and this includes the new
+top-level directory name (oneTBB).  The contents of the tar file are the
+same, but the new directory name is enough to invalidate the spack
+checksum.
+</p>
+<p><b>Fixed:</b> The new checksums were added to spack in commit
+<a href="https://github.com/spack/spack/pull/15675">16f104aafe2b</a>
+on 2020-03-27.  So, if you update your spack repository after this
+commit, then the checksums will match.
+</p>
+<p><b>Workaround:</b> If you have an older spack repository, then you will
+need to disable verifying checksums.
+</p>
+<div class="example">
+<pre class="example">spack install --no-checksum intel-tbb
+</pre></div>
+
+
 <a name="g_t_00282019_002d09_002d25_0029-New-micro_002darchitecture-targets"></a>
-<h4 class="subsection">2.1 (2019-09-25) New micro-architecture targets</h4>
+<h4 class="subsection">2.2 (2019-09-25) New micro-architecture targets</h4>
 
 <p>Spack recently changed how it treats a system&rsquo;s architecture and target
 to allow a hierarchy of fine-grained micro-architectures.  The &rsquo;target&rsquo;
@@ -138,7 +162,7 @@ specify this in <code>packages.yaml</code>.  For example:
 
 
 <a name="g_t_00282019_002d08_002d28_0029-Cray-front_002dend-compilers"></a>
-<h4 class="subsection">2.2 (2019-08-28) Cray front-end compilers</h4>
+<h4 class="subsection">2.3 (2019-08-28) Cray front-end compilers</h4>
 
 <p><code>Spack compiler find</code> is currently broken for detecting the
 front-end compilers on Cray that HPCToolkit uses.  Normally, you would

--- a/spack/spack-issues.txt
+++ b/spack/spack-issues.txt
@@ -3,8 +3,9 @@ Current Spack Issues for HPCToolkit
 
 1 Introduction
 2 Current Issues
-2.1 (2019-09-25) New micro-architecture targets
-2.2 (2019-08-28) Cray front-end compilers
+2.1 (2020-03-27) Intel-TBB checksums don't match
+2.2 (2019-09-25) New micro-architecture targets
+2.3 (2019-08-28) Cray front-end compilers
 3 Recently Resolved Issues
 3.1 (2019-11-19) External perl breaks libunwind
 3.2 (2019-10-08) Python 3.x breaks PAPI
@@ -38,12 +39,31 @@ hpctoolkit web site.
 
      <http://hpctoolkit.org/spack-issues.html>
 
-Last revised: Feb 28, 2020.
+Last revised: March 27, 2020.
 
 2 Current Issues
 ================
 
-2.1 (2019-09-25) New micro-architecture targets
+2.1 (2020-03-27) Intel-TBB checksums don't match
+------------------------------------------------
+
+Intel recently moved the TBB project on GitHub to a new repository,
+'oneAPI-SRC/oneTBB'.  When downloading the intel-tbb tar file, github
+makes the tar file on the fly, and this includes the new top-level
+directory name (oneTBB). The contents of the tar file are the same, but
+the new directory name is enough to invalidate the spack checksum.
+
+Fixed: The new checksums were added to spack in commit 16f104aafe2b
+(https://github.com/spack/spack/pull/15675) on 2020-03-27.  So, if you
+update your spack repository after this commit, then the checksums will
+match.
+
+Workaround: If you have an older spack repository, then you will need to
+disable verifying checksums.
+
+     spack install --no-checksum intel-tbb
+
+2.2 (2019-09-25) New micro-architecture targets
 -----------------------------------------------
 
 Spack recently changed how it treats a system's architecture and target
@@ -72,7 +92,7 @@ specify this in 'packages.yaml'.  For example:
        all:
          target: ['x86_64']
 
-2.2 (2019-08-28) Cray front-end compilers
+2.3 (2019-08-28) Cray front-end compilers
 -----------------------------------------
 
 'Spack compiler find' is currently broken for detecting the front-end


### PR DESCRIPTION
Intel moved their repo for TBB, thus invalidating all of the
spack sha256 checksums.