### PR TITLE
AMD GPU support with rocm 3.7

### DIFF
--- a/configure
+++ b/configure
@@ -23657,7 +23657,7 @@ if test "$OPT_HAVE_ROCM" = "yes" ; then
 
 $as_echo "#define USE_ROCM 1" >>confdefs.h
 
-  OPT_ROCM_IFLAGS="-I${OPT_ROCM}/hip -I${OPT_ROCM}/hip/include -I${OPT_ROCM}/roctracer/include -I${OPT_ROCM}/hcc/include -I${OPT_ROCM}/hsa/include "
+  OPT_ROCM_IFLAGS="-I${OPT_ROCM}/include -I${OPT_ROCM}/hip -I${OPT_ROCM}/hip/include -I${OPT_ROCM}/roctracer/include -I${OPT_ROCM}/hcc/include -I${OPT_ROCM}/hsa/include "
 fi
 
  if test "$OPT_HAVE_ROCM" = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -4772,7 +4772,7 @@ AC_ARG_WITH([rocm],
 
 if test "$OPT_HAVE_ROCM" = "yes" ; then
   AC_DEFINE(USE_ROCM, 1, [use ROCM])
-  OPT_ROCM_IFLAGS="-I${OPT_ROCM}/hip -I${OPT_ROCM}/hip/include -I${OPT_ROCM}/roctracer/include -I${OPT_ROCM}/hcc/include -I${OPT_ROCM}/hsa/include "
+  OPT_ROCM_IFLAGS="-I${OPT_ROCM}/include -I${OPT_ROCM}/hip -I${OPT_ROCM}/hip/include -I${OPT_ROCM}/roctracer/include -I${OPT_ROCM}/hcc/include -I${OPT_ROCM}/hsa/include "
 fi
 
 AM_CONDITIONAL([OPT_ENABLE_ROCM], [test "$OPT_HAVE_ROCM" = yes])

--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -521,7 +521,9 @@ if OPT_ENABLE_ROCM
 MY_ROCM_FILES=\
 	sample-sources/amd.c \
 	gpu/amd/roctracer-activity-translate.c \
-	gpu/amd/roctracer-api.c 	
+	gpu/amd/roctracer-api.c \
+	gpu/amd/rocm-debug-api.c \
+	gpu/amd/rocm-binary-processing.c
 endif
 
 if OPT_ENABLE_LEVEL0

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -538,11 +538,16 @@ am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	gpu/nvidia/cupti-analysis.c gpu/nvidia/cupti-api.c \
 	gpu/nvidia/cupti-gpu-api.c sample-sources/upc.c \
 	sample-sources/amd.c gpu/amd/roctracer-activity-translate.c \
+<<<<<<< HEAD
 	gpu/amd/roctracer-api.c sample-sources/level0.c \
 	gpu/level0/level0-api.c gpu/level0/level0-command-list-map.c \
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c gpu/level0/level0-event-map.c \
 	gpu/level0/level0-handle-map.c unwind/common/backtrace.c \
+=======
+	gpu/amd/roctracer-api.c gpu/amd/rocm-debug-api.c \
+	gpu/amd/rocm-binary-processing.c unwind/common/backtrace.c \
+>>>>>>> Update Makefile.am for AMD
 	unwind/common/unw-throw.c unwind/common/binarytree_uwi.c \
 	unwind/common/interval_t.c unwind/common/libunw_intervals.c \
 	unwind/common/stack_troll.c unwind/common/uw_hash.c \
@@ -736,6 +741,7 @@ am__objects_36 =
 @OPT_ENABLE_ROCM_TRUE@am__objects_37 =  \
 @OPT_ENABLE_ROCM_TRUE@	sample-sources/libhpcrun_la-amd.lo \
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-activity-translate.lo \
+<<<<<<< HEAD
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-api.lo
 @OPT_ENABLE_ROCM_TRUE@am__objects_38 = $(am__objects_37)
 @OPT_ENABLE_LEVEL0_TRUE@am__objects_39 =  \
@@ -748,6 +754,13 @@ am__objects_36 =
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-handle-map.lo
 @OPT_ENABLE_LEVEL0_TRUE@am__objects_40 = $(am__objects_39)
 am__objects_41 = unwind/common/libhpcrun_la-backtrace.lo \
+=======
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-api.lo \
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-debug-api.lo \
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-binary-processing.lo
+@OPT_ENABLE_ROCM_TRUE@am__objects_37 = $(am__objects_36)
+am__objects_38 = unwind/common/libhpcrun_la-backtrace.lo \
+>>>>>>> Update Makefile.am for AMD
 	unwind/common/libhpcrun_la-unw-throw.lo
 am__objects_42 = $(am__objects_41) \
 	unwind/common/libhpcrun_la-binarytree_uwi.lo \
@@ -1870,7 +1883,9 @@ MY_AARCH64_FILES = \
 @OPT_ENABLE_ROCM_TRUE@MY_ROCM_FILES = \
 @OPT_ENABLE_ROCM_TRUE@	sample-sources/amd.c \
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/roctracer-activity-translate.c \
-@OPT_ENABLE_ROCM_TRUE@	gpu/amd/roctracer-api.c 	
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/roctracer-api.c \
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/rocm-debug-api.c \
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/rocm-binary-processing.c
 
 @OPT_ENABLE_LEVEL0_TRUE@MY_LEVEL0_FILES = \
 @OPT_ENABLE_LEVEL0_TRUE@	sample-sources/level0.c \
@@ -2781,6 +2796,7 @@ gpu/amd/libhpcrun_la-roctracer-activity-translate.lo:  \
 	gpu/amd/$(am__dirstamp) gpu/amd/$(DEPDIR)/$(am__dirstamp)
 gpu/amd/libhpcrun_la-roctracer-api.lo: gpu/amd/$(am__dirstamp) \
 	gpu/amd/$(DEPDIR)/$(am__dirstamp)
+<<<<<<< HEAD
 sample-sources/libhpcrun_la-level0.lo: sample-sources/$(am__dirstamp) \
 	sample-sources/$(DEPDIR)/$(am__dirstamp)
 gpu/level0/$(am__dirstamp):
@@ -2806,6 +2822,12 @@ gpu/level0/libhpcrun_la-level0-event-map.lo:  \
 gpu/level0/libhpcrun_la-level0-handle-map.lo:  \
 	gpu/level0/$(am__dirstamp) \
 	gpu/level0/$(DEPDIR)/$(am__dirstamp)
+=======
+gpu/amd/libhpcrun_la-rocm-debug-api.lo: gpu/amd/$(am__dirstamp) \
+	gpu/amd/$(DEPDIR)/$(am__dirstamp)
+gpu/amd/libhpcrun_la-rocm-binary-processing.lo:  \
+	gpu/amd/$(am__dirstamp) gpu/amd/$(DEPDIR)/$(am__dirstamp)
+>>>>>>> Update Makefile.am for AMD
 unwind/common/libhpcrun_la-backtrace.lo:  \
 	unwind/common/$(am__dirstamp) \
 	unwind/common/$(DEPDIR)/$(am__dirstamp)
@@ -3709,6 +3731,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/$(DEPDIR)/libhpcrun_o-gpu-trace-channel.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/$(DEPDIR)/libhpcrun_o-gpu-trace-item.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/$(DEPDIR)/libhpcrun_o-gpu-trace.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/amd/$(DEPDIR)/libhpcrun_la-roctracer-activity-translate.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/amd/$(DEPDIR)/libhpcrun_la-roctracer-api.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-api.Plo@am__quote@
@@ -5338,6 +5362,7 @@ gpu/amd/libhpcrun_la-roctracer-api.lo: gpu/amd/roctracer-api.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-roctracer-api.lo `test -f 'gpu/amd/roctracer-api.c' || echo '$(srcdir)/'`gpu/amd/roctracer-api.c
 
+<<<<<<< HEAD
 sample-sources/libhpcrun_la-level0.lo: sample-sources/level0.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT sample-sources/libhpcrun_la-level0.lo -MD -MP -MF sample-sources/$(DEPDIR)/libhpcrun_la-level0.Tpo -c -o sample-sources/libhpcrun_la-level0.lo `test -f 'sample-sources/level0.c' || echo '$(srcdir)/'`sample-sources/level0.c
 @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) sample-sources/$(DEPDIR)/libhpcrun_la-level0.Tpo sample-sources/$(DEPDIR)/libhpcrun_la-level0.Plo
@@ -5386,6 +5411,21 @@ gpu/level0/libhpcrun_la-level0-handle-map.lo: gpu/level0/level0-handle-map.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-handle-map.c' object='gpu/level0/libhpcrun_la-level0-handle-map.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-handle-map.lo `test -f 'gpu/level0/level0-handle-map.c' || echo '$(srcdir)/'`gpu/level0/level0-handle-map.c
+=======
+gpu/amd/libhpcrun_la-rocm-debug-api.lo: gpu/amd/rocm-debug-api.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/amd/libhpcrun_la-rocm-debug-api.lo -MD -MP -MF gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Tpo -c -o gpu/amd/libhpcrun_la-rocm-debug-api.lo `test -f 'gpu/amd/rocm-debug-api.c' || echo '$(srcdir)/'`gpu/amd/rocm-debug-api.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Tpo gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/amd/rocm-debug-api.c' object='gpu/amd/libhpcrun_la-rocm-debug-api.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-rocm-debug-api.lo `test -f 'gpu/amd/rocm-debug-api.c' || echo '$(srcdir)/'`gpu/amd/rocm-debug-api.c
+
+gpu/amd/libhpcrun_la-rocm-binary-processing.lo: gpu/amd/rocm-binary-processing.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/amd/libhpcrun_la-rocm-binary-processing.lo -MD -MP -MF gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Tpo -c -o gpu/amd/libhpcrun_la-rocm-binary-processing.lo `test -f 'gpu/amd/rocm-binary-processing.c' || echo '$(srcdir)/'`gpu/amd/rocm-binary-processing.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Tpo gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/amd/rocm-binary-processing.c' object='gpu/amd/libhpcrun_la-rocm-binary-processing.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-rocm-binary-processing.lo `test -f 'gpu/amd/rocm-binary-processing.c' || echo '$(srcdir)/'`gpu/amd/rocm-binary-processing.c
+>>>>>>> Update Makefile.am for AMD
 
 unwind/common/libhpcrun_la-backtrace.lo: unwind/common/backtrace.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT unwind/common/libhpcrun_la-backtrace.lo -MD -MP -MF unwind/common/$(DEPDIR)/libhpcrun_la-backtrace.Tpo -c -o unwind/common/libhpcrun_la-backtrace.lo `test -f 'unwind/common/backtrace.c' || echo '$(srcdir)/'`unwind/common/backtrace.c

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -538,16 +538,12 @@ am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	gpu/nvidia/cupti-analysis.c gpu/nvidia/cupti-api.c \
 	gpu/nvidia/cupti-gpu-api.c sample-sources/upc.c \
 	sample-sources/amd.c gpu/amd/roctracer-activity-translate.c \
