### PR TITLE
L0 refactor

### DIFF
--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -536,8 +536,7 @@ MY_LEVEL0_FILES=\
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c \
 	gpu/level0/level0-event-map.c \
-	gpu/level0/level0-handle-map.c \
-	gpu/level0/level0-intercept.c
+	gpu/level0/level0-handle-map.c
 endif
 
 MY_UPC_FILES = sample-sources/upc.c

--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -532,6 +532,7 @@ if OPT_ENABLE_LEVEL0
 MY_LEVEL0_FILES=\
 	sample-sources/level0.c \
 	gpu/level0/level0-api.c \
+	gpu/level0/level0-command-list-context-map.c \
 	gpu/level0/level0-command-list-map.c \
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c \

--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -536,7 +536,8 @@ MY_LEVEL0_FILES=\
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c \
 	gpu/level0/level0-event-map.c \
-	gpu/level0/level0-handle-map.c
+	gpu/level0/level0-handle-map.c \
+	gpu/level0/level0-intercept.c
 endif
 
 MY_UPC_FILES = sample-sources/upc.c

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -553,11 +553,11 @@ am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	gpu/level0/level0-api.c gpu/level0/level0-command-list-map.c \
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c gpu/level0/level0-event-map.c \
-	gpu/level0/level0-handle-map.c unwind/common/backtrace.c \
-	unwind/common/unw-throw.c unwind/common/binarytree_uwi.c \
-	unwind/common/interval_t.c unwind/common/libunw_intervals.c \
-	unwind/common/stack_troll.c unwind/common/uw_hash.c \
-	unwind/common/uw_recipe_map.c \
+	gpu/level0/level0-handle-map.c gpu/level0/level0-intercept.c \
+	unwind/common/backtrace.c unwind/common/unw-throw.c \
+	unwind/common/binarytree_uwi.c unwind/common/interval_t.c \
+	unwind/common/libunw_intervals.c unwind/common/stack_troll.c \
+	unwind/common/uw_hash.c unwind/common/uw_recipe_map.c \
 	unwind/generic-libunwind/libunw-unwind.c \
 	unwind/ppc64/ppc64-unwind.c \
 	unwind/ppc64/ppc64-unwind-interval.c \
@@ -758,7 +758,8 @@ am__objects_36 =
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-command-process.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-data-node.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-event-map.lo \
-@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-handle-map.lo
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-handle-map.lo \
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-intercept.lo
 @OPT_ENABLE_LEVEL0_TRUE@am__objects_40 = $(am__objects_39)
 am__objects_41 = unwind/common/libhpcrun_la-backtrace.lo \
 	unwind/common/libhpcrun_la-unw-throw.lo
@@ -1904,7 +1905,8 @@ MY_AARCH64_FILES = \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-command-process.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-data-node.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-event-map.c \
-@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-handle-map.c
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-handle-map.c \
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-intercept.c
 
 MY_UPC_FILES = sample-sources/upc.c
 MY_INCLUDE_DIRS = \
@@ -2868,6 +2870,9 @@ gpu/level0/libhpcrun_la-level0-event-map.lo:  \
 gpu/level0/libhpcrun_la-level0-handle-map.lo:  \
 	gpu/level0/$(am__dirstamp) \
 	gpu/level0/$(DEPDIR)/$(am__dirstamp)
+gpu/level0/libhpcrun_la-level0-intercept.lo:  \
+	gpu/level0/$(am__dirstamp) \
+	gpu/level0/$(DEPDIR)/$(am__dirstamp)
 unwind/common/libhpcrun_la-backtrace.lo:  \
 	unwind/common/$(am__dirstamp) \
 	unwind/common/$(DEPDIR)/$(am__dirstamp)
@@ -3800,6 +3805,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-data-node.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-event-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-handle-map.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/nvidia/$(DEPDIR)/libhpcrun_la-cubin-hash-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/nvidia/$(DEPDIR)/libhpcrun_la-cubin-id-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/nvidia/$(DEPDIR)/libhpcrun_la-cubin-symbols.Plo@am__quote@
@@ -5483,6 +5489,13 @@ gpu/level0/libhpcrun_la-level0-handle-map.lo: gpu/level0/level0-handle-map.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-handle-map.c' object='gpu/level0/libhpcrun_la-level0-handle-map.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-handle-map.lo `test -f 'gpu/level0/level0-handle-map.c' || echo '$(srcdir)/'`gpu/level0/level0-handle-map.c
+
+gpu/level0/libhpcrun_la-level0-intercept.lo: gpu/level0/level0-intercept.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/level0/libhpcrun_la-level0-intercept.lo -MD -MP -MF gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Tpo -c -o gpu/level0/libhpcrun_la-level0-intercept.lo `test -f 'gpu/level0/level0-intercept.c' || echo '$(srcdir)/'`gpu/level0/level0-intercept.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Tpo gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-intercept.c' object='gpu/level0/libhpcrun_la-level0-intercept.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-intercept.lo `test -f 'gpu/level0/level0-intercept.c' || echo '$(srcdir)/'`gpu/level0/level0-intercept.c
 
 unwind/common/libhpcrun_la-backtrace.lo: unwind/common/backtrace.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT unwind/common/libhpcrun_la-backtrace.lo -MD -MP -MF unwind/common/$(DEPDIR)/libhpcrun_la-backtrace.Tpo -c -o unwind/common/libhpcrun_la-backtrace.lo `test -f 'unwind/common/backtrace.c' || echo '$(srcdir)/'`unwind/common/backtrace.c

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -553,11 +553,11 @@ am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	gpu/level0/level0-api.c gpu/level0/level0-command-list-map.c \
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c gpu/level0/level0-event-map.c \
-	gpu/level0/level0-handle-map.c gpu/level0/level0-intercept.c \
-	unwind/common/backtrace.c unwind/common/unw-throw.c \
-	unwind/common/binarytree_uwi.c unwind/common/interval_t.c \
-	unwind/common/libunw_intervals.c unwind/common/stack_troll.c \
-	unwind/common/uw_hash.c unwind/common/uw_recipe_map.c \
+	gpu/level0/level0-handle-map.c unwind/common/backtrace.c \
+	unwind/common/unw-throw.c unwind/common/binarytree_uwi.c \
+	unwind/common/interval_t.c unwind/common/libunw_intervals.c \
+	unwind/common/stack_troll.c unwind/common/uw_hash.c \
+	unwind/common/uw_recipe_map.c \
 	unwind/generic-libunwind/libunw-unwind.c \
 	unwind/ppc64/ppc64-unwind.c \
 	unwind/ppc64/ppc64-unwind-interval.c \
@@ -758,8 +758,7 @@ am__objects_36 =
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-command-process.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-data-node.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-event-map.lo \
-@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-handle-map.lo \
-@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-intercept.lo
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-handle-map.lo
 @OPT_ENABLE_LEVEL0_TRUE@am__objects_40 = $(am__objects_39)
 am__objects_41 = unwind/common/libhpcrun_la-backtrace.lo \
 	unwind/common/libhpcrun_la-unw-throw.lo
@@ -1905,8 +1904,7 @@ MY_AARCH64_FILES = \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-command-process.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-data-node.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-event-map.c \
-@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-handle-map.c \
-@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-intercept.c
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-handle-map.c
 
 MY_UPC_FILES = sample-sources/upc.c
 MY_INCLUDE_DIRS = \
@@ -2870,9 +2868,6 @@ gpu/level0/libhpcrun_la-level0-event-map.lo:  \
 gpu/level0/libhpcrun_la-level0-handle-map.lo:  \
 	gpu/level0/$(am__dirstamp) \
 	gpu/level0/$(DEPDIR)/$(am__dirstamp)
-gpu/level0/libhpcrun_la-level0-intercept.lo:  \
-	gpu/level0/$(am__dirstamp) \
-	gpu/level0/$(DEPDIR)/$(am__dirstamp)
 unwind/common/libhpcrun_la-backtrace.lo:  \
 	unwind/common/$(am__dirstamp) \
 	unwind/common/$(DEPDIR)/$(am__dirstamp)
