### PR TITLE
Merge <gpu-kernel> nodes

### DIFF
--- a/src/lib/analysis/CallPath-CudaCFG.cpp
+++ b/src/lib/analysis/CallPath-CudaCFG.cpp
@@ -135,6 +135,9 @@ typedef std::map<int, double> AdjustFactor;
 
 static std::vector<size_t> gpu_inst_index;
 
+static void
+normalizeTraceNodes(std::set<Prof::CCT::ANode *> &gpu_roots);
+
 // Static functions
 static void
 constructFrame(Prof::Struct::ANode *strct, Prof::CCT::ANode *frame, 
@@ -312,6 +315,9 @@ transformCudaCFGMain(Prof::CallPath::Profile& prof) {
   std::set<Prof::CCT::ANode *> gpu_roots;
   findGPURoots(prof.cct()->root(), prof.structure()->root(), gpu_roots);
 
+  // If the first prof node has no inst metrics, assign it one
+  normalizeTraceNodes(gpu_roots);
+
   // Find <target_vma, <Struct::Stmt> > mappings
   StructCallMap struct_call_map; 
   constructStructCallMap(prof.structure()->root(), struct_call_map);
@@ -384,6 +390,31 @@ transformCudaCFGMain(Prof::CallPath::Profile& prof) {
     constructCallingContext(cct_graph, incoming_samples);
 
     delete cct_graph;
+  }
+}
+
+
+static void
+normalizeTraceNodes(std::set<Prof::CCT::ANode *> &gpu_roots) {
+  for (auto *gpu_root : gpu_roots) {
+    Prof::CCT::ANodeIterator prof_it(gpu_root, NULL/*filter*/, false/*leavesOnly*/,
+      IteratorStack::PreOrder);
+    for (Prof::CCT::ANode *n = NULL; (n = prof_it.current()); ++prof_it) {
+      if (n->isLeaf()) {
+        bool find = false;
+        for (size_t i = 0; i < gpu_inst_index.size(); ++i) {
+          if (n->demandMetric(gpu_inst_index[i]) != 0.0) {
+            find = true;
+            break;
+          }
+        }
+        if (!find) {
+          // Find a pseudo instruction node for tracing
+          n->demandMetric(gpu_inst_index[0]) = WARP_SIZE;
+          n->demandMetric(gpu_inst_index[0] + 1) = WARP_SIZE;
+        }
+      }
+    }
   }
 }
 

--- a/src/tool/hpcrun/cct/cct.c
+++ b/src/tool/hpcrun/cct/cct.c
@@ -435,6 +435,20 @@ hpcrun_cct_children(cct_node_t* x)
     return x? x->children : NULL;
 }
 
+cct_node_t*
+hpcrun_leftmost_child(cct_node_t* x)
+{
+  cct_node_t *leftmost = x->children;
+  if (leftmost != NULL) {
+    for (;;) {
+      cct_node_t *more_left = leftmost->left;
+      if (more_left == NULL) break;
+      leftmost = more_left;
+    }
+  }
+  return leftmost;
+}
+
 int32_t
 hpcrun_cct_persistent_id(cct_node_t* x)
 {
@@ -1016,8 +1030,6 @@ cct_disjoint_union_cached(cct_node_t* target, cct_node_t* src)
   target->children = src;
   src->parent = target;
 }
-
-
 
 
 // FIXME: only temporary function, until hpcrun_merge is repaired

--- a/src/tool/hpcrun/cct/cct.h
+++ b/src/tool/hpcrun/cct/cct.h
@@ -136,6 +136,7 @@ extern cct_node_t* hpcrun_cct_top_new(uint16_t lmid, uintptr_t lmip);
 
 extern cct_node_t* hpcrun_cct_parent(cct_node_t* node);
 extern cct_node_t* hpcrun_cct_children(cct_node_t* node);
+extern cct_node_t* hpcrun_leftmost_child(cct_node_t* node);
 extern int32_t hpcrun_cct_persistent_id(cct_node_t* node);
 extern cct_addr_t* hpcrun_cct_addr(cct_node_t* node);
 extern bool hpcrun_cct_is_leaf(cct_node_t* node);

--- a/src/tool/hpcrun/cct/cct_bundle.c
+++ b/src/tool/hpcrun/cct/cct_bundle.c
@@ -153,8 +153,12 @@ hpcrun_cct_bundle_get_no_activity_node
  cct_bundle_t* cct
 )
 {
-  placeholder_t *nap = hpcrun_placeholder_get(hpcrun_placeholder_type_no_activity);
-  cct_node_t *no_activity_cct = 
-    hpcrun_cct_insert_ip_norm(cct->top, nap->pc_norm); 
+  cct_node_t *no_activity_cct = NULL; 
+  if (cct) {
+    placeholder_t *nap = 
+      hpcrun_placeholder_get(hpcrun_placeholder_type_no_activity);
+    no_activity_cct = 
+      hpcrun_cct_insert_ip_norm(cct->top, nap->pc_norm); 
+  }
   return no_activity_cct;
 }

