### PR TITLE
Update CallPath-CudaCFG.cpp

### DIFF
--- a/src/lib/analysis/CallPath-CudaCFG.cpp
+++ b/src/lib/analysis/CallPath-CudaCFG.cpp
@@ -113,7 +113,7 @@ using std::string;
 #define OUTPUT_SCC_FRAME 1
 #define SIMULATE_SCC_WITH_LOOP 1
 
-#define WARP_SIZE 32
+#define WARP_SIZE 1
 
 namespace Analysis {
 


### PR DESCRIPTION
Previously, in `hpcrun`, we used `#warp instruction x 32` to represent thread instructions. In the currently version, I notice that we no long scale the instruction count, so I need to apportion each call site one warp instruction instead of 32 thread instructions.