@@ -3805,7 +3800,6 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-data-node.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-event-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-handle-map.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/nvidia/$(DEPDIR)/libhpcrun_la-cubin-hash-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/nvidia/$(DEPDIR)/libhpcrun_la-cubin-id-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/nvidia/$(DEPDIR)/libhpcrun_la-cubin-symbols.Plo@am__quote@
@@ -5489,13 +5483,6 @@ gpu/level0/libhpcrun_la-level0-handle-map.lo: gpu/level0/level0-handle-map.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-handle-map.c' object='gpu/level0/libhpcrun_la-level0-handle-map.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-handle-map.lo `test -f 'gpu/level0/level0-handle-map.c' || echo '$(srcdir)/'`gpu/level0/level0-handle-map.c
-
-gpu/level0/libhpcrun_la-level0-intercept.lo: gpu/level0/level0-intercept.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/level0/libhpcrun_la-level0-intercept.lo -MD -MP -MF gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Tpo -c -o gpu/level0/libhpcrun_la-level0-intercept.lo `test -f 'gpu/level0/level0-intercept.c' || echo '$(srcdir)/'`gpu/level0/level0-intercept.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Tpo gpu/level0/$(DEPDIR)/libhpcrun_la-level0-intercept.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-intercept.c' object='gpu/level0/libhpcrun_la-level0-intercept.lo' libtool=yes @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-intercept.lo `test -f 'gpu/level0/level0-intercept.c' || echo '$(srcdir)/'`gpu/level0/level0-intercept.c
 
 unwind/common/libhpcrun_la-backtrace.lo: unwind/common/backtrace.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT unwind/common/libhpcrun_la-backtrace.lo -MD -MP -MF unwind/common/$(DEPDIR)/libhpcrun_la-backtrace.Tpo -c -o unwind/common/libhpcrun_la-backtrace.lo `test -f 'unwind/common/backtrace.c' || echo '$(srcdir)/'`unwind/common/backtrace.c

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -550,7 +550,9 @@ am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	sample-sources/amd.c gpu/amd/roctracer-activity-translate.c \
 	gpu/amd/roctracer-api.c gpu/amd/rocm-debug-api.c \
 	gpu/amd/rocm-binary-processing.c sample-sources/level0.c \
-	gpu/level0/level0-api.c gpu/level0/level0-command-list-map.c \
+	gpu/level0/level0-api.c \
+	gpu/level0/level0-command-list-context-map.c \
+	gpu/level0/level0-command-list-map.c \
 	gpu/level0/level0-command-process.c \
 	gpu/level0/level0-data-node.c gpu/level0/level0-event-map.c \
 	gpu/level0/level0-handle-map.c unwind/common/backtrace.c \
@@ -754,6 +756,7 @@ am__objects_36 =
 @OPT_ENABLE_LEVEL0_TRUE@am__objects_39 =  \
 @OPT_ENABLE_LEVEL0_TRUE@	sample-sources/libhpcrun_la-level0.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-api.lo \
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-command-list-context-map.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-command-list-map.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-command-process.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-data-node.lo \
@@ -1900,6 +1903,7 @@ MY_AARCH64_FILES = \
 @OPT_ENABLE_LEVEL0_TRUE@MY_LEVEL0_FILES = \
 @OPT_ENABLE_LEVEL0_TRUE@	sample-sources/level0.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-api.c \
+@OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-command-list-context-map.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-command-list-map.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-command-process.c \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/level0-data-node.c \
@@ -2853,6 +2857,9 @@ gpu/level0/$(DEPDIR)/$(am__dirstamp):
 	@: > gpu/level0/$(DEPDIR)/$(am__dirstamp)
 gpu/level0/libhpcrun_la-level0-api.lo: gpu/level0/$(am__dirstamp) \
 	gpu/level0/$(DEPDIR)/$(am__dirstamp)
+gpu/level0/libhpcrun_la-level0-command-list-context-map.lo:  \
+	gpu/level0/$(am__dirstamp) \
+	gpu/level0/$(DEPDIR)/$(am__dirstamp)
 gpu/level0/libhpcrun_la-level0-command-list-map.lo:  \
 	gpu/level0/$(am__dirstamp) \
 	gpu/level0/$(DEPDIR)/$(am__dirstamp)
@@ -3795,6 +3802,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/amd/$(DEPDIR)/libhpcrun_la-roctracer-activity-translate.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/amd/$(DEPDIR)/libhpcrun_la-roctracer-api.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-api.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-command-list-context-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-command-list-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-command-process.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/level0/$(DEPDIR)/libhpcrun_la-level0-data-node.Plo@am__quote@
@@ -5448,6 +5456,13 @@ gpu/level0/libhpcrun_la-level0-api.lo: gpu/level0/level0-api.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-api.c' object='gpu/level0/libhpcrun_la-level0-api.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-api.lo `test -f 'gpu/level0/level0-api.c' || echo '$(srcdir)/'`gpu/level0/level0-api.c
+
+gpu/level0/libhpcrun_la-level0-command-list-context-map.lo: gpu/level0/level0-command-list-context-map.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/level0/libhpcrun_la-level0-command-list-context-map.lo -MD -MP -MF gpu/level0/$(DEPDIR)/libhpcrun_la-level0-command-list-context-map.Tpo -c -o gpu/level0/libhpcrun_la-level0-command-list-context-map.lo `test -f 'gpu/level0/level0-command-list-context-map.c' || echo '$(srcdir)/'`gpu/level0/level0-command-list-context-map.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/level0/$(DEPDIR)/libhpcrun_la-level0-command-list-context-map.Tpo gpu/level0/$(DEPDIR)/libhpcrun_la-level0-command-list-context-map.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/level0/level0-command-list-context-map.c' object='gpu/level0/libhpcrun_la-level0-command-list-context-map.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o gpu/level0/libhpcrun_la-level0-command-list-context-map.lo `test -f 'gpu/level0/level0-command-list-context-map.c' || echo '$(srcdir)/'`gpu/level0/level0-command-list-context-map.c
 
 gpu/level0/libhpcrun_la-level0-command-list-map.lo: gpu/level0/level0-command-list-map.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT gpu/level0/libhpcrun_la-level0-command-list-map.lo -MD -MP -MF gpu/level0/$(DEPDIR)/libhpcrun_la-level0-command-list-map.Tpo -c -o gpu/level0/libhpcrun_la-level0-command-list-map.lo `test -f 'gpu/level0/level0-command-list-map.c' || echo '$(srcdir)/'`gpu/level0/level0-command-list-map.c

--- a/src/tool/hpcrun/gpu/level0/level0-api.c
+++ b/src/tool/hpcrun/gpu/level0/level0-api.c
@@ -58,6 +58,7 @@
 #include "level0-event-map.h"
 #include "level0-command-process.h"
 #include "level0-data-node.h"
+#include "level0-intercept.h"
 
 #include <hpcrun/main.h>
 #include <hpcrun/memory/hpcrun-malloc.h>
@@ -66,26 +67,19 @@
 #include <hpcrun/gpu/gpu-application-thread-api.h>
 
 #include <level_zero/ze_api.h>
-#include <level_zero/zet_api.h>
 
 //******************************************************************************
 // macros
 //******************************************************************************
-#define DEBUG 0
+#define DEBUG 1
 
 #include "hpcrun/gpu/gpu-print.h"
 
 #define FORALL_LEVEL0_ROUTINES(macro)			\
   macro(zeInit)   \
-  macro(zetInit)  \
   macro(zeDriverGet)  \
   macro(zeDeviceGet) \
   macro(zeDeviceGetProperties)   \
-  macro(zetTracerCreate) \
-  macro(zetTracerSetPrologues) \
-  macro(zetTracerSetEpilogues) \
-  macro(zetTracerSetEnabled) \
-  macro(zetTracerDestroy) \
   macro(zeEventCreate) \
   macro(zeEventDestroy) \
   macro(zeEventPoolCreate) \
@@ -106,10 +100,9 @@
 // local variables
 //******************************************************************************
 
-// Assume one driver, one device, and one tracer.
+// Assume one driver and one device.
 ze_driver_handle_t hDriver = NULL;
 ze_device_handle_t hDevice = NULL;
-zet_tracer_handle_t hTracer = NULL;
 
 //----------------------------------------------------------
 // level0 function pointers for late binding
@@ -118,14 +111,6 @@ zet_tracer_handle_t hTracer = NULL;
 LEVEL0_FN
 (
  zeInit,
- (
-  ze_init_flag_t
- )
-);
-
-LEVEL0_FN
-(
- zetInit,
  (
   ze_init_flag_t
  )
@@ -156,51 +141,6 @@ LEVEL0_FN
  (
   ze_device_handle_t,
   ze_device_properties_t*
- )
-);
-
-LEVEL0_FN
-(
- zetTracerCreate,
- (
-  zet_driver_handle_t,
-  const zet_tracer_desc_t*,
-  zet_tracer_handle_t*
- )
-);
-
-LEVEL0_FN
-(
- zetTracerSetPrologues,
- (
-  zet_tracer_handle_t,
-  zet_core_callbacks_t*
- )
-);
-
-LEVEL0_FN
-(
- zetTracerSetEpilogues,
- (
-  zet_tracer_handle_t,
-  zet_core_callbacks_t*
- )
-);
-
-LEVEL0_FN
-(
- zetTracerSetEnabled,
- (
-  zet_tracer_handle_t,
-  ze_bool_t
- )
-);
-
-LEVEL0_FN
-(
- zetTracerDestroy,
- (
-  zet_tracer_handle_t
  )
 );
 
@@ -298,70 +238,110 @@ get_gpu_driver_and_device
 
   ze_driver_handle_t* allDrivers = (ze_driver_handle_t*)hpcrun_malloc_safe(driverCount * sizeof(ze_driver_handle_t));
   HPCRUN_LEVEL0_CALL(zeDriverGet, (&driverCount, allDrivers));