--- a/src/tool/hpcrun/gpu/gpu-activity-process.c
+++ b/src/tool/hpcrun/gpu/gpu-activity-process.c
@@ -230,21 +230,20 @@ gpu_sample_process
       PRINT("external_id %lu\n", external_id);
 
       bool more_samples = 
-	gpu_host_correlation_map_samples_increase
-	(external_id, sample->details.pc_sampling.samples);
+        gpu_host_correlation_map_samples_increase
+        (external_id, sample->details.pc_sampling.samples);
 
       if (!more_samples) {
-	gpu_correlation_id_map_delete(correlation_id);
+        gpu_correlation_id_map_delete(correlation_id);
       }
 
       cct_node_t *host_op_node =
-	gpu_host_correlation_map_entry_op_cct_get(host_op_entry, 
-						  gpu_placeholder_type_kernel);
+        gpu_host_correlation_map_entry_op_function_get(host_op_entry);
 
       cct_node_t *cct_child = hpcrun_cct_insert_ip_norm(host_op_node, ip);
       if (cct_child) {
-	PRINT("cct_child %p\n", cct_child);
-	attribute_activity(host_op_entry, sample, cct_child);
+        PRINT("cct_child %p\n", cct_child);
+        attribute_activity(host_op_entry, sample, cct_child);
       }
     } else {
       PRINT("host_map_entry %lu not found\n", external_id);
@@ -271,8 +270,7 @@ gpu_sampling_info_process
       gpu_host_correlation_map_lookup(external_id);
     if (host_op_entry != NULL) {
       cct_node_t *host_op_node =
-	gpu_host_correlation_map_entry_op_cct_get(host_op_entry, 
-						  gpu_placeholder_type_kernel);
+        gpu_host_correlation_map_entry_op_function_get(host_op_entry);
 
       attribute_activity(host_op_entry, sri, host_op_node);
     }
@@ -380,15 +378,22 @@ gpu_kernel_process
 
     if (host_op_entry != NULL) {
       cct_node_t *func_node = 
-	gpu_host_correlation_map_entry_op_function_get(host_op_entry);
+        gpu_host_correlation_map_entry_op_function_get(host_op_entry);
       // do not delete it because it shares external_id with activity samples
 
+      cct_node_t *cct_child = hpcrun_cct_children(func_node);
+      if (cct_child == NULL) {
+        // In case the kernel node does not have a child.
+        // e.g. failed to interpret the cubin function address
+        cct_child = func_node;
+      }
+
       gpu_trace_item_t entry_trace;
-      trace_item_set(&entry_trace, activity, host_op_entry, func_node);
+      trace_item_set(&entry_trace, activity, host_op_entry, cct_child);
 
       gpu_context_stream_trace
-	(activity->details.kernel.context_id, activity->details.kernel.stream_id,
-	 &entry_trace);
+        (activity->details.kernel.context_id, activity->details.kernel.stream_id,
+         &entry_trace);
 
       attribute_activity(host_op_entry, activity, func_node);
     }
@@ -486,16 +491,16 @@ gpu_cdpkernel_process
       gpu_host_correlation_map_lookup(external_id);
     if (host_op_entry != NULL) {
       cct_node_t *host_op_node =
-	gpu_host_correlation_map_entry_op_cct_get(host_op_entry, 
-						  gpu_placeholder_type_trace);
+        gpu_host_correlation_map_entry_op_cct_get(host_op_entry, 
+          gpu_placeholder_type_trace);
       cct_node_t *func_node = hpcrun_cct_children(host_op_node);
 
       gpu_trace_item_t entry_trace;
       trace_item_set(&entry_trace, activity, host_op_entry, func_node);
 
       gpu_context_stream_trace
-	(activity->details.cdpkernel.context_id, activity->details.cdpkernel.stream_id,
-	 &entry_trace);
+        (activity->details.cdpkernel.context_id, activity->details.cdpkernel.stream_id,
+         &entry_trace);
     }
     gpu_correlation_id_map_delete(correlation_id);
   }
