### PR TITLE
correct labels of GPU synchronization metrics

### DIFF
--- a/src/tool/hpcrun/gpu/gpu-metrics.h
+++ b/src/tool/hpcrun/gpu/gpu-metrics.h
@@ -202,15 +202,15 @@ typedef enum {
 
 
 #define FORALL_GSYNC(macro)					\
-  macro("GSYNC:UNK (us)",         GPU_SYNC_UNKNOWN,		\
+  macro("GSYNC:UNK (sec)",         GPU_SYNC_UNKNOWN,		\
 	"GPU synchronizations: unknown kind")			\
-  macro("GSYNC:EVT (us)",         GPU_SYNC_EVENT,		\
+  macro("GSYNC:EVT (sec)",         GPU_SYNC_EVENT,		\
 	"GPU synchronizations: event")				\
-  macro("GSYNC:STRE (us)",        GPU_SYNC_STREAM_EVENT_WAIT,	\
+  macro("GSYNC:STRE (sec)",        GPU_SYNC_STREAM_EVENT_WAIT,	\
 	"GPU synchronizations: stream event wait")		\
-  macro("GSYNC:STR (us)",         GPU_SYNC_STREAM,		\
+  macro("GSYNC:STR (sec)",         GPU_SYNC_STREAM,		\
 	"GPU synchronizations: stream")				\
-  macro("GSYNC:CTX (us)",         GPU_SYNC_CONTEXT,		\
+  macro("GSYNC:CTX (sec)",         GPU_SYNC_CONTEXT,		\
 	"GPU synchronizations: context")     \
   macro("GSYNC:COUNT",           GPU_SYNC_COUNT, \
         "GPU synchronizations: count")


### PR DESCRIPTION
times had previously been updated to be computed in seconds, but the labels still said microseconds (us).