### PR TITLE
Remove --metric-db from hpcprof

### DIFF
--- a/doc/man/hpcprof.tex
+++ b/doc/man/hpcprof.tex
@@ -169,10 +169,6 @@ If not given, the default is \Prog{all}..
 Write the computed experiment database to \Arg{db-path}.
 The default path is \File{./hpctoolkit-$<$application$>$-database}.
 
-\item[\OptArg{--metric-db}{yes | no}]
-If \Prog{yes}, generate a thread-level metric value database for \Prog{hpcviewer} scatter plots.
-The default is \Prog{yes}.
-
 \item[\Opt{--remove-redundancy}]
 Eliminate procedure name redundancy in output file \File{experiment.xml}.
 

--- a/src/lib/analysis/ArgsHPCProf.cpp
+++ b/src/lib/analysis/ArgsHPCProf.cpp
@@ -152,10 +152,14 @@ Options: Metrics:\n\
 Options: Output:\n\
   -o <db-path>, --db <db-path>, --output <db-path>\n\
                        Specify Experiment database name <db-path>.\n\
-                       {./" Analysis_DB_DIR "}\n\
+                       {./" Analysis_DB_DIR "}";
+
+static const char* usage_details_2 = "\n\
   --metric-db <yes|no>\n\
                        Control whether to generate a thread-level metric\n\
-                       value database for hpcviewer scatter plots. {no}\n\
+                       value database for hpcviewer scatter plots. {no}";
+
+static const char* usage_details_3 = "\n\
   --remove-redundancy \n\
                        Eliminate procedure name redundancy in experiment.xml\n\
   --struct-id          Add 'str=nnn' field to profile data with the hpcstruct\n\
@@ -256,10 +260,32 @@ ArgsHPCProf::printVersion(std::ostream& os) const
 
 
 void 
-ArgsHPCProf::printUsage(std::ostream& os) const
+ArgsHPCProf::printUsage(std::ostream& os, AppType type) const
+{
+  switch(type) {
+    case AppType::APP_HPCPROF: 
+      printUsageProf(os);
+      break;
+
+    case AppType::APP_HPCPROF_MPI:
+      printUsageProfMPI(os);
+      break;
+  }
+} 
+
+void 
+ArgsHPCProf::printUsageProf(std::ostream& os) const
 {
   os << "Usage: " << getCmd() << " " << usage_summary << endl
-     << usage_details << endl;
+     << usage_details << usage_details_3 << endl;
+} 
+
+
+void 
+ArgsHPCProf::printUsageProfMPI(std::ostream& os) const
+{
+  os << "Usage: " << getCmd() << " " << usage_summary << endl
+     << usage_details << usage_details_2 << usage_details_3 << endl;
 } 
 
 
@@ -310,7 +336,7 @@ static inline void find_files(std::vector<std::string> &files,
 
 
 void
-ArgsHPCProf::parse(int argc, const char* const argv[])
+ArgsHPCProf::parse(int argc, const char* const argv[], AppType type)
 {
   try {
     // -------------------------------------------------------
@@ -333,7 +359,7 @@ ArgsHPCProf::parse(int argc, const char* const argv[])
       trace = dbg;
     }
     if (parser.isOpt("help")) { 
-      printUsage(std::cerr); 
+      printUsage(std::cerr, type); 
       exit(0);
     }
     if (parser.isOpt("remove-redundancy")) { 

--- a/src/lib/analysis/ArgsHPCProf.hpp
+++ b/src/lib/analysis/ArgsHPCProf.hpp
@@ -80,6 +80,8 @@
 
 namespace Analysis {
 
+enum class AppType {APP_HPCPROF, APP_HPCPROF_MPI};
+
 class ArgsHPCProf
   : public Analysis::Args
 {
@@ -89,15 +91,21 @@ public:
 
   // Parse the command line
   virtual void
-  parse(int argc, const char* const argv[]);
+  parse(int argc, const char* const argv[], AppType type);
 
   // Version and Usage information
   void
   printVersion(std::ostream& os) const;
 
   void
-  printUsage(std::ostream& os) const;
-  
+  printUsage(std::ostream& os, AppType type) const;
+
+  void
+  printUsageProf(std::ostream& os) const;
+
+  void
+  printUsageProfMPI(std::ostream& os) const;
+
   // Error
   void
   printError(std::ostream& os, const char* msg) const;

--- a/src/tool/hpcprof-mpi/main.cpp
+++ b/src/tool/hpcprof-mpi/main.cpp
@@ -238,7 +238,7 @@ static int
 realmain(int argc, char* const* argv) 
 {
   Args args;
-  args.parse(argc, argv); // may call exit()
+  args.parse(argc, argv, Analysis::AppType::APP_HPCPROF_MPI); // may call exit()
 
   RealPathMgr::singleton().searchPaths(args.searchPathStr());
   hpcprof_set_abort_timeout();

--- a/src/tool/hpcprof/Args.cpp
+++ b/src/tool/hpcprof/Args.cpp
@@ -101,7 +101,7 @@ Args::~Args()
 void
 Args::parse(int argc, const char* const argv[])
 {
-  ArgsHPCProf::parse(argc, argv);
+  ArgsHPCProf::parse(argc, argv, Analysis::AppType::APP_HPCPROF);
 
   if (parser.isOpt("metric")) {
     hpcprof_isMetricArg = true;


### PR DESCRIPTION
hpcprof at the moment doesn't support --metric-db, we should remove this option from the help (-h) and the man page.