@@ -547,7 +552,7 @@ gpu_instruction_process
     if (host_op_entry != NULL) {
       // Function node has the start pc of the function
       cct_node_t *func_node = 
-	gpu_host_correlation_map_entry_op_function_get(host_op_entry);
+        gpu_host_correlation_map_entry_op_function_get(host_op_entry);
 
       cct_node_t *func_ins = hpcrun_cct_insert_ip_norm(func_node, pc);
       attribute_activity(host_op_entry, activity, func_ins);

--- a/src/tool/hpcrun/gpu/gpu-host-correlation-map.c
+++ b/src/tool/hpcrun/gpu/gpu-host-correlation-map.c
@@ -317,13 +317,7 @@ gpu_host_correlation_map_entry_op_function_get
  gpu_host_correlation_map_entry_t *entry
 )
 {
-  // TODO: We should not use the child node of the trace; this only applies to
-  // cupti at this point.
-  cct_node_t *trace_node = entry->gpu_op_ccts.ccts[gpu_placeholder_type_trace];
-  if (trace_node != NULL) 
-    return trace_node;
-  else
-    return entry->gpu_op_ccts.ccts[gpu_placeholder_type_kernel];
+  return entry->gpu_op_ccts.ccts[gpu_placeholder_type_kernel];
 }
 
 

--- a/src/tool/hpcrun/gpu/gpu-host-correlation-map.c
+++ b/src/tool/hpcrun/gpu/gpu-host-correlation-map.c
@@ -321,7 +321,7 @@ gpu_host_correlation_map_entry_op_function_get
   // cupti at this point.
   cct_node_t *trace_node = entry->gpu_op_ccts.ccts[gpu_placeholder_type_trace];
   if (trace_node != NULL) 
-    return hpcrun_cct_children(trace_node);
+    return trace_node;
   else
     return entry->gpu_op_ccts.ccts[gpu_placeholder_type_kernel];
 }

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -579,8 +579,10 @@ cupti_error_callback_dummy // __attribute__((unused))
  const char *error_string
 )
 {
-  ETMSG(CUPTI, "%s: function %s failed with error %s", type, fn, error_string);
-  exit(-1);
+  
+  EEMSG("FATAL: hpcrun failure: failure type = %s, "
+	"function %s failed with error %s", type, fn, error_string);
+  exit(1);
 }
 
 

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -233,7 +233,7 @@ static spinlock_t files_lock = SPINLOCK_UNLOCKED;
 
 static __thread bool cupti_stop_flag = false;
 static __thread bool cupti_runtime_api_flag = false;
-static __thread cct_node_t *cupti_trace_node = NULL;
+static __thread cct_node_t *cupti_kernel_ph = NULL;
 
 static bool cupti_correlation_enabled = false;
 static bool cupti_pc_sampling_enabled = false;
@@ -720,6 +720,32 @@ cupti_func_ip_resolve
 }
 
 
+void
+ensure_kernel_ip_present
+(
+ cct_node_t *kernel_ph, 
+ ip_normalized_t kernel_ip
+)
+{
+  // if the phaceholder was previously inserted, it will have a child
+  // we only want to insert a child if there isn't one already. if the
+  // node contains a child already, then the gpu monitoring thread 
+  // may be adding children to the splay tree of children. in that case 
+  // trying to add a child here (which will turn into a lookup of the
+  // previously added child, would race with any insertions by the 
+  // GPU monitoring thread.
+  //
+  // INVARIANT: avoid a race modifying the splay tree of children by 
+  // not attempting to insert a child in a worker thread when a child 
+  // is already present
+  if (hpcrun_cct_children(kernel_ph) == NULL) {
+    cct_node_t *kernel = 
+      hpcrun_cct_insert_ip_norm(kernel_ph, kernel_ip);
+    hpcrun_cct_retain(kernel);
+  }
+}
+
+
 static void
 cupti_subscriber_callback
 (
@@ -761,7 +787,7 @@ cupti_subscriber_callback
 
     bool is_valid_op = false;
     gpu_op_placeholder_flags_t gpu_op_placeholder_flags = 0;
-    ip_normalized_t func_ip;
+    ip_normalized_t kernel_ip;
 
     switch (cb_id) {
       //FIXME(Keren): do not support memory allocate and free for current CUPTI version
@@ -889,8 +915,6 @@ cupti_subscriber_callback
         {
           gpu_op_placeholder_flags_set(&gpu_op_placeholder_flags,
             gpu_placeholder_type_kernel);
-          gpu_op_placeholder_flags_set(&gpu_op_placeholder_flags,
-            gpu_placeholder_type_trace);
           is_valid_op = true;
 
           if (cd->callbackSite == CUPTI_API_ENTER) {
@@ -900,7 +924,7 @@ cupti_subscriber_callback
             //if (cb_id != CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice)
             // CUfunction is the first param
             CUfunction function_ptr = *(CUfunction *)((CUfunction)cd->functionParams);
-            func_ip = cupti_func_ip_resolve(function_ptr);
+            kernel_ip = cupti_func_ip_resolve(function_ptr);
           }
           break;
         }
@@ -927,9 +951,10 @@ cupti_subscriber_callback
         gpu_op_ccts_insert(api_node, &gpu_op_ccts, gpu_op_placeholder_flags);
 
         if (is_kernel_op) {
-          cct_node_t *trace_node = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_trace);
-          cct_node_t *cct_func = hpcrun_cct_insert_ip_norm(trace_node, func_ip);
-          hpcrun_cct_retain(cct_func);
+          cct_node_t *kernel_ph = 
+	    gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_kernel);
+
+	  ensure_kernel_ip_present(kernel_ph, kernel_ip);
         }
 
         hpcrun_safe_exit();
