### PR TITLE
ompt_task_data_t freelist implemented using sequential stack abstraction

### DIFF
--- a/src/tool/hpcrun/ompt/ompt-callstack.c
+++ b/src/tool/hpcrun/ompt/ompt-callstack.c
@@ -62,6 +62,7 @@
 #include "ompt-interface.h"
 #include "ompt-placeholders.h"
 #include "ompt-thread.h"
+#include "ompt-task.h"
 
 #if defined(HOST_CPU_PPC) 
 #include "ompt-gcc4-ppc64.h"

--- a/src/tool/hpcrun/ompt/ompt-region.c
+++ b/src/tool/hpcrun/ompt/ompt-region.c
@@ -76,6 +76,7 @@
 #include "ompt-region.h"
 #include "ompt-region-debug.h"
 #include "ompt-thread.h"
+#include "ompt-task.h"
 
 
 

--- a/src/tool/hpcrun/ompt/ompt-task.h
+++ b/src/tool/hpcrun/ompt/ompt-task.h
@@ -53,14 +53,18 @@
 //*****************************************************************************
 
 #include "omp-tools.h"
+#include <lib/prof-lean/stacks.h>
 
-typedef struct ompt_task_data_t ompt_task_data_t;
+// ompt_task_data_t stack declaration
+typedef struct ompt_task_data_t typed_stack_elem(task);
+typed_stack_declare_type(task);
+typed_stack_declare(task, sstack);
 
 //*****************************************************************************
 // interface operations
 //*****************************************************************************
 
-ompt_task_data_t*
+typed_stack_elem_ptr(task)
 ompt_task_acquire
 (
  cct_node_t *callpath,


### PR DESCRIPTION
ompt_task_data_t freelist has been implemented by using sequential stack abstraction.

I was not sure about the proper way of invalidating the next pointer of a ompt_task_data_t structure, so I described two possible approaches in a comment that starts with: ***FIXME vi3 to jmc*** inside ompt-task.c.