### PR TITLE
Use and prefer versioned Python interpreters for stringify.py.

### DIFF
--- a/src/tool/hpcstruct/Makefile.am
+++ b/src/tool/hpcstruct/Makefile.am
@@ -176,8 +176,10 @@ MOSTLYCLEANFILES = $(MYCLEAN)
 # Other rules
 #############################################################################
 
+PYTHON ?= $(shell which python3 || which python2 || which python)
+
 %.h : $(srcdir)/%.txt
-	$(srcdir)/stringify.py < $<  > $@
+	$(PYTHON) $(srcdir)/stringify.py $< $@
 
 
 #############################################################################

--- a/src/tool/hpcstruct/Makefile.in
+++ b/src/tool/hpcstruct/Makefile.in
@@ -1100,8 +1100,10 @@ endef
 # Other rules
 #############################################################################
 
+PYTHON ?= $(shell which python3 || which python2 || which python)
+
 %.h : $(srcdir)/%.txt
-	$(srcdir)/stringify.py < $<  > $@
+	$(PYTHON) $(srcdir)/stringify.py $< $@
 
 %.cpp.pp : %.cpp
 	$(CXXCPP) $(MYCPPFLAGS_0_CXX) $< > $@

--- a/src/tool/hpcstruct/stringify.py
+++ b/src/tool/hpcstruct/stringify.py
@@ -4,5 +4,7 @@ import sys
 import re
 
 end = re.compile('\n')
-for line in sys.stdin:
-    print('"' + end.sub(r'\\n"', line))
+with open(sys.argv[1], 'r') as infile:
+    with open(sys.argv[2], 'w') as outfile:
+        for line in infile:
+            print('"' + end.sub(r'\\n"', line), file=outfile)


### PR DESCRIPTION
Needed to build on recent Debian, which has removed `python` in favor of the versioned dichotomy `python2` and `python3`.

Also fixes an issue where the build would fail strangely in compilation if Python wasn't available on the first `make` invocation.