-<<<<<<< HEAD
-	gpu/amd/roctracer-api.c sample-sources/level0.c \
+	gpu/amd/roctracer-api.c gpu/amd/rocm-debug-api.c \
+	gpu/amd/rocm-binary-processing.c sample-sources/level0.c \
 	gpu/level0/level0-api.c gpu/level0/level0-command-list-map.c \
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c gpu/level0/level0-event-map.c \
 	gpu/level0/level0-handle-map.c unwind/common/backtrace.c \
-=======
-	gpu/amd/roctracer-api.c gpu/amd/rocm-debug-api.c \
-	gpu/amd/rocm-binary-processing.c unwind/common/backtrace.c \
->>>>>>> Update Makefile.am for AMD
 	unwind/common/unw-throw.c unwind/common/binarytree_uwi.c \
 	unwind/common/interval_t.c unwind/common/libunw_intervals.c \
 	unwind/common/stack_troll.c unwind/common/uw_hash.c \
@@ -741,8 +737,9 @@ am__objects_36 =
 @OPT_ENABLE_ROCM_TRUE@am__objects_37 =  \
 @OPT_ENABLE_ROCM_TRUE@	sample-sources/libhpcrun_la-amd.lo \
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-activity-translate.lo \
-<<<<<<< HEAD
-@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-api.lo
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-api.lo \
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-debug-api.lo \
+@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-binary-processing.lo
 @OPT_ENABLE_ROCM_TRUE@am__objects_38 = $(am__objects_37)
 @OPT_ENABLE_LEVEL0_TRUE@am__objects_39 =  \
 @OPT_ENABLE_LEVEL0_TRUE@	sample-sources/libhpcrun_la-level0.lo \
@@ -754,13 +751,6 @@ am__objects_36 =
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-handle-map.lo
 @OPT_ENABLE_LEVEL0_TRUE@am__objects_40 = $(am__objects_39)
 am__objects_41 = unwind/common/libhpcrun_la-backtrace.lo \
-=======
-@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-api.lo \
-@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-debug-api.lo \
-@OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-binary-processing.lo
-@OPT_ENABLE_ROCM_TRUE@am__objects_37 = $(am__objects_36)
-am__objects_38 = unwind/common/libhpcrun_la-backtrace.lo \
->>>>>>> Update Makefile.am for AMD
 	unwind/common/libhpcrun_la-unw-throw.lo
 am__objects_42 = $(am__objects_41) \
 	unwind/common/libhpcrun_la-binarytree_uwi.lo \
@@ -2796,7 +2786,10 @@ gpu/amd/libhpcrun_la-roctracer-activity-translate.lo:  \
 	gpu/amd/$(am__dirstamp) gpu/amd/$(DEPDIR)/$(am__dirstamp)
 gpu/amd/libhpcrun_la-roctracer-api.lo: gpu/amd/$(am__dirstamp) \
 	gpu/amd/$(DEPDIR)/$(am__dirstamp)
-<<<<<<< HEAD
+gpu/amd/libhpcrun_la-rocm-debug-api.lo: gpu/amd/$(am__dirstamp) \
+	gpu/amd/$(DEPDIR)/$(am__dirstamp)
+gpu/amd/libhpcrun_la-rocm-binary-processing.lo:  \
+	gpu/amd/$(am__dirstamp) gpu/amd/$(DEPDIR)/$(am__dirstamp)
 sample-sources/libhpcrun_la-level0.lo: sample-sources/$(am__dirstamp) \
 	sample-sources/$(DEPDIR)/$(am__dirstamp)
 gpu/level0/$(am__dirstamp):
@@ -2822,12 +2815,6 @@ gpu/level0/libhpcrun_la-level0-event-map.lo:  \
 gpu/level0/libhpcrun_la-level0-handle-map.lo:  \
 	gpu/level0/$(am__dirstamp) \
 	gpu/level0/$(DEPDIR)/$(am__dirstamp)
-=======
-gpu/amd/libhpcrun_la-rocm-debug-api.lo: gpu/amd/$(am__dirstamp) \
-	gpu/amd/$(DEPDIR)/$(am__dirstamp)
-gpu/amd/libhpcrun_la-rocm-binary-processing.lo:  \
-	gpu/amd/$(am__dirstamp) gpu/amd/$(DEPDIR)/$(am__dirstamp)
->>>>>>> Update Makefile.am for AMD
 unwind/common/libhpcrun_la-backtrace.lo:  \
 	unwind/common/$(am__dirstamp) \
 	unwind/common/$(DEPDIR)/$(am__dirstamp)
@@ -5362,7 +5349,20 @@ gpu/amd/libhpcrun_la-roctracer-api.lo: gpu/amd/roctracer-api.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-roctracer-api.lo `test -f 'gpu/amd/roctracer-api.c' || echo '$(srcdir)/'`gpu/amd/roctracer-api.c
 
-<<<<<<< HEAD
+gpu/amd/libhpcrun_la-rocm-debug-api.lo: gpu/amd/rocm-debug-api.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/amd/libhpcrun_la-rocm-debug-api.lo -MD -MP -MF gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Tpo -c -o gpu/amd/libhpcrun_la-rocm-debug-api.lo `test -f 'gpu/amd/rocm-debug-api.c' || echo '$(srcdir)/'`gpu/amd/rocm-debug-api.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Tpo gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/amd/rocm-debug-api.c' object='gpu/amd/libhpcrun_la-rocm-debug-api.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-rocm-debug-api.lo `test -f 'gpu/amd/rocm-debug-api.c' || echo '$(srcdir)/'`gpu/amd/rocm-debug-api.c
+
+gpu/amd/libhpcrun_la-rocm-binary-processing.lo: gpu/amd/rocm-binary-processing.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/amd/libhpcrun_la-rocm-binary-processing.lo -MD -MP -MF gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Tpo -c -o gpu/amd/libhpcrun_la-rocm-binary-processing.lo `test -f 'gpu/amd/rocm-binary-processing.c' || echo '$(srcdir)/'`gpu/amd/rocm-binary-processing.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Tpo gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/amd/rocm-binary-processing.c' object='gpu/amd/libhpcrun_la-rocm-binary-processing.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-rocm-binary-processing.lo `test -f 'gpu/amd/rocm-binary-processing.c' || echo '$(srcdir)/'`gpu/amd/rocm-binary-processing.c
+
 sample-sources/libhpcrun_la-level0.lo: sample-sources/level0.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT sample-sources/libhpcrun_la-level0.lo -MD -MP -MF sample-sources/$(DEPDIR)/libhpcrun_la-level0.Tpo -c -o sample-sources/libhpcrun_la-level0.lo `test -f 'sample-sources/level0.c' || echo '$(srcdir)/'`sample-sources/level0.c
 @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) sample-sources/$(DEPDIR)/libhpcrun_la-level0.Tpo sample-sources/$(DEPDIR)/libhpcrun_la-level0.Plo