+  PRINT("Get %d driver handles\n", driverCount);
 
   // Find a driver instance with a GPU device
   for(i = 0; i < driverCount; ++i) {
-      uint32_t deviceCount = 0;
-      HPCRUN_LEVEL0_CALL(zeDeviceGet, (allDrivers[i], &deviceCount, NULL));
+    uint32_t deviceCount = 0;
+    HPCRUN_LEVEL0_CALL(zeDeviceGet, (allDrivers[i], &deviceCount, NULL));
+    PRINT("\tGet %d device handles\n", deviceCount);
 
-      ze_device_handle_t* allDevices = (ze_device_handle_t*)hpcrun_malloc_safe(deviceCount * sizeof(ze_device_handle_t));
-      HPCRUN_LEVEL0_CALL(zeDeviceGet, (allDrivers[i], &deviceCount, allDevices));
+    ze_device_handle_t* allDevices = (ze_device_handle_t*)hpcrun_malloc_safe(deviceCount * sizeof(ze_device_handle_t));
+    HPCRUN_LEVEL0_CALL(zeDeviceGet, (allDrivers[i], &deviceCount, allDevices));
 
-      for(d = 0; d < deviceCount; ++d) {
-          ze_device_properties_t device_properties;
-          HPCRUN_LEVEL0_CALL(zeDeviceGetProperties, (allDevices[d], &device_properties));
-          if(ZE_DEVICE_TYPE_GPU == device_properties.type) {
-              hDriver = allDrivers[i];
-              hDevice = allDevices[d];
-              break;
-          }
+    for(d = 0; d < deviceCount; ++d) {
+      ze_device_properties_t device_properties;
+      HPCRUN_LEVEL0_CALL(zeDeviceGetProperties, (allDevices[d], &device_properties));
+      if(ZE_DEVICE_TYPE_GPU == device_properties.type) {
+        hDriver = allDrivers[i];
+        hDevice = allDevices[d];
+        break;
       }
-      if(NULL != hDriver) {
-          break;
-      }
+    }
+    if(NULL != hDriver) {
+      break;
+    }
   }
 
   if(NULL == hDevice) {
-      fprintf(stderr, "NO GPU Device found\n");
-      exit(0);
+    fprintf(stderr, "NO GPU Device found\n");
+    exit(0);
   }
 }
 
-static void
-level0_event_pool_create_entry
+//******************************************************************************
+// interface operations
+//******************************************************************************
+
+int
+level0_bind
 (
-  ze_event_pool_create_params_t *params,
-  ze_result_t result,
-  void *global_data,
-  void **instance_data
+ void
 )
 {
-  const ze_event_pool_desc_t* desc = *(params->pdesc);
-  if (desc == NULL) {
-    // Based on Level 0 header file,
-    // zeEventPoolCreate will return ZE_RESULT_ERROR_INVALID_NULL_POINTER for this caes.
-    // Therefore, we do nothing in this case.
-    return;
-  }
+#ifndef HPCRUN_STATIC_LINK
+  // dynamic libraries only availabile in non-static case
+  hpcrun_force_dlopen(true);
+  CHK_DLOPEN(level0, level0_path(), RTLD_NOW | RTLD_GLOBAL);
+  hpcrun_force_dlopen(false);
 
-  // Here we need to allocate a new event pool descriptor
-  // as we cannot directly change the passed in object (declared ad const)
-  // This leads to one description per event pool creation.
-  ze_event_pool_desc_t* pool_desc = (ze_event_pool_desc_t*) hpcrun_malloc_safe(sizeof(ze_event_pool_desc_t));
-  pool_desc->version = desc->version;
-  pool_desc->flags = desc->flags;
-  pool_desc->count = desc->count;
+#define LEVEL0_BIND(fn) \
+  CHK_DLSYM(level0, fn);
 
-  // We attach the time stamp flag to the event pool,
-  // so that we can query time stamps for events in this pool.
-  int flags = pool_desc->flags | ZE_EVENT_POOL_FLAG_TIMESTAMP;
-  pool_desc->flags = (ze_event_pool_flag_t)(flags);
-  *(params->pdesc) = pool_desc;
+  FORALL_LEVEL0_ROUTINES(LEVEL0_BIND)
 
+#undef LEVEL0_BIND
+
+  return 0;
+#else
+  return -1;
+#endif // ! HPCRUN_STATIC_LINK
 }
 
-static void
-attribute_event
+void
+level0_init
+(
+ void
+)
+{
+  level0_intercept_setup();
+  HPCRUN_LEVEL0_CALL(zeInit,(ZE_INIT_FLAG_NONE));
+  get_gpu_driver_and_device();
+}
+
+void
+level0_fini
+(
+ void* args
+)
+{
+  gpu_application_thread_process_activities();
+  level0_intercept_teardown();
+}
+
+void
+level0_create_new_event
+(
+  ze_event_handle_t* event_ptr,
+  ze_event_pool_handle_t* event_pool_ptr
+)
+{
+  ze_event_pool_desc_t event_pool_desc = {
+    ZE_EVENT_POOL_DESC_VERSION_CURRENT,
+    ZE_EVENT_POOL_FLAG_TIMESTAMP,
+    1 };
+  HPCRUN_LEVEL0_CALL(zeEventPoolCreate, (hDriver, &event_pool_desc, 1, &hDevice, event_pool_ptr));
+
+  ze_event_desc_t event_desc = {
+    ZE_EVENT_DESC_VERSION_CURRENT,
+    0,
+    ZE_EVENT_SCOPE_FLAG_HOST,
+    ZE_EVENT_SCOPE_FLAG_HOST };
+  HPCRUN_LEVEL0_CALL(zeEventCreate, (*event_pool_ptr, &event_desc, event_ptr));
+}
+
+void
+level0_attribute_event
 (
   ze_event_handle_t event
 )
@@ -397,404 +377,24 @@ attribute_event
   level0_event_map_delete(event);
 }
 
-static void
-level0_event_destroy_entry
+void
+level0_get_memory_types
 (
-  ze_event_destroy_params_t *params,
-  ze_result_t result,
-  void *global_data,
-  void **instance_data
+  const void* src_ptr,
+  const void* dest_ptr,
+  ze_memory_type_t *src_type_ptr,
+  ze_memory_type_t *dst_type_ptr
 )
 {
-  attribute_event(*(params->phEvent));
-}
-
-static void
-level0_event_host_reset_entry
-(
-  ze_event_host_reset_params_t *params,
-  ze_result_t result,
-  void *global_data,
-  void **instance_data
-)
-{
-  attribute_event(*(params->phEvent));
-}
-
-static void
-create_new_event
-(
-  ze_event_handle_t* event_ptr,
-  ze_event_pool_handle_t* event_pool_ptr
-)
-{
-  ze_event_pool_desc_t event_pool_desc = {
-    ZE_EVENT_POOL_DESC_VERSION_CURRENT,
-    ZE_EVENT_POOL_FLAG_TIMESTAMP,
-    1 };
-  HPCRUN_LEVEL0_CALL(zeEventPoolCreate, (hDriver, &event_pool_desc, 1, &hDevice, event_pool_ptr));
-
-  ze_event_desc_t event_desc = {
-    ZE_EVENT_DESC_VERSION_CURRENT,
-    0,
-    ZE_EVENT_SCOPE_FLAG_HOST,
-    ZE_EVENT_SCOPE_FLAG_HOST };
-  HPCRUN_LEVEL0_CALL(zeEventCreate, (*event_pool_ptr, &event_desc, event_ptr));
-}
-
-static void
-level0_command_list_append_launch_kernel_entry
-(
-  ze_command_list_append_launch_kernel_params_t* params,
-  ze_result_t result,
-  void* global_data,
-  void** instance_data
-)
-{
-  ze_kernel_handle_t kernel = *(params->phKernel);
-  ze_command_list_handle_t command_list = *(params->phCommandList);
-  ze_event_handle_t event = *(params->phSignalEvent);
-  ze_event_pool_handle_t event_pool = NULL;
-
-  if (event == NULL) {
-    // If the kernel is launched without an event,
-    // we create a new event for collecting time stamps
-    create_new_event(&event, &event_pool);
-    *(params->phSignalEvent) = event;
-  }
-
-  PRINT("level0_command_list_append_launch_kernel_entry: kernel handle %p, commmand list handle %p, event handle %p, event pool handle %p\n",
-    (void*)kernel, (void*)command_list, (void*)event, (void*)event_pool);
-
-  // Lookup the command list and append the kernel launch to the command list
-  level0_data_node_t ** command_list_data_head = level0_commandlist_map_lookup(command_list);
-  if (command_list_data_head != NULL) {
-    level0_data_node_t * data_for_kernel = level0_commandlist_append_kernel(command_list_data_head, kernel, event, event_pool);
-    // Associate the data entry with the event
-    level0_event_map_insert(event, data_for_kernel);
-  } else {
-    // Cannot find command list.
-    // This means we are dealing with an immediate command list
-    level0_data_node_t * data_for_kernel = level0_commandlist_alloc_kernel(kernel, event, event_pool);;
-    // Associate the data entry with the event
-    level0_event_map_insert(event, data_for_kernel);
-    // For immediate command list, the kernel is dispatched to GPU at this point.
-    // So, we attribute GPU metrics to the current CPU calling context.
-    level0_command_begin(data_for_kernel);
-  }
-}
-
-static void
-level0_command_list_append_launch_memcpy_entry
-(
-  ze_command_list_append_memory_copy_params_t* params,
-  ze_result_t result,
-  void* global_data,
-  void** instance_data
-)
-{
-  ze_command_list_handle_t command_list = *(params->phCommandList);
-  ze_event_handle_t event = *(params->phEvent);
-  ze_event_pool_handle_t event_pool = NULL;
-  size_t mem_copy_size = *(params->psize);
-  const void* dest_ptr = *(params->pdstptr);
-  const void* src_ptr = *(params->psrcptr);
-
-  if (event == NULL) {
-    // If the memcpy is launched without an event,
-    // we create a new event for collecting time stamps
-    create_new_event(&event, &event_pool);
-    *(params->phEvent) = event;
-  }
-
   // Get source and destination type.
   // Level 0 does not track memory allocated through system allocator such as malloc.
   // In such case, zeDriverGetMemAllocProperties will return failure.
   // So, we default the memory type to be HOST.
-  ze_memory_type_t src_type = ZE_MEMORY_TYPE_HOST;
   ze_memory_allocation_properties_t property;
   if (HPCRUN_LEVEL0_CALL(zeDriverGetMemAllocProperties, (hDriver, src_ptr, &property, NULL)) == ZE_RESULT_SUCCESS) {
-    src_type = property.type;
+    *src_type_ptr = property.type;
   }
-  ze_memory_type_t dst_type = ZE_MEMORY_TYPE_HOST;
   if (HPCRUN_LEVEL0_CALL(zeDriverGetMemAllocProperties, (hDriver, dest_ptr, &property, NULL)) == ZE_RESULT_SUCCESS) {
-    dst_type = property.type;
-  }
-
-  PRINT("level0_command_list_append_launch_memcpy_entry: src_type %d, dst_type %d, size %lu, command list %p, event handle %p, event pool handle %p\n",
-    src_type, dst_type, mem_copy_size, (void*)command_list, (void*)event, (void*)event_pool);
-
-  // Lookup the command list and append the mempcy to the command list
-  level0_data_node_t ** command_list_data_head = level0_commandlist_map_lookup(command_list);
-  if (command_list_data_head != NULL) {
-    level0_data_node_t * data_for_memcpy = level0_commandlist_append_memcpy(command_list_data_head, src_type, dst_type, mem_copy_size, event, event_pool);
-    // Associate the data entry with the event
-    level0_event_map_insert(event, data_for_memcpy);
-  } else {
-    // Cannot find command list.
-    // This means we are dealing with an immediate command list
-    level0_data_node_t * data_for_memcpy = level0_commandlist_alloc_memcpy(src_type, dst_type, mem_copy_size, event, event_pool);
-    // Associate the data entry with the event
-    level0_event_map_insert(event, data_for_memcpy);
-    // For immediate command list, the mempcy is dispatched to GPU at this point.
-    // So, we attribute GPU metrics to the current CPU calling context.
-    level0_command_begin(data_for_memcpy);
+    *dst_type_ptr = property.type;
   }
 }
