### PR TITLE
Fix integer overflow while collecting pc samples for a long running kernel

### DIFF
--- a/src/tool/hpcrun/gpu/gpu-metrics.c
+++ b/src/tool/hpcrun/gpu/gpu-metrics.c
@@ -208,7 +208,7 @@ gpu_metrics_attribute_metric_int
 (
  metric_data_list_t *metrics, 
  int metric_index,
- int value
+ uint64_t value
 )
 {
   hpcrun_metric_std_inc(metric_index, metrics, (cct_metric_data_t){.i = value});
@@ -248,13 +248,13 @@ gpu_metrics_attribute_pc_sampling
  gpu_activity_t *activity
 )
 {
-  uint32_t sample_period = 
+  uint64_t sample_period = 
     1 << gpu_monitoring_instruction_sample_frequency_get();
 
   gpu_pc_sampling_t *sinfo = &(activity->details.pc_sampling);
   cct_node_t *cct_node = activity->cct_node;
 
-  int inst_count = sinfo->samples * sample_period;
+  uint64_t inst_count = sinfo->samples * sample_period;
 
   metric_data_list_t *inst_metric = 
     hpcrun_reify_metric_set(cct_node, METRIC_ID(GPU_INST_ALL));
@@ -272,7 +272,7 @@ gpu_metrics_attribute_pc_sampling
     metric_data_list_t *stall_metrics = 
       hpcrun_reify_metric_set(cct_node, stall_kind_metric_index);
 
-    int stall_count = sinfo->latencySamples * sample_period;
+    uint64_t stall_count = sinfo->latencySamples * sample_period;
 
     if (sinfo->stallReason != GPU_INST_STALL_NONE) {
       // stall summary metric


### PR DESCRIPTION
1. I believe `cct_metric_data_t.i` should be a `uint64_t` value.
2. The integer overflow error was found while profiling a single spec accel kernel that runs for 1 minute, collecting samples greater than *2^22*. When we do scaling at Line 275, *2^22 * 2^10 = 2^32*, causing an overflow.