@@ -947,16 +972,14 @@ cupti_subscriber_callback
       }
     } else if (is_kernel_op && cupti_runtime_api_flag && cd->callbackSite ==
       CUPTI_API_ENTER) {
-      if (cupti_trace_node != NULL) {
-        cct_node_t *cct_func = hpcrun_cct_insert_ip_norm(cupti_trace_node, func_ip);
-        hpcrun_cct_retain(cct_func);
+      if (cupti_kernel_ph != NULL) {
+	ensure_kernel_ip_present(cupti_kernel_ph, kernel_ip);
       }
     } else if (is_kernel_op && ompt_runtime_api_flag && cd->callbackSite ==
       CUPTI_API_ENTER) {
       cct_node_t *ompt_trace_node = ompt_trace_node_get();
       if (ompt_trace_node != NULL) {
-        cct_node_t *cct_func = hpcrun_cct_insert_ip_norm(ompt_trace_node, func_ip);
-        hpcrun_cct_retain(cct_func);
+	ensure_kernel_ip_present(ompt_trace_node, kernel_ip);
       }
     }
   } else if (domain == CUPTI_CB_DOMAIN_RUNTIME_API) {
@@ -1079,7 +1102,7 @@ cupti_subscriber_callback
 
         hpcrun_safe_exit();
 
-        cupti_trace_node = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_trace);
+        cupti_kernel_ph = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_kernel);
 
         // Generate notification entry
         uint64_t cpu_submit_time = hpcrun_nanotime();
@@ -1095,7 +1118,7 @@ cupti_subscriber_callback
         correlation_id = cupti_correlation_id_pop();
         TMSG(CUPTI_TRACE, "Runtime pop externalId %lu (cb_id = %u)", correlation_id, cb_id);
 
-        cupti_trace_node = NULL;
+        cupti_kernel_ph = NULL;
       }
     } else {
       TMSG(CUPTI_TRACE, "Go through runtime with kernel_op %d, valid_op %d, "

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -794,10 +794,14 @@ hpcrun_thread_init(int id, local_thread_data_t* local_thread_data) // cct_ctxt_t
 
   td->inside_hpcrun = 1;  // safe enter, disable signals
 
-  if (! thr_ctxt) EMSG("Thread id %d passes null context", id);
   
-  if (ENABLED(THREAD_CTXT))
-    hpcrun_walk_path(thr_ctxt->context, logit, (cct_op_arg_t) (intptr_t) id);
+  if (ENABLED(THREAD_CTXT)) {
+    if (thr_ctxt) {
+      hpcrun_walk_path(thr_ctxt->context, logit, (cct_op_arg_t) (intptr_t) id);
+    } else {
+      EMSG("Thread id %d passes null context", id);
+    }
+  }
 
   epoch_t* epoch = TD_GET(core_profile_trace_data.epoch);
 

--- a/src/tool/hpcrun/threadmgr.c
+++ b/src/tool/hpcrun/threadmgr.c
@@ -345,8 +345,10 @@ hpcrun_threadMgr_data_put( epoch_t *epoch, thread_data_t *data, int no_separator
 
   if (!no_separator) {
     cct_node_t *node  = hpcrun_cct_bundle_get_no_activity_node(&epoch->csdata);
-    hpcrun_trace_append(&(data->core_profile_trace_data), node, 0, 
-			HPCTRACE_FMT_DLCA_NULL);
+    if (node) {
+      hpcrun_trace_append(&(data->core_profile_trace_data), node, 0, 
+			  HPCTRACE_FMT_DLCA_NULL);
+    }
   }
 
   // step 2: enqueue thread data into the free list


### PR DESCRIPTION
1. If `-e nvidia` is used, we attribute kernel metrics to `<gpu kernel>` but not `<gpu trace>`. This is the simplest case.

2. If `-e nvidia -t` is used, we attribute kernel metrics to `<gpu kernel>`, and we pass a child of `<gpu kernel>` to tracing threads, which can help show specific function names in *hpctraceviewer*.

3. If `-e nvidia,pc` is used, we assign the first instruction of gpu kernels a pseudo sample, if needed, to avoid dividing zero in apportion. 

@jmellorcrummey , @laksono , I suggest test both quicksilver and laghos to verify the correctness of this commit.