-
-static void
-level0_command_list_append_barrier_entry
-(
-  ze_command_list_append_barrier_params_t* params,
-  ze_result_t result,
-  void* global_data,
-  void** instance_data
-)
-{
-  PRINT("Enter unimplemented level0_command_list_append_barrier_entry\n");
-}
-
-static void
-level0_command_list_create_exit
-(
-  ze_command_list_create_params_t* params,
-  ze_result_t result,
-  void* pTracerUserData,
-  void** ppTracerInstanceUserData
-)
-{
-  ze_command_list_handle_t handle = **params->pphCommandList;
-  PRINT("level0_command_list_create_exit: command list %p\n", (void*)handle);
-  // Record the creation of a command list
-  level0_commandlist_map_insert(handle);
-}
-
-static void
-level0_command_list_destroy_entry
-(
-  ze_command_list_destroy_params_t* params,
-  ze_result_t result,
-  void* pTracerUserData,
-  void** ppTracerInstanceUserData
-)
-{
-  ze_command_list_handle_t handle = *params->phCommandList;
-  level0_data_node_t ** command_list_head = level0_commandlist_map_lookup(handle);
-  level0_data_node_t * command_node = *command_list_head;
-  for (; command_node != NULL; command_node = command_node->next) {
-    attribute_event(command_node->event);
-  }
-
-  // Record the deletion of a command list
-  level0_commandlist_map_delete(handle);
-}
-
-static void
-level0_command_queue_execute_command_list_entry
-(
-  ze_command_queue_execute_command_lists_params_t* params,
-  ze_result_t result,
-  void* pTracerUserData,
-  void** ppTracerInstanceUserData
-)
-{
-  // We associate GPU metrics for GPU activitities in non-immediate command list
-  // to the CPU call contexts where the command list is executed, not where
-  // the GPU activity is appended.
-  uint32_t size = *(params->pnumCommandLists);
-  uint32_t i;
-  for (i = 0; i < size; ++i) {
-    ze_command_list_handle_t command_list_handle = *(params->pphCommandLists[i]);
-    PRINT("level0_command_queue_execute_command_list_entry: command list %p\n", (void*)command_list_handle);
-    level0_data_node_t ** command_list_head = level0_commandlist_map_lookup(command_list_handle);
-    level0_data_node_t * command_node = *command_list_head;
-    for (; command_node != NULL; command_node = command_node->next) {
-      level0_command_begin(command_node);
-    }
-  }
-}
-
-static void
-process_immediate_command_list
-(
-  ze_event_handle_t event,
-  ze_command_list_handle_t command_list
-)
-{
-  level0_data_node_t ** command_list_data_head = level0_commandlist_map_lookup(command_list);
-  if (command_list_data_head == NULL) {
-    // This is a GPU activity to an immediate command list
-    level0_data_node_t* data_for_act = level0_event_map_lookup(event);
-    attribute_event(event);
-
-    // For command in immediate command list,
-    // the ownership of data node belongs to the user, not the command list
-    level0_data_node_return_free_list(data_for_act);
-  }
-}
-
-static void
-level0_command_list_append_launch_kernel_exit(
-  ze_command_list_append_launch_kernel_params_t* params,
-  ze_result_t result,
-  void* global_data,
-  void** instance_data)
-{
-  process_immediate_command_list(*(params->phSignalEvent), *(params->phCommandList));
-}
-
-static void
-level0_command_list_append_memcpy_exit
-(
-  ze_command_list_append_memory_copy_params_t* params,
-  ze_result_t result,
-  void* global_data,
-  void** instance_data
-)
-{
-  process_immediate_command_list(*(params->phEvent), *(params->phCommandList));
-}
-
-static void
-level0_command_list_append_memfill_exit
-(
-  ze_command_list_append_memory_fill_params_t* params,
-  ze_result_t result,
-  void* pTracerUserData,
-  void** ppTracerInstanceUserData
-)
-{
-  PRINT("Enter unimplemented OnExitCommandListAPpendMemoryFill\n");
-}
-
-static void
-level0_command_list_append_memcpy_region_exit
-(
-  ze_command_list_append_memory_copy_region_params_t* params,
-  ze_result_t result,
-  void* pTracerUserData,
-  void** ppTracerInstanceUserData
-)
-{
-  PRINT("Enter unimplemented level0_command_list_append_memcpy_region_exit\n");
-}
-
-static void
-OnEnterEventHostSignal
-(
-  ze_event_host_signal_params_t* params,
-  ze_result_t result,
-  void* pTracerUserData,
-  void** ppTracerInstanceUserData
-)
-{
-  PRINT("Enter OnEnterEvenHostSignal on event %p\n");
-}
-
-static void
-OnEnterEventHostSynchronize
-(
-  ze_event_host_synchronize_params_t* params,
-  ze_result_t result,
-  void* pTracerUserData,
-  void** ppTracerInstanceUserData
-)
-{
-  PRINT("Enter OnEnterEventHostSynchronize on event %p\n");
-}
-
-void setup_tracer() {
-  zet_tracer_desc_t tracer_desc;
-  tracer_desc.version = ZET_TRACER_DESC_VERSION_CURRENT;
-  tracer_desc.pUserData = NULL;
-  HPCRUN_LEVEL0_CALL(zetTracerCreate, (hDriver, &tracer_desc, &hTracer));
-
-  // Set all callbacks
-  zet_core_callbacks_t prologue_callbacks = {};
-  prologue_callbacks.Event.pfnDestroyCb = level0_event_destroy_entry;
-  prologue_callbacks.Event.pfnHostResetCb = level0_event_host_reset_entry;
-  prologue_callbacks.Event.pfnHostSignalCb = OnEnterEventHostSignal;
-  prologue_callbacks.Event.pfnHostSynchronizeCb = OnEnterEventHostSynchronize;
-  prologue_callbacks.EventPool.pfnCreateCb = level0_event_pool_create_entry;
-
-  prologue_callbacks.CommandList.pfnAppendLaunchKernelCb =
-    level0_command_list_append_launch_kernel_entry;
-  prologue_callbacks.CommandList.pfnAppendMemoryCopyCb =
-    level0_command_list_append_launch_memcpy_entry;
-  prologue_callbacks.CommandList.pfnAppendBarrierCb =
-    level0_command_list_append_barrier_entry;
-  prologue_callbacks.CommandList.pfnDestroyCb = level0_command_list_destroy_entry;
-  prologue_callbacks.CommandQueue.pfnExecuteCommandListsCb = level0_command_queue_execute_command_list_entry;
-
-  zet_core_callbacks_t epilogue_callbacks = {};
-  epilogue_callbacks.CommandList.pfnCreateCb = level0_command_list_create_exit;
-  epilogue_callbacks.CommandList.pfnAppendLaunchKernelCb =
-    level0_command_list_append_launch_kernel_exit;
-  epilogue_callbacks.CommandList.pfnAppendMemoryCopyCb =
-    level0_command_list_append_memcpy_exit;
-  epilogue_callbacks.CommandList.pfnAppendMemoryFillCb = level0_command_list_append_memfill_exit;
-  epilogue_callbacks.CommandList.pfnAppendMemoryCopyRegionCb = level0_command_list_append_memcpy_region_exit;
-
-  HPCRUN_LEVEL0_CALL(zetTracerSetPrologues, (hTracer, &prologue_callbacks));
-  HPCRUN_LEVEL0_CALL(zetTracerSetEpilogues, (hTracer, &epilogue_callbacks));
-
-  // Enable tracing
-  HPCRUN_LEVEL0_CALL(zetTracerSetEnabled, (hTracer, 1));
-}
-
-
-//******************************************************************************
-// interface operations
-//******************************************************************************
-
-int
-level0_bind
-(
- void
-)
-{
-  // Enable level 0 API tracing
-  setenv("ZE_ENABLE_API_TRACING", "1", 1);
-
-#ifndef HPCRUN_STATIC_LINK
-  // dynamic libraries only availabile in non-static case
-  hpcrun_force_dlopen(true);
-  CHK_DLOPEN(level0, level0_path(), RTLD_NOW | RTLD_GLOBAL);
-  hpcrun_force_dlopen(false);
-
-#define LEVEL0_BIND(fn) \
-  CHK_DLSYM(level0, fn);
-
-  FORALL_LEVEL0_ROUTINES(LEVEL0_BIND)
-
-#undef LEVEL0_BIND
-
-  return 0;
-#else
-  return -1;
-#endif // ! HPCRUN_STATIC_LINK
-}
-
-void
-level0_init
-(
- void
-)
-{
-  HPCRUN_LEVEL0_CALL(zeInit,(ZE_INIT_FLAG_NONE));
-  HPCRUN_LEVEL0_CALL(zetInit, (ZE_INIT_FLAG_NONE));
-  get_gpu_driver_and_device();
-  setup_tracer();
-}
-
-void
-level0_fini
-(
- void* args
-)
-{
-  gpu_application_thread_process_activities();
-  HPCRUN_LEVEL0_CALL(zetTracerSetEnabled, (hTracer, 0));
-  HPCRUN_LEVEL0_CALL(zetTracerDestroy, (hTracer));
-}
-