@@ -5411,21 +5411,6 @@ gpu/level0/libhpcrun_la-level0-handle-map.lo: gpu/level0/level0-handle-map.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-handle-map.c' object='gpu/level0/libhpcrun_la-level0-handle-map.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-handle-map.lo `test -f 'gpu/level0/level0-handle-map.c' || echo '$(srcdir)/'`gpu/level0/level0-handle-map.c
-=======
-gpu/amd/libhpcrun_la-rocm-debug-api.lo: gpu/amd/rocm-debug-api.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/amd/libhpcrun_la-rocm-debug-api.lo -MD -MP -MF gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Tpo -c -o gpu/amd/libhpcrun_la-rocm-debug-api.lo `test -f 'gpu/amd/rocm-debug-api.c' || echo '$(srcdir)/'`gpu/amd/rocm-debug-api.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Tpo gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-debug-api.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/amd/rocm-debug-api.c' object='gpu/amd/libhpcrun_la-rocm-debug-api.lo' libtool=yes @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-rocm-debug-api.lo `test -f 'gpu/amd/rocm-debug-api.c' || echo '$(srcdir)/'`gpu/amd/rocm-debug-api.c
-
-gpu/amd/libhpcrun_la-rocm-binary-processing.lo: gpu/amd/rocm-binary-processing.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/amd/libhpcrun_la-rocm-binary-processing.lo -MD -MP -MF gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Tpo -c -o gpu/amd/libhpcrun_la-rocm-binary-processing.lo `test -f 'gpu/amd/rocm-binary-processing.c' || echo '$(srcdir)/'`gpu/amd/rocm-binary-processing.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Tpo gpu/amd/$(DEPDIR)/libhpcrun_la-rocm-binary-processing.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/amd/rocm-binary-processing.c' object='gpu/amd/libhpcrun_la-rocm-binary-processing.lo' libtool=yes @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/amd/libhpcrun_la-rocm-binary-processing.lo `test -f 'gpu/amd/rocm-binary-processing.c' || echo '$(srcdir)/'`gpu/amd/rocm-binary-processing.c
->>>>>>> Update Makefile.am for AMD
 
 unwind/common/libhpcrun_la-backtrace.lo: unwind/common/backtrace.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT unwind/common/libhpcrun_la-backtrace.lo -MD -MP -MF unwind/common/$(DEPDIR)/libhpcrun_la-backtrace.Tpo -c -o unwind/common/libhpcrun_la-backtrace.lo `test -f 'unwind/common/backtrace.c' || echo '$(srcdir)/'`unwind/common/backtrace.c

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
@@ -1,0 +1,328 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2020, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+//******************************************************************************
+// system includes
+//******************************************************************************
+
+#include <gelf.h>
+#include <errno.h>     // errno
+#include <fcntl.h>     // open
+#include <sys/stat.h>  // mkdir
+#include <sys/types.h>
+#include <unistd.h>
+#include <linux/limits.h>  // PATH_MAX
+
+//******************************************************************************
+// local includes
+//******************************************************************************
+
+#include "rocm-debug-api.h"
+#include "rocm-binary-processing.h"
+#include <hpcrun/files.h>
+#include "lib/prof-lean/elf-helper.h"
+
+//******************************************************************************
+// type declarations
+//******************************************************************************
+
+typedef struct amd_gpu_binary {
+  size_t size;
+  char* buf;
+} amd_gpu_binary_t;
+
+typedef struct amd_function_table {
+  size_t size;
+  char** names;
+  uint64_t* addrs;
+} amd_function_table_t;
+
+#define DEBUG 0
+
+#include "hpcrun/gpu/gpu-print.h"
+
+//******************************************************************************
+// local variables
+//******************************************************************************
+
+amd_gpu_binary_t binary;
+amd_function_table_t function_table;
+static uint32_t amd_gpu_module_id;
+
+//******************************************************************************
+// private operations
+//******************************************************************************
+
+static void
+construct_amd_gpu_symbols
+(
+  Elf *elf
+)
+{
+  // Initialize elf_help_t to handle extended numbering
+  elf_helper_t eh;
+  elf_helper_initialize(elf, &eh);
+
+  // Get section name section index to find ".strtab"
+  size_t shstrndx;
+  if (elf_getshdrstrndx(elf, &shstrndx) != 0) return;
+
+  // Find .symtab and .strtab sections
+  Elf_Scn *scn = NULL;
+  Elf_Scn *symtab_scn = NULL;
+  Elf_Scn *strtab_scn = NULL;
+  while ((scn = elf_nextscn(elf, scn)) != NULL) {
+    GElf_Shdr shdr;
+    if (!gelf_getshdr(scn, &shdr)) continue;
+    if (shdr.sh_type == SHT_SYMTAB) {
+      symtab_scn = scn;
+      continue;
+    }
+    char *name = elf_strptr(elf, shstrndx , shdr.sh_name);
+    if (name == NULL) continue;
+    if (strcmp(name, ".strtab") == 0) {
+      strtab_scn = scn;
+    }
+  }
+
+  // Get total number of symbols in .symtab
+  GElf_Shdr symtab;
+  gelf_getshdr(symtab_scn, &symtab);
+
+  int nsymbols = 0;
+  if (symtab.sh_entsize > 0) { // avoid divide by 0
+    nsymbols = symtab.sh_size / symtab.sh_entsize;
+    if (nsymbols <= 0) return;
+  } else {
+    return;
+  }
+
+  Elf_Data *symtab_data = elf_getdata(symtab_scn, NULL);
+  if (symtab_data == NULL) return;
+
+  // Get total number of function symbols in .symtab
+  size_t nfuncs = 0;
+  for (int i = 0; i < nsymbols; i++) {
+    GElf_Sym sym;
+    GElf_Sym *symp = NULL;
+    int section_index;
+    symp = elf_helper_get_symbol(&eh, i, &sym, &section_index);
+    if (symp) { // symbol properly read
+      int symtype = GELF_ST_TYPE(sym.st_info);
+      if (sym.st_shndx == SHN_UNDEF) continue;
+      if (symtype != STT_FUNC) continue;
+      nfuncs++;
+    }
+  }
+
+  // Get symbol name string table
+  Elf_Data *strtab_data = elf_getdata(strtab_scn, NULL);
+  if (strtab_data == NULL) return;
+  char* symbol_name_buf = (char*)(strtab_data->d_buf);
+
+  // Initialize our function table
+  function_table.size = nfuncs;
+  function_table.names = (char**)hpcrun_malloc(sizeof(char*) * function_table.size);
+  function_table.addrs = (uint64_t*)hpcrun_malloc(sizeof(uint64_t) * function_table.size);
+  int index = 0;
+
+  // Put each function symbol into our function table
+  for (int i = 0; i < nsymbols; i++) {
+    GElf_Sym sym;
+    GElf_Sym *symp = NULL;
+    int section_index;
+    symp = elf_helper_get_symbol(&eh, i, &sym, &section_index);
+    if (symp) { // symbol properly read
+      int symtype = GELF_ST_TYPE(sym.st_info);
+      if (sym.st_shndx == SHN_UNDEF) continue;
+      if (symtype != STT_FUNC) continue;
+      function_table.names[index] = symbol_name_buf + sym.st_name;
+      function_table.addrs[index] = sym.st_value;
+      ++index;
+    }
+  }
+#if DEBUG != 0
+  printf("Dump AMD GPU functions\n");
+  for (size_t i = 0; i < function_table.size; ++i) {
+    printf("Function %s, at address %lx\n", function_table.names[i], function_table.addrs[i]);
+  }
+#endif
+}
+
+static void
+parse_amd_gpu_binary_uri
+(
+  char *uri
+)
+{
+  // File URI example: file:///home/users/coe0173/HIP-Examples/HIP-Examples-Applications/FloydWarshall/FloydWarshall#offset=26589&size=31088
+  char* filepath = uri + strlen("file://");
+  char* filepath_end = filepath;
+
+  // filepath is seperated by either # or ?
+  while (*filepath_end != '#' && *filepath_end != '?')
+    ++filepath_end;
+  *filepath_end = 0;
+
+  // Get the offset field in the uri
+  char* uri_suffix = filepath_end + 1;
+  char* index = strstr(uri_suffix, "offset=") + strlen("offset=");
+  char* endptr;
+  unsigned long long offset = strtoull(index, &endptr, 10);
+
+  // Get the size field in the uri
+  index = strstr(uri_suffix, "size=") + strlen("size=");
+  unsigned long int size = strtoul(index, &endptr, 10);
+
+  PRINT("Parsing URI, filepath %s\n", filepath);
+  PRINT("\toffset %lx, size %lx\n", offset, size);
+  
+  char* filename = strrchr(filepath, '/') + 1;
+
+  // Create file name
+  char gpu_file_path[PATH_MAX];
+  size_t used = 0;
+  used += sprintf(&gpu_file_path[used], "%s", hpcrun_files_output_directory());
+  used += sprintf(&gpu_file_path[used], "%s", "/amd/");
+  mkdir(file_name, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  used += sprintf(&gpu_file_path[used], "%s.rocm-gpu", filename);
+	
+  // We directly return if we have write down this URI
+  int wfd;
+  wfd = open(gpu_file_path, O_WRONLY | O_CREAT | O_EXCL, 0644);
+  if (wfd < 0) {   
+    return;
+  }
+  
+  int rfd = open(filepath, O_RDONLY);
+  if (rfd < 0) {
+    PRINT("\tcannot open the file specified in the file URI\n");
+	return;
+  }
+
+  if (lseek(rfd, offset, SEEK_SET) < 0) {
+    PRINT("\tcannot seek to the offset\n");
+	return;
+  }
+
+  binary.size = size;
+  binary.buf = (char*)hpcrun_malloc(size);
+  if (read(rfd, binary.buf, size) != size) {
+    PRINT("\tfail to read file\n");
+	return;
+  }
+  write(wfd, (const void*)(binary.buf), binary.size);
+  close(wfd);
+
+  amd_gpu_module_id = hpcrun_loadModule_add(gpu_file_path);
+}
+
+static void
+parse_amd_gpu_binary
+(
+)
+{
+  rocm_debug_api_init();
+  size_t code_object_count;
+  rocm_debug_api_query_code_object(&code_object_count);
+
+  char* gpu_binary_uri = NULL;
+  for (size_t i = 0; i < code_object_count; ++i) {
+    char* uri = rocm_debug_api_query_uri(i);
+    parse_amd_uri(uri);
+    // Ignore memory URI as it points to amd's gpu runtime
+	if (strncmp(uri, "memory://", strlen("memory://")) == 0) {
+        continue;		
+	}
+
+    // Assume we have only one code object
+	if (strncmp(uri, "file://", strlen("file://")) == 0) {
+        gpu_binary_uri = uri;
+		break;
+	}
+  }
+
+  parse_amd_gpu_binary_uri(gpu_binary_uri);
+  elf_version(EV_CURRENT);
+  Elf *elf = elf_memory(binary.buf, binary.size);
+  if (elf != 0) {
+	  construct_amd_gpu_symbols(elf);
+	  elf_end(elf);
+  }  
+}
+
+static uintptr_t
+lookup_amd_function
+(
+  const char *kernel_name
+)
+{
+  for (size_t i = 0; i < function_table.size; ++i) {
+    if (strcmp(kernel_name, function_table.names[i]) == 0) {
+      return (uintptr_t)(function_table.addrs[i]);
+    }
+  }
+  return 0;
+}
+
+//******************************************************************************
+// interface operations
+//******************************************************************************
+
+ip_normalized_t
+rocm_binary_function_lookup
+(
+  const char* kernel_name
+)
+{
+  // TODO: Handle multi-threaded case
+  if (binary.size == 0) {
+    parse_amd_gpu_binary();
+  }
+  ip_normalized_t nip;
+  nip.lm_id = amd_gpu_module_id;
+  nip.lm_ip = lookup_amd_function(kernel_name);
+
+  PRINT("HIP launch kernel %s, lm_ip %lx\n", kernel_name, nip.lm_ip);
+  return nip;
+}

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
@@ -216,7 +216,7 @@ parse_amd_gpu_binary_uri
 
   PRINT("Parsing URI, filepath %s\n", filepath);
   PRINT("\toffset %lx, size %lx\n", offset, size);
-  
+
   char* filename = strrchr(filepath, '/') + 1;
 
   // Create file name
@@ -226,14 +226,14 @@ parse_amd_gpu_binary_uri
   used += sprintf(&gpu_file_path[used], "%s", "/amd/");
   mkdir(file_name, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
   used += sprintf(&gpu_file_path[used], "%s.rocm-gpu", filename);
-	
+
   // We directly return if we have write down this URI
   int wfd;
   wfd = open(gpu_file_path, O_WRONLY | O_CREAT | O_EXCL, 0644);
-  if (wfd < 0) {   
+  if (wfd < 0) {
     return;
   }
-  
+
   int rfd = open(filepath, O_RDONLY);
   if (rfd < 0) {
     PRINT("\tcannot open the file specified in the file URI\n");
@@ -272,7 +272,7 @@ parse_amd_gpu_binary
     parse_amd_uri(uri);
     // Ignore memory URI as it points to amd's gpu runtime
 	if (strncmp(uri, "memory://", strlen("memory://")) == 0) {
-        continue;		
+        continue;
 	}
 
     // Assume we have only one code object
@@ -288,7 +288,7 @@ parse_amd_gpu_binary
   if (elf != 0) {
 	  construct_amd_gpu_symbols(elf);
 	  elf_end(elf);
-  }  
+  }
 }
 
 static uintptr_t

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
@@ -94,6 +94,18 @@ static uint32_t amd_gpu_module_id;
 // private operations
 //******************************************************************************
 
+// TODO:
+// construct_amd_gpu_symbols parses the ELF symbol and extract
+// the string names of functions.
+//
+// We have similar code in different places that iterate over
+// the ELF symbol table, and doing slightly different things.
+// At least, NVIDIA support code iterates over symbol table
+// to relocate functions, and hpcfnbounds code iterates over
+// symbol table to find function starts.
+// It would be good to refactor these ELF operations into commond
+// code.
+
 static void
 construct_amd_gpu_symbols
 (
@@ -189,6 +201,12 @@ construct_amd_gpu_symbols
   }
 #endif
 }
+
+// TODO:
+// Eventually, we want to write the URI into our load map rather than copying the binary into a file.
+// To handle this long-term goal, the URI parsing would have to be code shared by hpcrun, hpcprof,
+// and hpcstruct. We can move function parse_amd_gpu_binary_uri to prof-lean direcotry and refactor
+// the function to return something that can help identifies the GPU binary specified by the URI.
 
 static void
 parse_amd_gpu_binary_uri
@@ -302,6 +320,16 @@ parse_amd_gpu_binary
   return 0;
 }
 
