### PR TITLE
Add GPU and OMP place folders as "fake" procedures

### DIFF
--- a/src/lib/prof/NameMappings.cpp
+++ b/src/lib/prof/NameMappings.cpp
@@ -120,7 +120,15 @@ static NameMapping renamingTable[] = {
 };
 
 static const char *fakeProcedures[] = {
-  PROGRAM_ROOT, THREAD_ROOT, GUARD_NAME, NO_ACTIVITY, "<partial call paths>"
+  PROGRAM_ROOT, THREAD_ROOT, GUARD_NAME, NO_ACTIVITY, "<partial call paths>",
+
+  OMP_IDLE, OMP_OVERHEAD, OMP_BARRIER_WAIT, OMP_TASK_WAIT, OMP_MUTEX_WAIT,
+
+  OMP_TGT_ALLOC, OMP_TGT_COPYIN, OMP_TGT_COPYOUT, OMP_TGT_DELETE,
+  OMP_TGT_ALLOC, OMP_TGT_KERNEL,
+
+  GPU_COPY, GPU_COPYIN, GPU_COPYOUT, GPU_ALLOC, GPU_ALLOC, GPU_DELETE,
+  GPU_SYNC, GPU_KERNEL, GPU_TRACE
 };
 
 static NameMappings_t renamingMap;


### PR DESCRIPTION
This is to help hpcviewer to distinguish between place folders and normal procedures. 
hpcviewer will add the name of the load module if a node doesn't have the source code. However,
if a node is a place holder, hpcviewer should not add the load module name (since the source code is not available).