--- a/src/tool/hpcrun/gpu/level0/level0-api.c
+++ b/src/tool/hpcrun/gpu/level0/level0-api.c
@@ -58,7 +58,6 @@
 #include "level0-event-map.h"
 #include "level0-command-process.h"
 #include "level0-data-node.h"
-#include "level0-intercept.h"
 
 #include <hpcrun/main.h>
 #include <hpcrun/memory/hpcrun-malloc.h>
@@ -86,8 +85,13 @@
   macro(zeEventPoolDestroy) \
   macro(zeEventQueryStatus) \
   macro(zeEventGetTimestamp) \
-  macro(zeDriverGetMemAllocProperties)
-
+  macro(zeDriverGetMemAllocProperties) \
+  macro(zeCommandListAppendLaunchKernel) \
+  macro(zeCommandListAppendMemoryCopy) \
+  macro(zeCommandListCreate) \
+  macro(zeCommandListDestroy) \
+  macro(zeCommandQueueExecuteCommandLists) \
+  macro(zeEventHostReset)
 
 #define LEVEL0_FN_NAME(f) DYN_FN_NAME(f)
 
@@ -208,7 +212,72 @@ LEVEL0_FN
     const void* ptr,
     ze_memory_allocation_properties_t*,
     ze_device_handle_t*
-  );
+  )
+);
+
+LEVEL0_FN
+(
+  zeCommandListAppendLaunchKernel,
+  (
+    ze_command_list_handle_t hCommandList,          ///< [in] handle of the command list
+    ze_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+    const ze_group_count_t* pLaunchFuncArgs,        ///< [in] thread group launch arguments
+    ze_event_handle_t hSignalEvent,                 ///< [in][optional] handle of the event to signal on completion
+    uint32_t numWaitEvents,                         ///< [in][optional] number of events to wait on before launching; must be 0
+                                                    ///< if `nullptr == phWaitEvents`
+    ze_event_handle_t* phWaitEvents                 ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                    ///< on before launching
+  )
+);
+
+LEVEL0_FN
+(
+  zeCommandListAppendMemoryCopy,
+  (
+    ze_command_list_handle_t hCommandList,          ///< [in] handle of command list
+    void* dstptr,                                   ///< [in] pointer to destination memory to copy to
+    const void* srcptr,                             ///< [in] pointer to source memory to copy from
+    size_t size,                                    ///< [in] size in bytes to copy
+    ze_event_handle_t hEvent                        ///< [in][optional] handle of the event to signal on completion
+  )
+);
+
+LEVEL0_FN
+(
+  zeCommandListCreate,
+  (
+    ze_device_handle_t hDevice,                     ///< [in] handle of the device object
+    const ze_command_list_desc_t* desc,             ///< [in] pointer to command list descriptor
+    ze_command_list_handle_t* phCommandList         ///< [out] pointer to handle of command list object created
+  )
+);
+
+LEVEL0_FN
+(
+  zeCommandListDestroy,
+  (
+    ze_command_list_handle_t hCommandList           ///< [in][release] handle of command list object to destroy
+  )
+);
+
+LEVEL0_FN
+(
+  zeCommandQueueExecuteCommandLists,
+  (
+    ze_command_queue_handle_t hCommandQueue,        ///< [in] handle of the command queue
+    uint32_t numCommandLists,                       ///< [in] number of command lists to execute
+    ze_command_list_handle_t* phCommandLists,       ///< [in][range(0, numCommandLists)] list of handles of the command lists
+                                                    ///< to execute
+    ze_fence_handle_t hFence                        ///< [in][optional] handle of the fence to signal on completion
+  )
+);
+
+LEVEL0_FN
+(
+  zeEventHostReset,
+  (
+    ze_event_handle_t hEvent                        ///< [in] handle of the event
+  )
 );
 
 //******************************************************************************
@@ -269,57 +338,7 @@ get_gpu_driver_and_device
   }
 }
 
-//******************************************************************************
-// interface operations
-//******************************************************************************
-
-int
-level0_bind
-(
- void
-)
-{
-#ifndef HPCRUN_STATIC_LINK
-  // dynamic libraries only availabile in non-static case
-  hpcrun_force_dlopen(true);
-  CHK_DLOPEN(level0, level0_path(), RTLD_NOW | RTLD_GLOBAL);
-  hpcrun_force_dlopen(false);
-
-#define LEVEL0_BIND(fn) \
-  CHK_DLSYM(level0, fn);
-
-  FORALL_LEVEL0_ROUTINES(LEVEL0_BIND)
-
-#undef LEVEL0_BIND
-
-  return 0;
-#else
-  return -1;
-#endif // ! HPCRUN_STATIC_LINK
-}
-
-void
-level0_init
-(
- void
-)
-{
-  level0_intercept_setup();
-  HPCRUN_LEVEL0_CALL(zeInit,(ZE_INIT_FLAG_NONE));
-  get_gpu_driver_and_device();
-}
-
-void
-level0_fini
-(
- void* args
-)
-{
-  gpu_application_thread_process_activities();
-  level0_intercept_teardown();
-}
-
-void
+static void
 level0_create_new_event
 (
   ze_event_handle_t* event_ptr,
@@ -340,7 +359,7 @@ level0_create_new_event
   HPCRUN_LEVEL0_CALL(zeEventCreate, (*event_pool_ptr, &event_desc, event_ptr));
 }
 
-void
+static void
 level0_attribute_event
 (
   ze_event_handle_t event
@@ -377,7 +396,7 @@ level0_attribute_event
   level0_event_map_delete(event);
 }
 