+// TODO:
+// lookup_amd_function is currently implemented as a linear search.
+// We would hope to get help from AMD that roctracer will directly
+// tell us the offset of a launched kernel, so that we do not have
+// to do name matching.
+//
+// If we got no help, then we would need to refactor the code to
+// to handle large GPU binaries. We will need to use more efficient
+// lookup data structure, a splay tree or a trie.
+
 static uintptr_t
 lookup_amd_function
 (
@@ -326,7 +354,14 @@ rocm_binary_function_lookup
   const char* kernel_name
 )
 {
-  // TODO: Handle multi-threaded case
+  // TODO:
+  // 1. Handle multi-threaded case. Currently, this function is called when the first
+  //    HIP kernel launch is done. So multiple threads can enter this concurrently.
+  // 2. Handle the case of multiple GPU binaries. Currently, this code assuems there is
+  //    only one AMD GPU binary. We will need to both assign different names to AMD GPU
+  //    binaries and also handle the possibility of one kernel name appearing in different
+  //    GPU binaries.
+
   if (binary.size == 0) {
     if (parse_amd_gpu_binary() < 0) {
       binary.size = -1;

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
@@ -224,7 +224,7 @@ parse_amd_gpu_binary_uri
   size_t used = 0;
   used += sprintf(&gpu_file_path[used], "%s", hpcrun_files_output_directory());
   used += sprintf(&gpu_file_path[used], "%s", "/amd/");
-  mkdir(file_name, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  mkdir(gpu_file_path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
   used += sprintf(&gpu_file_path[used], "%s.rocm-gpu", filename);
 
   // We directly return if we have write down this URI
@@ -269,7 +269,6 @@ parse_amd_gpu_binary
   char* gpu_binary_uri = NULL;
   for (size_t i = 0; i < code_object_count; ++i) {
     char* uri = rocm_debug_api_query_uri(i);
-    parse_amd_uri(uri);
     // Ignore memory URI as it points to amd's gpu runtime
 	if (strncmp(uri, "memory://", strlen("memory://")) == 0) {
         continue;

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.h
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.h
@@ -1,0 +1,61 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2020, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+#ifndef rocm_binary_processing_h
+#define rocm_binary_processing_h
+
+//******************************************************************************
+// local includes
+//******************************************************************************
+
+#include "hpcrun/utilities/ip-normalized.h"
+
+//******************************************************************************
+// interface operations
+//******************************************************************************
+
+ip_normalized_t
+rocm_binary_function_lookup
+(
+  const char* kernel_name
+);

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.h
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.h
@@ -59,3 +59,5 @@ rocm_binary_function_lookup
 (
   const char* kernel_name
 );
+
+#endif

--- a/src/tool/hpcrun/gpu/amd/rocm-debug-api.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-debug-api.c
@@ -1,0 +1,347 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2020, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+//******************************************************************************
+// system includes
+//******************************************************************************
+
+#include "amd-dbgapi.h"
+
+//******************************************************************************
+// local includes
+//******************************************************************************
+
+#include "rocm-debug-api.h"
+
+#include <hpcrun/safe-sampling.h>
+#include <hpcrun/sample-sources/libdl.h>
+
+//******************************************************************************
+// macros
+//******************************************************************************
+
+#define FORALL_ROCM_DEBUG_ROUTINES(macro)			\
+  macro(amd_dbgapi_initialize)   \
+  macro(amd_dbgapi_process_attach)   \
+  macro(amd_dbgapi_process_detach) \
+  macro(amd_dbgapi_code_object_list) \
+  macro(amd_dbgapi_code_object_get_info)
+
+
+#define ROCM_DEBUG_FN_NAME(f) DYN_FN_NAME(f)
+
+#define ROCM_DEBUG_FN(fn, args) \
+  static amd_dbgapi_status_t (*ROCM_DEBUG_FN_NAME(fn)) args
+
+#define HPCRUN_ROCM_DEBUG_CALL(fn, args) \
+{      \
+  amd_dbgapi_status_t ret = ROCM_DEBUG_FN_NAME(fn) args;	\
+  check_rocm_debug_status(ret, __LINE__); \
+}
+
+//******************************************************************************
+// debug print
+//******************************************************************************
+
+#define DEBUG 0
+
+#include "hpcrun/gpu/gpu-print.h"
+
+//******************************************************************************
+// local variables
+//******************************************************************************
+
+static amd_dbgapi_callbacks_t callbacks;
+static amd_dbgapi_process_id_t self;
+static amd_dbgapi_code_object_id_t *code_objects_id;
+
+//----------------------------------------------------------
+// rocm debug api function pointers for late binding
+//----------------------------------------------------------
+
+ROCM_DEBUG_FN
+(
+  amd_dbgapi_initialize,
+  (
+    amd_dbgapi_callbacks_t*
+  )
+);
+
+ROCM_DEBUG_FN
+(
+  amd_dbgapi_process_attach,
+  (
+    amd_dbgapi_client_process_id_t,
+    amd_dbgapi_process_id_t *
+  )
+);
+
+ROCM_DEBUG_FN
+(
+  amd_dbgapi_process_detach,
+  (
+    amd_dbgapi_process_id_t
+  )
+);
+
+ROCM_DEBUG_FN
+(
+  amd_dbgapi_code_object_list,
+  (
+    amd_dbgapi_process_id_t,
+    size_t *,
+    amd_dbgapi_code_object_id_t **,
+    amd_dbgapi_changed_t *
+  )
+);
+
+ROCM_DEBUG_FN
+(
+  amd_dbgapi_code_object_get_info,
+  (
+    amd_dbgapi_process_id_t,
+    amd_dbgapi_code_object_id_t,
+    amd_dbgapi_code_object_info_t,
+    size_t,
+    void*
+  )
+);
+
+//******************************************************************************
+// private operations
+//******************************************************************************
+
+static amd_dbgapi_status_t
+hpcrun_self_process
+(
+  amd_dbgapi_client_process_id_t cp,
+  amd_dbgapi_os_pid_t *os_pid
+)
+{
+  *os_pid = getpid();
+  return AMD_DBGAPI_STATUS_SUCCESS;
+}
+
+static amd_dbgapi_status_t
+hpcrun_enable_notify_shared_library
+(
+  amd_dbgapi_client_process_id_t client_process_id,
+  const char *shared_library_name,
+  amd_dbgapi_shared_library_id_t shared_library_id,
+  amd_dbgapi_shared_library_state_t *shared_library_state
+)
+{
+  if (strcmp(shared_library_name, "libhsa-runtime64.so.1") == 0)
+    *shared_library_state = AMD_DBGAPI_SHARED_LIBRARY_STATE_LOADED;
+  else
+    *shared_library_state = AMD_DBGAPI_SHARED_LIBRARY_STATE_UNLOADED;
+  return AMD_DBGAPI_STATUS_SUCCESS;
+}
+
+static amd_dbgapi_status_t
+hpcrun_disable_notify_shared_library
+(
+  amd_dbgapi_client_process_id_t client_process_id,
+  amd_dbgapi_shared_library_id_t shared_library_id
+)
+{
+  return AMD_DBGAPI_STATUS_SUCCESS;
+}
+
+static amd_dbgapi_status_t
+hpcun_get_symbol_address
+(
+  amd_dbgapi_client_process_id_t client_process_id,
+  amd_dbgapi_shared_library_id_t shared_library_id,
+  const char *symbol_name,
+  amd_dbgapi_global_address_t *address
+)
+{
+  *address = 0;
+  return AMD_DBGAPI_STATUS_SUCCESS;
+}
+
+static amd_dbgapi_status_t
+hpcurn_insert_breakpoint
+(
+  amd_dbgapi_client_process_id_t client_process_id,
+  amd_dbgapi_shared_library_id_t shared_library_id,
+  amd_dbgapi_global_address_t address,
+  amd_dbgapi_breakpoint_id_t breakpoint_id
+)
+{
+  return AMD_DBGAPI_STATUS_SUCCESS;
+}
+
+static amd_dbgapi_status_t
+hpcrun_remove_breakpoint
+(
+  amd_dbgapi_client_process_id_t client_process_id,
+  amd_dbgapi_breakpoint_id_t breakpoint_id
+)
+{
+  return AMD_DBGAPI_STATUS_SUCCESS;
+}
+
+static void
+hpcrun_log_message
+(
+  amd_dbgapi_log_level_t level,
+  const char *message
+)
+{
+  PRINT("%s\n", message);
+}
+
+static void
+check_rocm_debug_status
+(
+  amd_dbgapi_status_t ret,
+  int lineNo
+)
+{
+  if (ret == AMD_DBGAPI_STATUS_SUCCESS) {
+    return;
+  }
+
+#define CHECK_RET(x) if (ret == x) { PRINT(#x); }
+
+  CHECK_RET(AMD_DBGAPI_STATUS_FATAL);
+  CHECK_RET(AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED);
+  CHECK_RET(AMD_DBGAPI_STATUS_ERROR_INVALID_PROCESS_ID);
+  CHECK_RET(AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);
+  CHECK_RET(AMD_DBGAPI_STATUS_ERROR_CLIENT_CALLBACK);
+  CHECK_RET(AMD_DBGAPI_STATUS_ERROR_INVALID_CODE_OBJECT_ID);
+  CHECK_RET(AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_SIZE);
+
+#undef CHECK_RET
+
+  PRINT(" at line %d\n", lineNo);
+}
+
+//******************************************************************************
+// interface operations
+//******************************************************************************
+
+int
+rocm_debug_api_bind
+(
+  void
+)
+{
+  // This disable HIP's deferred code object loading.
+  // We can remove this when we start to use HSA API tracing
+  setenv("HIP_ENABLE_DEFERRED_LOADING", "0", 1);
+
+#ifndef HPCRUN_STATIC_LINK
+  // dynamic libraries only availabile in non-static case
+  hpcrun_force_dlopen(true);
+  CHK_DLOPEN(rocm_debug, "librocm-dbgapi.so", RTLD_NOW | RTLD_GLOBAL);
+  hpcrun_force_dlopen(false);
+
+#define ROCM_DEBUG_BIND(fn) \
+  CHK_DLSYM(rocm_debug, fn);
+
+  FORALL_ROCM_DEBUG_ROUTINES(ROCM_DEBUG_BIND)
+
+#undef ROCM_DEBUG_BIND
+  return 0;
+#else
+  return -1;
+#endif // ! HPCRUN_STATIC_LINK
+}
+
+void
+rocm_debug_api_init
+(
+  void
+)
+{
+  // Fill in call back functions for rocm debug api
+  callbacks.allocate_memory = malloc;
+  callbacks.deallocate_memory = free;
+  callbacks.get_os_pid = hpcrun_self_process;
+  callbacks.enable_notify_shared_library = hpcrun_enable_notify_shared_library;
+  callbacks.disable_notify_shared_library = hpcrun_disable_notify_shared_library;
+  callbacks.get_symbol_address = hpcrun_get_symbol_address;
+  callbacks.insert_breakpoint = insert_breakpoint_empty;
+  callbacks.remove_breakpoint = remove_breakpoint_empty;
+  callbacks.log_message = log_message_empty;
+
+  HPCRUN_ROCM_DEBUG_CALL(amd_dbgapi_initialize, (&callbacks));
+  HPCRUN_ROCM_DEBUG_CALL(amd_dbgapi_process_attach,
+    ((amd_dbgapi_client_process_id_t)(&self), &self));
+}
+
+void
+rocm_debug_api_fini
+(
+  void
+)
+{
+  HPCRUN_ROCM_DEBUG_CALL(amd_dbgapi_process_detach, (self));
+}
+
+void
+rocm_debug_api_query_code_object
+(
+  size_t* code_obejct_count_ptr,
+)
+{
+  HPCRUN_ROCM_DEBUG_CALL(amd_dbgapi_code_object_list,
+    (self, code_object_count_ptr, &code_objects_id, NULL));
+  PRINT("code object count %u\n", *code_object_count_ptr);
+}
+
+char*
+rocm_debug_api_query_uri
+(
+  size_t code_object_index
+)
+{
+  char* uri;
+  HPCRUN_ROCM_DEBUG_CALL(amd_dbgapi_code_object_get_info,
+    (self, code_objects_id[index], AMD_DBGAPI_CODE_OBJECT_INFO_URI_NAME,
+        sizeof(char*), (void*)(&uri)));
+  return uri;
+}

--- a/src/tool/hpcrun/gpu/amd/rocm-debug-api.h
+++ b/src/tool/hpcrun/gpu/amd/rocm-debug-api.h
@@ -1,0 +1,81 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2020, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+#ifndef rocm_debug_api_h
+#define rocm_debug_api_h
+
+//******************************************************************************
+// interface operations
+//******************************************************************************
+
+int
+rocm_debug_api_bind
+(
+  void
+);
+
+void
+rocm_debug_api_init
+(
+  void
+);
+
+void
+rocm_debug_api_fini
+(
+  void
+);
+
+void
+rocm_debug_api_query_code_object
+(
+  size_t* code_obejct_count_ptr,
+);
+
+char*
+rocm_debug_api_query_uri
+(
+  size_t code_object_index
+);
+
+#endif

--- a/src/tool/hpcrun/gpu/amd/rocm-debug-api.h
+++ b/src/tool/hpcrun/gpu/amd/rocm-debug-api.h
@@ -69,7 +69,7 @@ rocm_debug_api_fini
 void
 rocm_debug_api_query_code_object
 (
-  size_t* code_obejct_count_ptr,
+  size_t* code_obejct_count_ptr
 );
 
 char*

--- a/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
@@ -154,7 +154,7 @@ roctracer_activity_translate
 #if DEBUG
   const char * name = roctracer_op_string(record->domain, record->op, record->kind);
 #endif
-  memset(ga, sizeof(gpu_activity_t), 0);
+  memset(ga, 0, sizeof(gpu_activity_t));
   if (record->domain == ACTIVITY_DOMAIN_HIP_API) {
     switch(record->op){
     case HIP_API_ID_hipMemcpyDtoD:

--- a/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
@@ -60,7 +60,7 @@
 // HSA_OP_ID_COPY is defined in hcc/include/hc_prof_runtime.h.
 // However, this file will include C++ code, making it impossible
 // to compile with a C compiler.
-// HSA_OP_ID_COPY is a constant with value 1 at the moment. 
+// HSA_OP_ID_COPY is a constant with value 1 at the moment.
 
 // FIXME: when amd fixes their header files, include the header file rather than
 // replicating the declaration here
@@ -148,13 +148,13 @@ void
 roctracer_activity_translate
 (
  gpu_activity_t *ga,
- roctracer_record_t *record   
+ roctracer_record_t *record
 )
 {
 #if DEBUG
   const char * name = roctracer_op_string(record->domain, record->op, record->kind);
 #endif
-
+  memset(ga, sizeof(gpu_activity_t), 0);
   if (record->domain == ACTIVITY_DOMAIN_HIP_API) {
     switch(record->op){
     case HIP_API_ID_hipMemcpyDtoD:

--- a/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
@@ -198,6 +198,7 @@ roctracer_activity_translate
     case HIP_API_ID_hipLaunchCooperativeKernel:
     case HIP_API_ID_hipHccModuleLaunchKernel:
     case HIP_API_ID_hipExtModuleLaunchKernel:
+    case HIP_API_ID_hipLaunchKernel:
       convert_kernel_launch(ga, record);
       break;
     case HIP_API_ID_hipCtxSynchronize:

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -513,6 +513,8 @@ roctracer_bind
   // More details: https://github.com/ROCm-Developer-Tools/roctracer/issues/22
   setenv("HSA_ENABLE_INTERRUPT", "0", 1);
 
+  rocm_debug_api_bind();
+
 #ifndef HPCRUN_STATIC_LINK
   // dynamic libraries only availabile in non-static case
   hpcrun_force_dlopen(true);
@@ -541,8 +543,6 @@ roctracer_bind
   if (hip_kernel_name_ref_fn == 0) {
     return -1;
   }
-
-  rocm_debug_api_bind();
 
   return 0;
 #else

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -483,7 +483,7 @@ parse_amd_gpu_binary
   }
 
   // Create file name
-  char file_name[PATH_MAX];  
+  char file_name[PATH_MAX];
   size_t used = 0;
   used += sprintf(&file_name[used], "%s", hpcrun_files_output_directory());
   used += sprintf(&file_name[used], "%s", "/amd/");
@@ -500,7 +500,7 @@ lookup_amd_function
 (
   const char *kernel_name
 )
-{  
+{
   for (size_t i = 0; i < function_table.size; ++i) {
     if (strcmp(kernel_name, function_table.names[i]) == 0) {
       return (uintptr_t)(function_table.addrs[i]);
@@ -612,6 +612,8 @@ roctracer_subscriber_callback
     //case HIP_API_ID_hipExtModuleLaunchKernel:
     gpu_op_placeholder_flags_set(&gpu_op_placeholder_flags,
 				 gpu_placeholder_type_kernel);
+    gpu_op_placeholder_flags_set(&gpu_op_placeholder_flags,
+				 gpu_placeholder_type_trace);
     is_valid_op = true;
     is_kernel_op = true;
     break;
@@ -647,10 +649,14 @@ roctracer_subscriber_callback
     hpcrun_safe_enter();
     gpu_op_ccts_insert(api_node, &gpu_op_ccts, gpu_op_placeholder_flags);
     if (is_kernel_op) {
-      cct_node_t *kernel_ph = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_kernel);
       hipFunction_t f = data->args.hipModuleLaunchKernel.f;
       ip_normalized_t kernel_ip = hip_function_lookup(f);
+
+      cct_node_t *kernel_ph = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_kernel);
       ensure_kernel_ip_present(kernel_ph, kernel_ip);
+
+      cct_node_t *trace_ph = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_trace);
+      ensure_kernel_ip_present(trace_ph, kernel_ip);
     }
 
     hpcrun_safe_exit();

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -42,6 +42,19 @@
 // ******************************************************* EndRiceCopyright *
 
 //******************************************************************************
+// system includes
+//******************************************************************************
+
+#include <gelf.h>
+
+#include <errno.h>     // errno
+#include <fcntl.h>     // open
+#include <sys/stat.h>  // mkdir
+#include <sys/types.h>
+#include <unistd.h>
+#include <linux/limits.h>  // PATH_MAX
+
+//******************************************************************************
 // local includes
 //******************************************************************************
 
@@ -63,7 +76,8 @@
 #include <hpcrun/sample-sources/libdl.h>
 
 #include <hpcrun/utilities/hpcrun-nanotime.h>
-
+#include <hpcrun/files.h>
+#include "lib/prof-lean/elf-helper.h"
 
 
 //******************************************************************************
@@ -95,11 +109,49 @@
   }						\
 }
 
+typedef const char* (*hip_kernel_name_fnt)(const hipFunction_t f);
+static hip_kernel_name_fnt hip_kernel_name_fn;
+
+typedef int (*hiprtc_fnt)(uint64_t, void*);
+static hiprtc_fnt hiprtc_get_code;
+static hiprtc_fnt hiprtc_get_code_size;
+
+#define DEBUG 0
+
+#include "hpcrun/gpu/gpu-print.h"
+
+//******************************************************************************
+// type declaration
+//******************************************************************************
+
+typedef struct amd_kernel_internal {
+  uint64_t opaque[3];
+  uint64_t amd_program_internal;
+} amd_kernel_internal_t;
+
+typedef struct amd_hip_function {
+  amd_kernel_internal_t * amd_kernel;
+} amd_hip_function_t;
+
+typedef struct amd_gpu_binary {
+  size_t size;
+  char* buf;
+} amd_gpu_binary_t;
+
+typedef struct amd_function_table {
+  size_t size;
+  char** names;
+  uint64_t* addrs;
+} amd_function_table_t;
 
 
 //******************************************************************************
 // local variables
 //******************************************************************************
+
+amd_gpu_binary_t binary;
+amd_function_table_t function_table;
+static uint32_t amd_gpu_module_id;
 
 //----------------------------------------------------------
 // roctracer function pointers for late binding
@@ -256,7 +308,227 @@ roctracer_kernel_data_set
 }
 #endif
 
+static void
+ensure_kernel_ip_present
+(
+ cct_node_t *kernel_ph,
+ ip_normalized_t kernel_ip
+)
+{
+  // if the phaceholder was previously inserted, it will have a child
+  // we only want to insert a child if there isn't one already. if the
+  // node contains a child already, then the gpu monitoring thread
+  // may be adding children to the splay tree of children. in that case
+  // trying to add a child here (which will turn into a lookup of the
+  // previously added child, would race with any insertions by the
+  // GPU monitoring thread.
+  //
+  // INVARIANT: avoid a race modifying the splay tree of children by
+  // not attempting to insert a child in a worker thread when a child
+  // is already present
+  if (hpcrun_cct_children(kernel_ph) == NULL) {
+    cct_node_t *kernel =
+      hpcrun_cct_insert_ip_norm(kernel_ph, kernel_ip);
+    hpcrun_cct_retain(kernel);
+  }
+}
 
+static void
+construct_amd_gpu_symbols
+(
+ Elf *elf
+)
+{
+  // Initialize elf_help_t to handle extended numbering
+  elf_helper_t eh;
+  elf_helper_initialize(elf, &eh);
+
+  // Get section name section index to find ".strtab"
+  size_t shstrndx;
+  if (elf_getshdrstrndx(elf, &shstrndx) != 0) return;
+
+  // Find .symtab and .strtab sections
+  Elf_Scn *scn = NULL;
+  Elf_Scn *symtab_scn = NULL;
+  Elf_Scn *strtab_scn = NULL;
+  while ((scn = elf_nextscn(elf, scn)) != NULL) {
+    GElf_Shdr shdr;
+    if (!gelf_getshdr(scn, &shdr)) continue;
+    if (shdr.sh_type == SHT_SYMTAB) {
+      symtab_scn = scn;
+      continue;
+    }
+    char *name = elf_strptr(elf, shstrndx , shdr.sh_name);
+    if (name == NULL) continue;
+    if (strcmp(name, ".strtab") == 0) {
+      strtab_scn = scn;
+    }
+	}
+
+  // Get total number of symbols in .symtab
+  GElf_Shdr symtab;
+  gelf_getshdr(symtab_scn, &symtab);
+
+  int nsymbols = 0;
+  if (symtab.sh_entsize > 0) { // avoid divide by 0
+    nsymbols = symtab.sh_size / symtab.sh_entsize;
+    if (nsymbols <= 0) return;
+  } else {
+    return;
+  }
+
+  Elf_Data *symtab_data = elf_getdata(symtab_scn, NULL);
+  if (symtab_data == NULL) return;
+
+  // Get total number of function symbols in .symtab
+  size_t nfuncs = 0;
+  for (int i = 0; i < nsymbols; i++) {
+    GElf_Sym sym;
+    GElf_Sym *symp = NULL;
+    int section_index;
+    symp = elf_helper_get_symbol(&eh, i, &sym, &section_index);
+    if (symp) { // symbol properly read
+      int symtype = GELF_ST_TYPE(sym.st_info);
+      if (sym.st_shndx == SHN_UNDEF) continue;
+      if (symtype != STT_FUNC) continue;
+      nfuncs++;
+    }
+  }
+
+  // Get symbol name string table
+  Elf_Data *strtab_data = elf_getdata(strtab_scn, NULL);
+  if (strtab_data == NULL) return;
+  char* symbol_name_buf = (char*)(strtab_data->d_buf);
+
+  // Initialize our function table
+  function_table.size = nfuncs;
+  function_table.names = (char**)hpcrun_malloc(sizeof(char*) * function_table.size);
+  function_table.addrs = (uint64_t*)hpcrun_malloc(sizeof(uint64_t) * function_table.size);
+  int index = 0;
+
+  // Put each function symbol into our function table
+  for (int i = 0; i < nsymbols; i++) {
+    GElf_Sym sym;
+    GElf_Sym *symp = NULL;
+    int section_index;
+    symp = elf_helper_get_symbol(&eh, i, &sym, &section_index);
+    if (symp) { // symbol properly read
+      int symtype = GELF_ST_TYPE(sym.st_info);
+      if (sym.st_shndx == SHN_UNDEF) continue;
+      if (symtype != STT_FUNC) continue;
+      function_table.names[index] = symbol_name_buf + sym.st_name;
+      function_table.addrs[index] = sym.st_value;
+      ++index;
+    }
+  }
+#if DEBUG != 0
+  printf("Dump AMD GPU functions\n");
+  for (size_t i = 0; i < function_table.size; ++i) {
+    printf("Function %s, at address %lx\n", function_table.names[i], function_table.addrs[i]);
+  }
+#endif
+}
+
+static bool
+cupti_write_cubin
+(
+ const char *file_name,
+ const void *cubin,
+ size_t cubin_size
+)
+{
+  int fd;
+  errno = 0;
+  fd = open(file_name, O_WRONLY | O_CREAT | O_EXCL, 0644);
+  if (errno == EEXIST) {
+    close(fd);
+    return true;
+  }
+  if (fd >= 0) {
+    // Success
+    if (write(fd, cubin, cubin_size) != cubin_size) {
+      close(fd);
+      return false;
+    } else {
+      close(fd);
+      return true;
+    }
+  } else {
+    // Failure to open is a fatal error.
+    hpcrun_abort("hpctoolkit: unable to open file: '%s'", file_name);
+    return false;
+  }
+}
+
+static void
+parse_amd_gpu_binary
+(
+  hipFunction_t f
+)
+{
+  amd_hip_function_t* amd_hip_function = (amd_hip_function_t*)f;
+  amd_kernel_internal_t* amd_internal = amd_hip_function->amd_kernel;
+  uint64_t amd_program = amd_internal->amd_program_internal;
+  amd_program += 0x10;
+
+  hiprtc_get_code_size(amd_program, (void*)(&(binary.size)));
+  binary.buf = hpcrun_malloc(binary.size);
+  hiprtc_get_code(amd_program, (void*)(binary.buf));
+
+  elf_version(EV_CURRENT);
+  Elf *elf = elf_memory(binary.buf, binary.size);
+  if (elf != 0) {
+	  construct_amd_gpu_symbols(elf);
+	  elf_end(elf);
+  }
+
+  // Create file name
+  char file_name[PATH_MAX];  
+  size_t used = 0;
+  used += sprintf(&file_name[used], "%s", hpcrun_files_output_directory());
+  used += sprintf(&file_name[used], "%s", "/amd/");
+  mkdir(file_name, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  used += sprintf(&file_name[used], "%s", "amd_gpu_binary");
+
+  cupti_write_cubin(file_name, binary.buf, binary.size);
+
+  amd_gpu_module_id = hpcrun_loadModule_add(file_name);
+}
+
+static uintptr_t
+lookup_amd_function
+(
+  const char *kernel_name
+)
+{  
+  for (size_t i = 0; i < function_table.size; ++i) {
+    if (strcmp(kernel_name, function_table.names[i]) == 0) {
+      return (uintptr_t)(function_table.addrs[i]);
+    }
+  }
+  return 0;
+}
+
+static ip_normalized_t
+hip_function_lookup
+(
+  hipFunction_t f
+)
+{
+  // TODO: Handle multi-threaded case
+  if (binary.size == 0) {
+    parse_amd_gpu_binary(f);
+  }
+
+  const char * kernel_name = hip_kernel_name_fn(f);
+
+  ip_normalized_t nip;
+  nip.lm_id = amd_gpu_module_id;
+  nip.lm_ip = lookup_amd_function(kernel_name);
+
+  PRINT("HIP launch kernel %s, lm_ip %lx\n", kernel_name, nip.lm_ip);
+  return nip;
+}
 
 static void
 roctracer_subscriber_callback
@@ -269,6 +541,7 @@ roctracer_subscriber_callback
 {
   gpu_op_placeholder_flags_t gpu_op_placeholder_flags = 0;
   bool is_valid_op = false;
+  bool is_kernel_op = false;
   const hip_api_data_t* data = (const hip_api_data_t*)(callback_data);
 
   switch (callback_id) {
@@ -335,14 +608,14 @@ roctracer_subscriber_callback
 
   case HIP_API_ID_hipModuleLaunchKernel:
   case HIP_API_ID_hipLaunchCooperativeKernel:
-  case HIP_API_ID_hipHccModuleLaunchKernel:
+  case HIP_API_ID_hipHccModuleLaunchKernel: {
     //case HIP_API_ID_hipExtModuleLaunchKernel:
-
     gpu_op_placeholder_flags_set(&gpu_op_placeholder_flags,
 				 gpu_placeholder_type_kernel);
     is_valid_op = true;
+    is_kernel_op = true;
     break;
-
+  }
   case HIP_API_ID_hipCtxSynchronize:
   case HIP_API_ID_hipStreamSynchronize:
   case HIP_API_ID_hipDeviceSynchronize:
@@ -351,8 +624,14 @@ roctracer_subscriber_callback
 				 gpu_placeholder_type_sync);
     is_valid_op = true;
     break;
-
+  case HIP_API_ID_hipModuleGetFunction:
+    PRINT("hipModuleGetFunction %s\n", data->args.hipModuleGetFunction.kname);
+    break;
+  case HIP_API_ID_hipModuleLoad:
+    PRINT("hipMOoduleLoad %p\n", data->args.hipModuleLoad.module);
+    break;
   default:
+    PRINT("unhandled %u\n", callback_id);
     break;
   }
 
@@ -367,7 +646,15 @@ roctracer_subscriber_callback
     gpu_op_ccts_t gpu_op_ccts;
     hpcrun_safe_enter();
     gpu_op_ccts_insert(api_node, &gpu_op_ccts, gpu_op_placeholder_flags);
+    if (is_kernel_op) {
+      cct_node_t *kernel_ph = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_kernel);
+      hipFunction_t f = data->args.hipModuleLaunchKernel.f;
+      ip_normalized_t kernel_ip = hip_function_lookup(f);
+      ensure_kernel_ip_present(kernel_ph, kernel_ip);
+    }
+
     hpcrun_safe_exit();
+
 
     gpu_activity_channel_consume(gpu_metrics_attribute);
 
@@ -456,6 +743,8 @@ roctracer_bind
   // Somehow roctracter needs libkfdwrapper64.so, but does not really load it.
   // So, we load it before using any function in roctracter.
   CHK_DLOPEN(kfd, "libkfdwrapper64.so", RTLD_NOW | RTLD_GLOBAL);
+
+  CHK_DLOPEN(hip, "libamdhip64.so", RTLD_NOW | RTLD_GLOBAL);
   hpcrun_force_dlopen(false);
 
 #define ROCTRACER_BIND(fn) \
@@ -464,6 +753,24 @@ roctracer_bind
   FORALL_ROCTRACER_ROUTINES(ROCTRACER_BIND)
 
 #undef ROCTRACER_BIND
+
+  dlerror();
+  hip_kernel_name_fn = (hip_kernel_name_fnt) dlsym(hip, "hipKernelNameRef");
+  if (hip_kernel_name_fn == 0) {
+    return -1;
+  }
+
+  dlerror();
+  hiprtc_get_code = (hiprtc_fnt) dlsym(hip, "hiprtcGetCode");
+  if (hiprtc_get_code == 0) {
+    return -1;
+  }
+
+  dlerror();
+  hiprtc_get_code_size = (hiprtc_fnt) dlsym(hip, "hiprtcGetCodeSize");
+  if (hiprtc_get_code_size == 0) {
+    return -1;
+  }
 
   return 0;
 #else

--- a/src/tool/hpcrun/gpu/gpu-activity-process.c
+++ b/src/tool/hpcrun/gpu/gpu-activity-process.c
@@ -87,7 +87,7 @@
 static void
 gpu_context_stream_trace
 (
- uint32_t context_id, 
+ uint32_t context_id,
  uint32_t stream_id,
  gpu_trace_item_t *ti
 )
@@ -99,12 +99,12 @@ gpu_context_stream_trace
 static void
 gpu_context_trace
 (
- uint32_t context_id, 
+ uint32_t context_id,
  gpu_trace_item_t *ti
 )
 {
   gpu_context_id_map_context_process(context_id, gpu_trace_produce, ti);
-  
+
 }
 
 
@@ -133,7 +133,7 @@ attribute_activity
  cct_node_t *cct_node
 )
 {
-  gpu_activity_channel_t *channel = 
+  gpu_activity_channel_t *channel =
     gpu_host_correlation_map_entry_channel_get(hc);
   activity->cct_node = cct_node;
   gpu_activity_channel_produce(channel, activity);
@@ -157,13 +157,13 @@ gpu_memcpy_process
     if (host_op_entry != NULL) {
       gpu_placeholder_type_t mct;
       switch (activity->details.memcpy.copyKind) {
-        case GPU_MEMCPY_H2D: 
+        case GPU_MEMCPY_H2D:
           mct = gpu_placeholder_type_copyin;
           break;
-        case GPU_MEMCPY_D2H: 
+        case GPU_MEMCPY_D2H:
           mct = gpu_placeholder_type_copyout;
           break;
-        default: 
+        default:
           mct = gpu_placeholder_type_copy;
           break;
       }
@@ -181,7 +181,7 @@ gpu_memcpy_process
       trace_item_set(&entry_trace, activity, host_op_entry, host_op_node);
 
       gpu_context_stream_trace
-        (activity->details.memcpy.context_id, activity->details.memcpy.stream_id, 
+        (activity->details.memcpy.context_id, activity->details.memcpy.stream_id,
          &entry_trace);
 
       attribute_activity(host_op_entry, activity, host_op_node);
@@ -230,7 +230,7 @@ gpu_sample_process
     if (host_op_entry != NULL) {
       PRINT("external_id %lu\n", external_id);
 
-      bool more_samples = 
+      bool more_samples =
         gpu_host_correlation_map_samples_increase
         (external_id, sample->details.pc_sampling.samples);
 
@@ -276,9 +276,9 @@ gpu_sampling_info_process
       attribute_activity(host_op_entry, sri, host_op_node);
     }
     // sample info is the last record for a given correlation id
-    bool more_samples = 
+    bool more_samples =
       gpu_host_correlation_map_total_samples_update
-      (external_id, sri->details.pc_sampling_info.totalSamples - 
+      (external_id, sri->details.pc_sampling_info.totalSamples -
        sri->details.pc_sampling_info.droppedSamples);
     if (!more_samples) {
       gpu_correlation_id_map_delete(correlation_id);
@@ -315,15 +315,15 @@ gpu_memset_process
 )
 {
   uint32_t correlation_id = activity->details.memset.correlation_id;
-  gpu_correlation_id_map_entry_t *cid_map_entry = 
+  gpu_correlation_id_map_entry_t *cid_map_entry =
     gpu_correlation_id_map_lookup(correlation_id);
   if (cid_map_entry != NULL) {
     uint64_t external_id = gpu_correlation_id_map_entry_external_id_get(cid_map_entry);
-    gpu_host_correlation_map_entry_t *host_op_entry = 
+    gpu_host_correlation_map_entry_t *host_op_entry =
       gpu_host_correlation_map_lookup(external_id);
     if (host_op_entry != NULL) {
       cct_node_t *host_op_node =
-	gpu_host_correlation_map_entry_op_cct_get(host_op_entry, 
+	gpu_host_correlation_map_entry_op_cct_get(host_op_entry,
 						  gpu_placeholder_type_memset);
 
       gpu_trace_item_t entry_trace;
@@ -369,7 +369,7 @@ gpu_kernel_process
     gpu_correlation_id_map_lookup(correlation_id);
   if (cid_map_entry != NULL) {
     gpu_correlation_id_map_kernel_update
-      (correlation_id, activity->details.kernel.device_id, 
+      (correlation_id, activity->details.kernel.device_id,
        activity->details.interval.start, activity->details.interval.end);
 
     uint64_t external_id =
@@ -378,11 +378,18 @@ gpu_kernel_process
       gpu_host_correlation_map_lookup(external_id);
 
     if (host_op_entry != NULL) {
-      cct_node_t *func_ph = 
+      cct_node_t *func_ph =
         gpu_host_correlation_map_entry_op_cct_get(host_op_entry,
 						  gpu_placeholder_type_trace);
 
       cct_node_t *func_node = hpcrun_cct_children(func_ph); // only child
+
+      if (func_node == NULL) {
+        func_ph = gpu_host_correlation_map_entry_op_cct_get(host_op_entry,
+						  gpu_placeholder_type_kernel);
+        func_node = hpcrun_cct_children(func_ph);
+      }
+
       if (func_node == NULL) {
 	// in case placeholder doesn't have a child
         func_node = func_ph;
@@ -395,7 +402,7 @@ gpu_kernel_process
         (activity->details.kernel.context_id, activity->details.kernel.stream_id,
          &entry_trace);
 
-      cct_node_t *kernel_ph = 
+      cct_node_t *kernel_ph =
         gpu_host_correlation_map_entry_op_cct_get(host_op_entry,
 						  gpu_placeholder_type_kernel);
 
@@ -436,7 +443,7 @@ gpu_synchronization_process
       gpu_host_correlation_map_lookup(external_id);
     if (host_op_entry != NULL) {
       cct_node_t *host_op_node =
-        gpu_host_correlation_map_entry_op_cct_get(host_op_entry, 
+        gpu_host_correlation_map_entry_op_cct_get(host_op_entry,
           gpu_placeholder_type_sync);
 
       attribute_activity(host_op_entry, activity, host_op_node);
@@ -454,7 +461,7 @@ gpu_synchronization_process
           case GPU_SYNC_STREAM_EVENT_WAIT:
             // Insert a event for a specific stream
             PRINT("Add context %u stream %u sync\n", context_id, stream_id);
-            gpu_context_stream_trace(context_id, stream_id, &entry_trace); 
+            gpu_context_stream_trace(context_id, stream_id, &entry_trace);
             break;
           case GPU_SYNC_CONTEXT:
             // Insert events for all current active streams
@@ -464,13 +471,13 @@ gpu_synchronization_process
             break;
           case GPU_SYNC_EVENT:
             {
-              // Find the corresponding stream that records the event 
+              // Find the corresponding stream that records the event
               gpu_event_id_map_entry_t *event_id_entry = gpu_event_id_map_lookup(event_id);
               if (event_id_entry != NULL) {
                 context_id = gpu_event_id_map_entry_context_id_get(event_id_entry);
                 stream_id = gpu_event_id_map_entry_stream_id_get(event_id_entry);
                 PRINT("Add context %u stream %u event %u sync\n", context_id, stream_id, event_id);
-                gpu_context_stream_trace(context_id, stream_id, &entry_trace); 
+                gpu_context_stream_trace(context_id, stream_id, &entry_trace);
               }
               break;
             }
@@ -558,17 +565,17 @@ gpu_instruction_process
 )
 {
   uint32_t correlation_id = activity->details.instruction.correlation_id;
-  ip_normalized_t pc = activity->details.instruction.pc;    
+  ip_normalized_t pc = activity->details.instruction.pc;
   gpu_correlation_id_map_entry_t *cid_map_entry =
     gpu_correlation_id_map_lookup(correlation_id);
   if (cid_map_entry != NULL) {
     uint64_t external_id =
       gpu_correlation_id_map_entry_external_id_get(cid_map_entry);
     PRINT("external_id %lu\n", external_id);
-    gpu_host_correlation_map_entry_t *host_op_entry = 
+    gpu_host_correlation_map_entry_t *host_op_entry =
       gpu_host_correlation_map_lookup(external_id);
     if (host_op_entry != NULL) {
-      cct_node_t *func_ph = 
+      cct_node_t *func_ph =
         gpu_host_correlation_map_entry_op_function_get(host_op_entry);
 
       cct_node_t *func_ins = hpcrun_cct_insert_ip_norm(func_ph, pc);
@@ -599,7 +606,7 @@ gpu_activity_process
     gpu_sampling_info_process(ga);
     break;
 
-  case GPU_ACTIVITY_EXTERNAL_CORRELATION: 
+  case GPU_ACTIVITY_EXTERNAL_CORRELATION:
     gpu_correlation_process(ga);
     break;
 

--- a/src/tool/hpcrun/gpu/gpu-activity-process.c
+++ b/src/tool/hpcrun/gpu/gpu-activity-process.c
@@ -385,12 +385,6 @@ gpu_kernel_process
       cct_node_t *func_node = hpcrun_cct_children(func_ph); // only child
 
       if (func_node == NULL) {
-        func_ph = gpu_host_correlation_map_entry_op_cct_get(host_op_entry,
-						  gpu_placeholder_type_kernel);
-        func_node = hpcrun_cct_children(func_ph);
-      }
-
-      if (func_node == NULL) {
 	// in case placeholder doesn't have a child
         func_node = func_ph;
       }

--- a/src/tool/hpcrun/module-ignore-map.c
+++ b/src/tool/hpcrun/module-ignore-map.c
@@ -102,7 +102,7 @@
 #define PRINT(...)
 #endif
 
-#define NUM_FNS 3
+#define NUM_FNS 6
 
 
 
@@ -121,8 +121,13 @@ typedef struct module_ignore_entry {
 // static data
 //***************************************************************************
 
-static const char *NVIDIA_FNS[NUM_FNS] = {
-  "cuLaunchKernel", "cudaLaunchKernel", "cuptiActivityEnable"
+static const char *IGNORE_FNS[NUM_FNS] = {
+  "cuLaunchKernel",
+  "cudaLaunchKernel",
+  "cuptiActivityEnable",
+  "roctracer_set_properties",  // amd roctracer library
+  "amd_dbgapi_initialize",     // amd debug library
+  "hipKernelNameRefByPtr",     // amd hip runtime
 };
 static module_ignore_entry_t modules[NUM_FNS];
 static pfq_rwlock_t modules_lock;
@@ -259,7 +264,7 @@ serach_functions_in_module(Elf *e, GElf_Shdr* secHead, Elf_Scn *section)
     // We need to find functions defined in the module.
     if ( (symType == STT_FUNC) && (symBind == STB_GLOBAL) && (curSym.st_value != 0)) {
       for (i = 0; i < NUM_FNS; ++i) {
-        if (modules[i].empty && (strcmp(symName, NVIDIA_FNS[i]) == 0)) {
+        if (modules[i].empty && (strcmp(symName, IGNORE_FNS[i]) == 0)) {
           return i;          
         }
       }

--- a/src/tool/hpcrun/module-ignore-map.c
+++ b/src/tool/hpcrun/module-ignore-map.c
@@ -52,8 +52,8 @@
 // Purpose:
 //   implementation of a map of load modules that should be omitted
 //   from call paths for synchronous samples
-//   
-//  
+//
+//
 //***************************************************************************
 
 //***************************************************************************
@@ -81,7 +81,7 @@
 // local includes
 //***************************************************************************
 
-#include <monitor.h>  
+#include <monitor.h>
 
 #include <lib/prof-lean/pfq-rwlock.h>
 #include <hpcrun/loadmap.h>
@@ -101,6 +101,12 @@
 #else
 #define PRINT(...)
 #endif
+
+// TODO:
+// We will need to refactor this code to make the NUM_FNS a variable
+// and the table of functions to be looked up can be a linked list,
+// where any GPU can indicate that its functions should be added to
+// the module ignore map when that type of GPU is being monitored.
 
 #define NUM_FNS 6
 
@@ -150,7 +156,7 @@ pseudo_module_p
     // because we store [vdso] in hpctooolkit's measurement directory,
     // it actually has the name /path/to/measurement/directory/[vdso].
     // checking the last character tells us it is a virtual shared library.
-    return lastchar == ']'; 
+    return lastchar == ']';
 }
 
 
@@ -202,7 +208,7 @@ module_ignore_map_module_lookup
  load_module_t *module
 )
 {
-  return module_ignore_map_lookup(module->dso_info->start_addr, 
+  return module_ignore_map_lookup(module->dso_info->start_addr,
 				  module->dso_info->end_addr);
 }
 
@@ -220,7 +226,7 @@ module_ignore_map_inrange_lookup
 bool
 module_ignore_map_lookup
 (
- void *start, 
+ void *start,
  void *end
 )
 {
@@ -247,10 +253,10 @@ serach_functions_in_module(Elf *e, GElf_Shdr* secHead, Elf_Scn *section)
   Elf_Data *data;
   char *symName;
   uint64_t count;
-  GElf_Sym curSym;  
+  GElf_Sym curSym;
   uint64_t i, ii,symType, symBind;
   // char *marmite;
-  
+
   data = elf_getdata(section, NULL);           // use it to get the data
   if (data == NULL || secHead->sh_entsize == 0) return -1;
   count = (secHead->sh_size)/(secHead->sh_entsize);
@@ -265,7 +271,7 @@ serach_functions_in_module(Elf *e, GElf_Shdr* secHead, Elf_Scn *section)
     if ( (symType == STT_FUNC) && (symBind == STB_GLOBAL) && (curSym.st_value != 0)) {
       for (i = 0; i < NUM_FNS; ++i) {
         if (modules[i].empty && (strcmp(symName, IGNORE_FNS[i]) == 0)) {
-          return i;          
+          return i;
         }
       }
     }
@@ -281,7 +287,7 @@ module_ignore_map_ignore
 {
   // Update path
   // Only one thread could update the flag,
-  // Guarantee dlopen modules before notification are updated.  
+  // Guarantee dlopen modules before notification are updated.
   bool result = false;
   pfq_rwlock_node_t me;
   pfq_rwlock_write_lock(&modules_lock, &me);

--- a/src/tool/hpcrun/sample-sources/amd.c
+++ b/src/tool/hpcrun/sample-sources/amd.c
@@ -43,6 +43,7 @@
 #include <hpcrun/gpu/amd/roctracer-api.h>
 #include <hpcrun/gpu/gpu-activity.h>
 #include <hpcrun/gpu/gpu-metrics.h>
+#include <hpcrun/gpu/gpu-trace.h>
 #include <hpcrun/hpcrun_options.h>
 #include <hpcrun/hpcrun_stats.h>
 #include <hpcrun/metrics.h>
@@ -69,6 +70,8 @@
 #define AMD_ROCM "gpu=amd"
 
 static device_finalizer_fn_entry_t device_finalizer_shutdown;
+static device_finalizer_fn_entry_t device_trace_finalizer_shutdown;
+
 
 //******************************************************************************
 // interface operations
@@ -163,11 +166,16 @@ METHOD_FN(finalize_event_list)
     char* event = start_tok(evlist);
 #endif
     roctracer_init();
-    
+
+    // Init records
+    gpu_trace_init();
+
     device_finalizer_shutdown.fn = roctracer_fini;
     device_finalizer_register(device_finalizer_type_shutdown, &device_finalizer_shutdown);
 
-
+    // Register shutdown functions to write trace files
+    device_trace_finalizer_shutdown.fn = gpu_trace_fini;
+    device_finalizer_register(device_finalizer_type_shutdown, &device_trace_finalizer_shutdown);
 }
 
 


### PR DESCRIPTION
1. Update the use of roctracer to reflect API changes from rocm 2.x
2. Use AMD debug library to query binary URI and extract AMD GPU binary
3. Ignore monitoring threads created by AMD libraries