-void
+static void
 level0_get_memory_types
 (
   const void* src_ptr,
@@ -397,4 +416,392 @@ level0_get_memory_types
   if (HPCRUN_LEVEL0_CALL(zeDriverGetMemAllocProperties, (hDriver, dest_ptr, &property, NULL)) == ZE_RESULT_SUCCESS) {
     *dst_type_ptr = property.type;
   }
+}
+static void
+level0_event_pool_create_entry
+(
+  const ze_event_pool_desc_t* desc,
+  ze_event_pool_desc_t* pool_desc
+)
+{
+  if (desc == NULL) {
+    // Based on Level 0 header file,
+    // zeEventPoolCreate will return ZE_RESULT_ERROR_INVALID_NULL_POINTER for this caes.
+    // Therefore, we do nothing in this case.
+    return;
+  }
+
+  // Here we need to allocate a new event pool descriptor
+  // as we cannot directly change the passed in object (declared ad const)
+  // This leads to one description per event pool creation.
+  pool_desc->version = desc->version;
+  pool_desc->flags = desc->flags;
+  pool_desc->count = desc->count;
+
+  // We attach the time stamp flag to the event pool,
+  // so that we can query time stamps for events in this pool.
+  int flags = pool_desc->flags | ZE_EVENT_POOL_FLAG_TIMESTAMP;
+  pool_desc->flags = (ze_event_pool_flag_t)(flags);
+}
+
+static ze_event_handle_t
+level0_command_list_append_launch_kernel_entry
+(
+  ze_kernel_handle_t kernel,
+  ze_command_list_handle_t command_list,
+  ze_event_handle_t event
+)
+{
+  ze_event_pool_handle_t event_pool = NULL;
+
+  if (event == NULL) {
+    // If the kernel is launched without an event,
+    // we create a new event for collecting time stamps
+    level0_create_new_event(&event, &event_pool);
+  }
+
+  PRINT("level0_command_list_append_launch_kernel_entry: kernel handle %p, commmand list handle %p, event handle %p, event pool handle %p\n",
+    (void*)kernel, (void*)command_list, (void*)event, (void*)event_pool);
+
+  // Lookup the command list and append the kernel launch to the command list
+  level0_data_node_t ** command_list_data_head = level0_commandlist_map_lookup(command_list);
+  if (command_list_data_head != NULL) {
+    level0_data_node_t * data_for_kernel = level0_commandlist_append_kernel(command_list_data_head, kernel, event, event_pool);
+    // Associate the data entry with the event
+    level0_event_map_insert(event, data_for_kernel);
+  } else {
+    // Cannot find command list.
+    // This means we are dealing with an immediate command list
+    level0_data_node_t * data_for_kernel = level0_commandlist_alloc_kernel(kernel, event, event_pool);;
+    // Associate the data entry with the event
+    level0_event_map_insert(event, data_for_kernel);
+    // For immediate command list, the kernel is dispatched to GPU at this point.
+    // So, we attribute GPU metrics to the current CPU calling context.
+    level0_command_begin(data_for_kernel);
+  }
+  return event;
+}
+
+static ze_event_handle_t
+level0_command_list_append_launch_memcpy_entry
+(
+  ze_command_list_handle_t command_list,
+  ze_event_handle_t event,
+  size_t mem_copy_size,
+  const void* dest_ptr,
+  const void* src_ptr
+)
+{
+  ze_event_pool_handle_t event_pool = NULL;
+
+  if (event == NULL) {
+    // If the memcpy is launched without an event,
+    // we create a new event for collecting time stamps
+    level0_create_new_event(&event, &event_pool);
+  }
+
+  ze_memory_type_t src_type = ZE_MEMORY_TYPE_HOST;
+  ze_memory_type_t dst_type = ZE_MEMORY_TYPE_HOST;
+  level0_get_memory_types(src_ptr, dest_ptr, &src_type, &dst_type);
+
+  PRINT("level0_command_list_append_launch_memcpy_entry: src_type %d, dst_type %d, size %lu, command list %p, event handle %p, event pool handle %p\n",
+    src_type, dst_type, mem_copy_size, (void*)command_list, (void*)event, (void*)event_pool);
+
+  // Lookup the command list and append the mempcy to the command list
+  level0_data_node_t ** command_list_data_head = level0_commandlist_map_lookup(command_list);
+  if (command_list_data_head != NULL) {
+    level0_data_node_t * data_for_memcpy = level0_commandlist_append_memcpy(command_list_data_head, src_type, dst_type, mem_copy_size, event, event_pool);
+    // Associate the data entry with the event
+    level0_event_map_insert(event, data_for_memcpy);
+  } else {
+    // Cannot find command list.
+    // This means we are dealing with an immediate command list
+    level0_data_node_t * data_for_memcpy = level0_commandlist_alloc_memcpy(src_type, dst_type, mem_copy_size, event, event_pool);
+    // Associate the data entry with the event
+    level0_event_map_insert(event, data_for_memcpy);
+    // For immediate command list, the mempcy is dispatched to GPU at this point.
+    // So, we attribute GPU metrics to the current CPU calling context.
+    level0_command_begin(data_for_memcpy);
+  }
+  return event;
+}
+
+
+static void
+level0_command_list_create_exit
+(
+  ze_command_list_handle_t handle
+)
+{
+  PRINT("level0_command_list_create_exit: command list %p\n", (void*)handle);
+  // Record the creation of a command list
+  level0_commandlist_map_insert(handle);
+}
+
+static void
+level0_command_list_destroy_entry
+(
+  ze_command_list_handle_t handle
+)
+{
+  level0_data_node_t ** command_list_head = level0_commandlist_map_lookup(handle);
+  level0_data_node_t * command_node = *command_list_head;
+  for (; command_node != NULL; command_node = command_node->next) {
+    level0_attribute_event(command_node->event);
+  }
+
+  // Record the deletion of a command list
+  level0_commandlist_map_delete(handle);
+}
+
+static void
+level0_command_queue_execute_command_list_entry
+(
+  uint32_t numCommandLists,                       ///< [in] number of command lists to execute
+  ze_command_list_handle_t* phCommandLists       ///< [in][range(0, numCommandLists)] list of handles of the command lists
+)
+{
+  // We associate GPU metrics for GPU activitities in non-immediate command list
+  // to the CPU call contexts where the command list is executed, not where
+  // the GPU activity is appended.
+  uint32_t i;
+  for (i = 0; i < numCommandLists; ++i) {
+    ze_command_list_handle_t command_list_handle = phCommandLists[i];
+    PRINT("level0_command_queue_execute_command_list_entry: command list %p\n", (void*)command_list_handle);
+    level0_data_node_t ** command_list_head = level0_commandlist_map_lookup(command_list_handle);
+    level0_data_node_t * command_node = *command_list_head;
+    for (; command_node != NULL; command_node = command_node->next) {
+      level0_command_begin(command_node);
+    }
+  }
+}
+
+static void
+level0_process_immediate_command_list
+(
+  ze_event_handle_t event,
+  ze_command_list_handle_t command_list
+)
+{
+  level0_data_node_t ** command_list_data_head = level0_commandlist_map_lookup(command_list);
+  if (command_list_data_head == NULL) {
+    // This is a GPU activity to an immediate command list
+    level0_data_node_t* data_for_act = level0_event_map_lookup(event);
+    level0_attribute_event(event);
+
+    // For command in immediate command list,
+    // the ownership of data node belongs to the user, not the command list
+    level0_data_node_return_free_list(data_for_act);
+  }
+}
+
+//******************************************************************************
+// L0 public API override
+//******************************************************************************
+
+ze_result_t
+zeCommandListAppendLaunchKernel(
+  ze_command_list_handle_t hCommandList,          ///< [in] handle of the command list
+  ze_kernel_handle_t hKernel,                     ///< [in] handle of the kernel object
+  const ze_group_count_t* pLaunchFuncArgs,        ///< [in] thread group launch arguments
+  ze_event_handle_t hSignalEvent,                 ///< [in][optional] handle of the event to signal on completion
+  uint32_t numWaitEvents,                         ///< [in][optional] number of events to wait on before launching; must be 0
+                                                  ///< if `nullptr == phWaitEvents`
+  ze_event_handle_t* phWaitEvents                 ///< [in][optional][range(0, numWaitEvents)] handle of the events to wait
+                                                  ///< on before launching
+)
+{
+  PRINT("Enter zeCommandListAppendLaunchKernel wrapper\n");
+  // Entry action:
+  // We need to create a new event for querying time stamps
+  // if the user appends the kernel with an empty event parameter
+  ze_event_handle_t new_event_handle = level0_command_list_append_launch_kernel_entry(
+    hKernel, hCommandList, hSignalEvent);
+
+  // Execute the real level0 API
+  ze_result_t ret = HPCRUN_LEVEL0_CALL(zeCommandListAppendLaunchKernel,
+    (hCommandList, hKernel, pLaunchFuncArgs,
+    new_event_handle, numWaitEvents, phWaitEvents));
+
+  // Exit action
+  level0_process_immediate_command_list(new_event_handle, hCommandList);
+  return ret;
+}
+
+ze_result_t
+zeCommandListAppendMemoryCopy(
+  ze_command_list_handle_t hCommandList,          ///< [in] handle of command list
+  void* dstptr,                                   ///< [in] pointer to destination memory to copy to
+  const void* srcptr,                             ///< [in] pointer to source memory to copy from
+  size_t size,                                    ///< [in] size in bytes to copy
+  ze_event_handle_t hEvent                        ///< [in][optional] handle of the event to signal on completion
+)
+{
+  // Entry action:
+  // We need to create a new event for querying time stamps
+  // if the user appends the kernel with an empty event parameter
+  ze_event_handle_t new_event_handle =
+  level0_command_list_append_launch_memcpy_entry(
+      hCommandList, hEvent, size, dstptr, srcptr);
+  // Execute the real level0 API
+  ze_result_t ret = HPCRUN_LEVEL0_CALL(zeCommandListAppendMemoryCopy,
+    (hCommandList, dstptr, srcptr, size, new_event_handle));
+
+  // Exit action
+  level0_process_immediate_command_list(new_event_handle, hCommandList);
+  return ret;
+}
+
+
+ze_result_t
+zeCommandListCreate(
+  ze_device_handle_t hDevice,                     ///< [in] handle of the device object
+  const ze_command_list_desc_t* desc,             ///< [in] pointer to command list descriptor
+  ze_command_list_handle_t* phCommandList         ///< [out] pointer to handle of command list object created
+)
+{
+  // Entry action
+  // Execute the real level0 API
+  ze_result_t ret = HPCRUN_LEVEL0_CALL(zeCommandListCreate,
+    (hDevice, desc, phCommandList));
+
+  // Exit action
+  level0_command_list_create_exit(*phCommandList);
+  return ret;
+}
+
+ze_result_t
+zeCommandListDestroy(
+  ze_command_list_handle_t hCommandList           ///< [in][release] handle of command list object to destroy
+)
+{
+  // Entry action
+  level0_command_list_destroy_entry(hCommandList);
+  // Execute the real level0 API
+  ze_result_t ret = HPCRUN_LEVEL0_CALL(zeCommandListDestroy, (hCommandList));
+  // Exit action
+  return ret;
+}
+
+ze_result_t
+zeCommandQueueExecuteCommandLists(
+  ze_command_queue_handle_t hCommandQueue,        ///< [in] handle of the command queue
+  uint32_t numCommandLists,                       ///< [in] number of command lists to execute
+  ze_command_list_handle_t* phCommandLists,       ///< [in][range(0, numCommandLists)] list of handles of the command lists
+                                                  ///< to execute
+  ze_fence_handle_t hFence                        ///< [in][optional] handle of the fence to signal on completion
+)
+{
+  PRINT("Enter zeCommandQueueExecuteCommandLists wrapper\n");
+  // Entry action
+  level0_command_queue_execute_command_list_entry(numCommandLists, phCommandLists);
+  // Execute the real level0 API
+  ze_result_t ret = HPCRUN_LEVEL0_CALL(zeCommandQueueExecuteCommandLists,
+    (hCommandQueue, numCommandLists, phCommandLists, hFence));
+  // Exit action
+  return ret;
+}
+
+ze_result_t
+zeEventPoolCreate(
+  ze_driver_handle_t hDriver,                     ///< [in] handle of the driver instance
+  const ze_event_pool_desc_t* desc,               ///< [in] pointer to event pool descriptor
+  uint32_t numDevices,                            ///< [in][optional] number of device handles; must be 0 if `nullptr ==
+                                                  ///< phDevices`
+  ze_device_handle_t* phDevices,                  ///< [in][optional][range(0, numDevices)] array of device handles which
+                                                  ///< have visibility to the event pool.
+                                                  ///< if nullptr, then event pool is visible to all devices supported by the
+                                                  ///< driver instance.
+  ze_event_pool_handle_t* phEventPool             ///< [out] pointer handle of event pool object created
+)
+{
+  // Entry action
+  ze_event_pool_desc_t pool_desc;
+  level0_event_pool_create_entry(desc, &pool_desc);
+  // Execute the real level0 API
+  ze_result_t ret;
+  if (desc == NULL) {
+    ret = HPCRUN_LEVEL0_CALL(zeEventPoolCreate,
+      (hDriver, NULL, numDevices, phDevices, phEventPool));
+  } else {
+    ret = HPCRUN_LEVEL0_CALL(zeEventPoolCreate,
+      (hDriver, &pool_desc, numDevices, phDevices, phEventPool));
+  }
+  // Exit action
+  return ret;
+}
+
+ze_result_t
+zeEventDestroy(
+  ze_event_handle_t hEvent                        ///< [in][release] handle of event object to destroy
+)
+{
+  // Entry action
+  level0_attribute_event(hEvent);
+  // Execute the real level0 API
+  ze_result_t ret = HPCRUN_LEVEL0_CALL(zeEventDestroy, (hEvent));
+  // Exit action
+  return ret;
+}
+
+ze_result_t
+zeEventHostReset(
+  ze_event_handle_t hEvent                        ///< [in] handle of the event
+)
+{
+  // Entry action
+  level0_attribute_event(hEvent);
+  // Execute the real level0 API
+  ze_result_t ret = HPCRUN_LEVEL0_CALL(zeEventHostReset, (hEvent));
+
+  // Exit action
+  return ret;
+}
+
+//******************************************************************************
+// interface operations
+//******************************************************************************
+
+int
+level0_bind
+(
+ void
+)
+{
+#ifndef HPCRUN_STATIC_LINK
+  // dynamic libraries only availabile in non-static case
+  hpcrun_force_dlopen(true);
+  CHK_DLOPEN(level0, level0_path(), RTLD_NOW | RTLD_GLOBAL);
+  hpcrun_force_dlopen(false);
+
+#define LEVEL0_BIND(fn) \
+  CHK_DLSYM(level0, fn);
+
+  FORALL_LEVEL0_ROUTINES(LEVEL0_BIND)
+
+#undef LEVEL0_BIND
+
+  return 0;
+#else
+  return -1;
+#endif // ! HPCRUN_STATIC_LINK
+}
+
+void
+level0_init
+(
+ void
+)
+{
+  HPCRUN_LEVEL0_CALL(zeInit,(ZE_INIT_FLAG_NONE));
+  get_gpu_driver_and_device();
+}
+
+void
+level0_fini
+(
+ void* args
+)
+{
+  gpu_application_thread_process_activities();
 }

--- a/src/tool/hpcrun/gpu/level0/level0-api.h
+++ b/src/tool/hpcrun/gpu/level0/level0-api.h
@@ -74,26 +74,4 @@ level0_bind
   void
 );
 
-void
-level0_create_new_event
-(
-  ze_event_handle_t* event_ptr,
-  ze_event_pool_handle_t* event_pool_ptr
-);
-
-void
-level0_attribute_event
-(
-  ze_event_handle_t event
-);
-
-void
-level0_get_memory_types
-(
-  const void* src_ptr,
-  const void* dest_ptr,
-  ze_memory_type_t *src_type_ptr,
-  ze_memory_type_t *dst_type_ptr
-);
-
 #endif

--- a/src/tool/hpcrun/gpu/level0/level0-api.h
+++ b/src/tool/hpcrun/gpu/level0/level0-api.h
@@ -44,7 +44,11 @@
 #ifndef level0_api_h
 #define level0_api_h
 
+//******************************************************************************
+// local includes
+//******************************************************************************
 
+#include <level_zero/ze_api.h>
 
 //******************************************************************************
 // interface operations
@@ -70,6 +74,26 @@ level0_bind
   void
 );
 
+void
+level0_create_new_event
+(
+  ze_event_handle_t* event_ptr,
+  ze_event_pool_handle_t* event_pool_ptr
+);
 
+void
+level0_attribute_event
+(
+  ze_event_handle_t event
+);
+
+void
+level0_get_memory_types
+(
+  const void* src_ptr,
+  const void* dest_ptr,
+  ze_memory_type_t *src_type_ptr,
+  ze_memory_type_t *dst_type_ptr
+);
 
 #endif

--- a/src/tool/hpcrun/gpu/level0/level0-command-list-context-map.c
+++ b/src/tool/hpcrun/gpu/level0/level0-command-list-context-map.c
@@ -67,6 +67,10 @@
 // local data
 //******************************************************************************
 
+// TODO:
+// Replace mutual exclusion with more efficient
+// data structures.
+
 static level0_handle_map_entry_t *commandlist_context_map_root = NULL;
 
 static level0_handle_map_entry_t *commandlist_context_free_list = NULL;

--- a/src/tool/hpcrun/gpu/level0/level0-command-list-context-map.c
+++ b/src/tool/hpcrun/gpu/level0/level0-command-list-context-map.c
@@ -41,83 +41,91 @@
 //
 // ******************************************************* EndRiceCopyright *
 
-
-#ifndef level0_commandlist_map_h
-#define level0_commandlist_map_h
-
 //*****************************************************************************
 // system includes
 //*****************************************************************************
 
-#include <stdint.h>
+#include <assert.h>
+#include <string.h>
 
 //*****************************************************************************
 // local includes
 //*****************************************************************************
 
+#include "level0-command-list-context-map.h"
+#include "lib/prof-lean/spinlock.h"
 
-#include <level_zero/ze_api.h>
-#include <level_zero/zet_api.h>
-#include "level0-handle-map.h"
-#include "level0-data-node.h"
+//*****************************************************************************
+// macros
+//*****************************************************************************
+
+#define DEBUG 0
+
+#include "hpcrun/gpu/gpu-print.h"
+
+//******************************************************************************
+// local data
+//******************************************************************************
+
+static level0_handle_map_entry_t *commandlist_context_map_root = NULL;
+
+static level0_handle_map_entry_t *commandlist_context_free_list = NULL;
+
+static spinlock_t commandlist_context_map_lock = SPINLOCK_UNLOCKED;
 
 //*****************************************************************************
 // interface operations
 //*****************************************************************************
 
-level0_data_node_t**
-level0_commandlist_map_lookup
+ze_context_handle_t
+level0_commandlist_context_map_lookup
 (
  ze_command_list_handle_t command_list_handle
-);
+)
+{
+  spinlock_lock(&commandlist_context_map_lock);
+
+  uint64_t key = (uint64_t)command_list_handle;
+  level0_handle_map_entry_t *result =
+    level0_handle_map_lookup(&commandlist_context_map_root, key);
+
+  PRINT("level0 commandlist context map lookup: id=0x%lx (record %p)\n",
+       key, result);
+
+  spinlock_unlock(&commandlist_context_map_lock);
+  return (ze_context_handle_t)(*level0_handle_map_entry_data_get(result));
+}
 
 void
-level0_commandlist_map_insert
+level0_commandlist_context_map_insert
 (
- ze_command_list_handle_t command_list_handle
-);
+ ze_command_list_handle_t command_list_handle,
+ ze_context_handle_t hContext
+)
+{
+  spinlock_lock(&commandlist_context_map_lock);
+
+  uint64_t key = (uint64_t)command_list_handle;
+  level0_handle_map_entry_t *entry =
+    level0_handle_map_entry_new(&commandlist_context_free_list, key, (level0_data_node_t*)hContext);
+  level0_handle_map_insert(&commandlist_context_map_root, entry);
+
+  PRINT("level0 commandlist map insert: handle=%p (entry=%p)\n",
+	 command_list_handle, entry);
+
+  spinlock_unlock(&commandlist_context_map_lock);
+}
 
 void
-level0_commandlist_map_delete
+level0_commandlist_context_map_delete
 (
  ze_command_list_handle_t command_list_handle
-);
+)
+{
+  spinlock_lock(&commandlist_context_map_lock);
 
-level0_data_node_t*
-level0_commandlist_alloc_kernel
-(
- ze_kernel_handle_t kernel,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
-);
+  uint64_t key = (uint64_t)command_list_handle;
+  level0_handle_map_delete(&commandlist_context_map_root, &commandlist_context_free_list, key);
 
-level0_data_node_t*
-level0_commandlist_alloc_memcpy
-(
- ze_memory_type_t src_type,
- ze_memory_type_t dst_type,
- size_t copy_size,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
-);
-
-level0_data_node_t*
-level0_commandlist_append_kernel
-(
- level0_data_node_t** command_list,
- ze_kernel_handle_t kernel,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
-);
-
-level0_data_node_t*
-level0_commandlist_append_memcpy
-(
- level0_data_node_t** command_list,
- ze_memory_type_t src_type,
- ze_memory_type_t dst_type,
- size_t copy_size,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
-);
-#endif
+  spinlock_unlock(&commandlist_context_map_lock);
+}

--- a/src/tool/hpcrun/gpu/level0/level0-command-list-context-map.h
+++ b/src/tool/hpcrun/gpu/level0/level0-command-list-context-map.h
@@ -42,8 +42,8 @@
 // ******************************************************* EndRiceCopyright *
 
 
-#ifndef level0_commandlist_map_h
-#define level0_commandlist_map_h
+#ifndef level0_commandlist_context_map_h
+#define level0_commandlist_context_map_h
 
 //*****************************************************************************
 // system includes
@@ -65,59 +65,22 @@
 // interface operations
 //*****************************************************************************
 
-level0_data_node_t**
-level0_commandlist_map_lookup
+ze_context_handle_t
+level0_commandlist_context_map_lookup
 (
  ze_command_list_handle_t command_list_handle
 );
 
 void
-level0_commandlist_map_insert
+level0_commandlist_context_map_insert
 (
- ze_command_list_handle_t command_list_handle
+ ze_command_list_handle_t command_list_handle,
+ ze_context_handle_t hContext
 );
 
 void
-level0_commandlist_map_delete
+level0_commandlist_context_map_delete
 (
  ze_command_list_handle_t command_list_handle
-);
-
-level0_data_node_t*
-level0_commandlist_alloc_kernel
-(
- ze_kernel_handle_t kernel,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
-);
-
-level0_data_node_t*
-level0_commandlist_alloc_memcpy
-(
- ze_memory_type_t src_type,
- ze_memory_type_t dst_type,
- size_t copy_size,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
-);
-
-level0_data_node_t*
-level0_commandlist_append_kernel
-(
- level0_data_node_t** command_list,
- ze_kernel_handle_t kernel,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
-);
-
-level0_data_node_t*
-level0_commandlist_append_memcpy
-(
- level0_data_node_t** command_list,
- ze_memory_type_t src_type,
- ze_memory_type_t dst_type,
- size_t copy_size,
- ze_event_handle_t event,
- ze_event_pool_handle_t event_pool
 );
 #endif

--- a/src/tool/hpcrun/gpu/level0/level0-command-list-map.c
+++ b/src/tool/hpcrun/gpu/level0/level0-command-list-map.c
@@ -67,6 +67,10 @@
 // local data
 //******************************************************************************
 
+// TODO:
+// Replace mutual exclusion with more efficient
+// data structures.
+
 static level0_handle_map_entry_t *commandlist_map_root = NULL;
 
 static level0_handle_map_entry_t *commandlist_free_list = NULL;

--- a/src/tool/hpcrun/gpu/level0/level0-command-process.c
+++ b/src/tool/hpcrun/gpu/level0/level0-command-process.c
@@ -181,6 +181,7 @@ level0_command_begin
   switch (command_node->type) {
     case LEVEL0_KERNEL: {
       gpu_op_placeholder_flags_set(&gpu_op_placeholder_flags, gpu_placeholder_type_kernel);
+      gpu_op_placeholder_flags_set(&gpu_op_placeholder_flags, gpu_placeholder_type_trace);
       break;
     }
     case LEVEL0_MEMCPY: {

--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -189,7 +189,6 @@ METHOD_FN(process_event_list, int lush_metrics)
 static void
 METHOD_FN(finalize_event_list)
 {
-  //level0_intercept_setup();
 #ifndef HPCRUN_STATIC_LINK
   if (level0_bind()) {
     EEMSG("hpcrun: unable to bind to Level0 library %s\n", dlerror());

--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -86,6 +86,7 @@
 #include <hpcrun/gpu/amd/roctracer-api.h>
 #include <hpcrun/gpu/gpu-activity.h>
 #include <hpcrun/gpu/gpu-metrics.h>
+#include <hpcrun/gpu/gpu-trace.h>
 #include <hpcrun/hpcrun_options.h>
 #include <hpcrun/hpcrun_stats.h>
 #include <hpcrun/metrics.h>

--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -195,8 +195,11 @@ METHOD_FN(finalize_event_list)
     monitor_real_exit(-1);
   }
 #endif
-
   level0_init();
+
+  // Init records
+  gpu_trace_init();
+
   device_finalizer_shutdown.fn = level0_fini;
   device_finalizer_register(device_finalizer_type_shutdown, &device_finalizer_shutdown);
 }

--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -189,6 +189,7 @@ METHOD_FN(process_event_list, int lush_metrics)
 static void
 METHOD_FN(finalize_event_list)
 {
+  //level0_intercept_setup();
 #ifndef HPCRUN_STATIC_LINK
   if (level0_bind()) {
     EEMSG("hpcrun: unable to bind to Level0 library %s\n", dlerror());

--- a/src/tool/hpcrun/sample-sources/level0.h
+++ b/src/tool/hpcrun/sample-sources/level0.h
@@ -58,7 +58,5 @@ typedef struct cct_node_t cct_node_t;
 void level0_init();
 void level0_fini();
 int level0_bind();
-void level0_intercept_setup();
-
 
 #endif //HPCTOOLKIT_LEVEL0_H

--- a/src/tool/hpcrun/sample-sources/level0.h
+++ b/src/tool/hpcrun/sample-sources/level0.h
@@ -58,6 +58,7 @@ typedef struct cct_node_t cct_node_t;
 void level0_init();
 void level0_fini();
 int level0_bind();
+void level0_intercept_setup();
 
 
 #endif //HPCTOOLKIT_LEVEL0_H


### PR DESCRIPTION
This PR refactors Level0 support to work with Intel OneAPI Beta 9 or newer. Older versions of OneAPI is no longer supported. 

We also used function override to intercept Level0's public API as previous tracing support in Level0 is now marked as experimental and will be removed in the future.

I have rebased this PR upon the latest LD_AUDIT commits and tested it with DPC++ samples.