### PR TITLE
Rtld-audit Fallback Patch

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -424,6 +424,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/configure
+++ b/configure
@@ -734,6 +734,9 @@ TBB_LIB_DIR
 TBB_PROXY_LIB
 TBB_LFLAGS
 TBB_IFLAGS
+OPT_ENABLE_RTLD_AUDIT_FALSE
+OPT_ENABLE_RTLD_AUDIT_TRUE
+export_ld_audit
 OPT_PAPI_CUPTI_FALSE
 OPT_PAPI_CUPTI_TRUE
 OPT_PAPI_COMPONENT_FALSE
@@ -1043,6 +1046,7 @@ enable_papi_c_cupti
 with_perfmon
 enable_perf_events
 enable_kernel_blocking
+enable_rtld_audit
 with_tbb
 with_xed
 with_xerces
@@ -1748,6 +1752,8 @@ Optional Features:
                           force enable or disable kernel blocking support in
                           perf events (normally 4.3 or later), only needed if
                           fails to auto-detect correctly
+  --enable-rtld-audit     enable or disable the use of LD_AUDIT for monitoring
+                          of loaded binaries
   --enable-back-end       build only those tools needed to run hpcrun and
                           hpclink on the back-end compute nodes
   --enable-hpcrun         build hpcrun (default yes)
@@ -22042,6 +22048,56 @@ fi
 
 
 #-------------------------------------------------
+# Option: --disable-rtld-audit
+#-------------------------------------------------
+
+# Tracking changes to the set of currently loaded or mapped binaries at runtime
+# is difficult to do both accuractly and efficiently. In particular, there is
+# no clean way to wrap `dlopen` and still use the RUNPATH/RPATH present on the
+# original binary.
+
+# The solution to this is to use a series of hooks exposed by the dynamic
+# linker itself, allowing us to observe its actions without affecting it.
+# Collectively this interface is called the rtld-audit interface.
+
+# Unfortunately there are multiple bugs within all but the latest Glibc versions
+# that cause segfaults when this interface is in use. Thus, during this
+# transition period we allow for the usage of LD_AUDIT to be disabled.
+# The fallback wraps `dlopen` and thus may result in R*PATH issues.
+
+# Check whether --enable-rtld-audit was given.
+if test "${enable_rtld_audit+set}" = set; then :
+  enableval=$enable_rtld_audit; rtld_audit="$enableval"
+else
+  rtld_audit=yes
+fi
+
+
+if test "$rtld_audit" = no ; then
+  export_ld_audit='# LD_AUDIT disabled by configure'
+  rtld_audit_mesg='no'
+else
+  export_ld_audit='export LD_AUDIT="${hpcrun_dir}/libhpcrun_audit.so:${LD_AUDIT}"'
+  rtld_audit_mesg='yes'
+fi
+
+
+ if test "$rtld_audit" = yes; then
+  OPT_ENABLE_RTLD_AUDIT_TRUE=
+  OPT_ENABLE_RTLD_AUDIT_FALSE='#'
+else
+  OPT_ENABLE_RTLD_AUDIT_TRUE='#'
+  OPT_ENABLE_RTLD_AUDIT_FALSE=
+fi
+
+
+if test "$rtld_audit" = yes ; then
+
+$as_echo "#define ENABLE_RTLD_AUDIT 1" >>confdefs.h
+
+fi
+
+#-------------------------------------------------
 # Option: --with-tbb=PATH
 #-------------------------------------------------
 
@@ -24405,6 +24461,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${OPT_PAPI_CUPTI_TRUE}" && test -z "${OPT_PAPI_CUPTI_FALSE}"; then
   as_fn_error $? "conditional \"OPT_PAPI_CUPTI\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${OPT_ENABLE_RTLD_AUDIT_TRUE}" && test -z "${OPT_ENABLE_RTLD_AUDIT_FALSE}"; then
+  as_fn_error $? "conditional \"OPT_ENABLE_RTLD_AUDIT\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${OPT_USE_ZLIB_TRUE}" && test -z "${OPT_USE_ZLIB_FALSE}"; then
@@ -27072,6 +27132,8 @@ $as_echo "$as_me:   hpcserver?:   ${enable_hpcserver}" >&6;}
 $as_echo "$as_me:   hpcstruct:    ${hpcstruct_mesg}" >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}:   perf-events:  ${perf_event_mesg}" >&5
 $as_echo "$as_me:   perf-events:  ${perf_event_mesg}" >&6;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}:   rtld-audit:   ${rtld_audit_mesg}" >&5
+$as_echo "$as_me:   rtld-audit:   ${rtld_audit_mesg}" >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}: " >&5
 $as_echo "$as_me: " >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}:   C compiler: $CC_VERSION" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -3522,6 +3522,45 @@ AM_CONDITIONAL(OPT_PAPI_CUPTI, [test "$use_papi_c_cupti" = yes])
 
 
 #-------------------------------------------------
+# Option: --disable-rtld-audit
+#-------------------------------------------------
+
+# Tracking changes to the set of currently loaded or mapped binaries at runtime
+# is difficult to do both accuractly and efficiently. In particular, there is
+# no clean way to wrap `dlopen` and still use the RUNPATH/RPATH present on the
+# original binary.
+
+# The solution to this is to use a series of hooks exposed by the dynamic
+# linker itself, allowing us to observe its actions without affecting it.
+# Collectively this interface is called the rtld-audit interface.
+
+# Unfortunately there are multiple bugs within all but the latest Glibc versions
+# that cause segfaults when this interface is in use. Thus, during this
+# transition period we allow for the usage of LD_AUDIT to be disabled.
+# The fallback wraps `dlopen` and thus may result in R*PATH issues.
+
+AC_ARG_ENABLE([rtld-audit],
+  [AS_HELP_STRING([--enable-rtld-audit],
+      [enable or disable the use of LD_AUDIT for monitoring of loaded binaries])],
+  [rtld_audit="$enableval"],
+  [rtld_audit=yes])
+
+if test "$rtld_audit" = no ; then
+  export_ld_audit='# LD_AUDIT disabled by configure'
+  rtld_audit_mesg='no'
+else
+  export_ld_audit='export LD_AUDIT="${hpcrun_dir}/libhpcrun_audit.so:${LD_AUDIT}"'
+  rtld_audit_mesg='yes'
+fi
+
+AC_SUBST([export_ld_audit])
+AM_CONDITIONAL([OPT_ENABLE_RTLD_AUDIT], [test "$rtld_audit" = yes])
+
+if test "$rtld_audit" = yes ; then
+  AC_DEFINE([ENABLE_RTLD_AUDIT], [1], [Using the LD_AUDIT interface])
+fi
+
+#-------------------------------------------------
 # Option: --with-tbb=PATH
 #-------------------------------------------------
 
@@ -5237,6 +5276,7 @@ AC_MSG_NOTICE([  datacentric?: ${OPT_ENABLE_DATACENTRIC_TRACE}])
 AC_MSG_NOTICE([  hpcserver?:   ${enable_hpcserver}])
 AC_MSG_NOTICE([  hpcstruct:    ${hpcstruct_mesg}])
 AC_MSG_NOTICE([  perf-events:  ${perf_event_mesg}])
+AC_MSG_NOTICE([  rtld-audit:   ${rtld_audit_mesg}])
 AC_MSG_NOTICE([])
 AC_MSG_NOTICE([  C compiler: $CC_VERSION])
 AC_MSG_NOTICE([  Path:      $CC_PATH])

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -405,6 +405,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/doc/man/Makefile.in
+++ b/doc/man/Makefile.in
@@ -379,6 +379,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/doc/manual/Makefile.in
+++ b/doc/manual/Makefile.in
@@ -376,6 +376,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/doc/www/Makefile.in
+++ b/doc/www/Makefile.in
@@ -376,6 +376,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -375,6 +375,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -405,6 +405,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/extern/Makefile.in
+++ b/src/extern/Makefile.in
@@ -414,6 +414,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/extern/libunwind/Makefile.in
+++ b/src/extern/libunwind/Makefile.in
@@ -349,6 +349,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/extern/lzma/Makefile.in
+++ b/src/extern/lzma/Makefile.in
@@ -349,6 +349,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/include/hpctoolkit-config.h.in
+++ b/src/include/hpctoolkit-config.h.in
@@ -33,6 +33,9 @@
 /* Symtab supports openmp (for fnbounds) */
 #undef ENABLE_OPENMP_SYMTAB
 
+/* Using the LD_AUDIT interface */
+#undef ENABLE_RTLD_AUDIT
+
 /* Add extra annotations for debugging with Valgrind */
 #undef ENABLE_VG_ANNOTATIONS
 

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -417,6 +417,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/analysis/Makefile.in
+++ b/src/lib/analysis/Makefile.in
@@ -453,6 +453,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/banal/Makefile.in
+++ b/src/lib/banal/Makefile.in
@@ -448,6 +448,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/binutils/Makefile.in
+++ b/src/lib/binutils/Makefile.in
@@ -459,6 +459,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/isa/Makefile.in
+++ b/src/lib/isa/Makefile.in
@@ -446,6 +446,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/prof-lean/Makefile.in
+++ b/src/lib/prof-lean/Makefile.in
@@ -449,6 +449,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/prof/Makefile.in
+++ b/src/lib/prof/Makefile.in
@@ -456,6 +456,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/profxml/Makefile.in
+++ b/src/lib/profxml/Makefile.in
@@ -451,6 +451,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/stubs-gcc_s/Makefile.in
+++ b/src/lib/stubs-gcc_s/Makefile.in
@@ -429,6 +429,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/support-lean/Makefile.in
+++ b/src/lib/support-lean/Makefile.in
@@ -435,6 +435,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/support/Makefile.in
+++ b/src/lib/support/Makefile.in
@@ -464,6 +464,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/lib/xml/Makefile.in
+++ b/src/lib/xml/Makefile.in
@@ -448,6 +448,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/Makefile.in
+++ b/src/tool/Makefile.in
@@ -422,6 +422,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcfnbounds/Makefile.in
+++ b/src/tool/hpcfnbounds/Makefile.in
@@ -532,6 +532,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcfnbounds2/Makefile.in
+++ b/src/tool/hpcfnbounds2/Makefile.in
@@ -430,6 +430,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpclump/Makefile.in
+++ b/src/tool/hpclump/Makefile.in
@@ -463,6 +463,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcprof-flat/Makefile.in
+++ b/src/tool/hpcprof-flat/Makefile.in
@@ -498,6 +498,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcprof-mpi/Makefile.in
+++ b/src/tool/hpcprof-mpi/Makefile.in
@@ -498,6 +498,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcprof/Makefile.in
+++ b/src/tool/hpcprof/Makefile.in
@@ -495,6 +495,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcproftt/Makefile.in
+++ b/src/tool/hpcproftt/Makefile.in
@@ -498,6 +498,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcrun-flat/Makefile.in
+++ b/src/tool/hpcrun-flat/Makefile.in
@@ -493,6 +493,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -121,7 +121,9 @@ endif
 
 if OPT_ENABLE_HPCRUN_DYNAMIC
   pkglib_LTLIBRARIES += libhpcrun.la
+if OPT_ENABLE_RTLD_AUDIT
   pkglib_LTLIBRARIES += libhpcrun_audit.la
+endif
   pkglib_LTLIBRARIES += libhpcrun_ga.la
   pkglib_LTLIBRARIES += libhpcrun_gprof.la
   pkglib_LTLIBRARIES += libhpcrun_io.la
@@ -453,6 +455,11 @@ MY_DYNAMIC_FILES = 			\
 	monitor-exts/openmp.c		\
         custom-init-dynamic.c
 
+if OPT_ENABLE_RTLD_AUDIT
+else
+MY_DYNAMIC_FILES += audit/fake-auditor.c
+endif
+
 MY_STATIC_FILES = 			\
 	fnbounds/fnbounds_static.c      \
         custom-init-static.c
@@ -589,8 +596,10 @@ libhpcrun_la_SOURCES = 			\
 	$(MY_BASE_FILES)		\
 	$(MY_DYNAMIC_FILES)
 
+if OPT_ENABLE_RTLD_AUDIT
 libhpcrun_audit_la_SOURCES =		\
 	audit/auditor.c
+endif
 
 libhpcrun_o_SOURCES = 			\
 	$(MY_BASE_FILES)		\
@@ -650,9 +659,11 @@ if OPT_BGQ_BACKEND
   libhpcrun_la_CPPFLAGS += -I$(srcdir)/utilities/bgq-cnk
 endif
 
+if OPT_ENABLE_RTLD_AUDIT
 libhpcrun_audit_la_CPPFLAGS =		\
 	$(MY_CPP_DEFINES)		\
 	$(MY_INCLUDE_DIRS)
+endif
 
 
 libhpcrun_o_CPPFLAGS =			\
@@ -781,7 +792,9 @@ OUR_LZMA_A = $(top_builddir)/src/extern/lzma/liblzma.a
 
 libhpcrun_la_LDFLAGS = -Wl,-Bsymbolic
 
+if OPT_ENABLE_RTLD_AUDIT
 libhpcrun_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
+endif
 
 libhpcrun_ga_la_LDFLAGS = -Wl,-Bsymbolic
 

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -125,35 +125,35 @@ pkglibexec_PROGRAMS =
 @OPT_BUILD_FRONT_END_TRUE@am__append_1 = scripts/hpcsummary \
 @OPT_BUILD_FRONT_END_TRUE@	scripts/hpclog
 @OPT_BUILD_FRONT_END_TRUE@am__append_2 = hpctoolkit.h
-@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am__append_3 = libhpcrun.la \
-@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	libhpcrun_audit.la \
-@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	libhpcrun_ga.la \
+@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am__append_3 = libhpcrun.la
+@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@@OPT_ENABLE_RTLD_AUDIT_TRUE@am__append_4 = libhpcrun_audit.la
+@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am__append_5 = libhpcrun_ga.la \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	libhpcrun_gprof.la \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	libhpcrun_io.la \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	libhpcrun_memleak.la \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	libhpcrun_pthread.la \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	libhpctoolkit.la
-@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am__append_4 = scripts/hpcrun
+@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am__append_6 = scripts/hpcrun
 @OPT_ENABLE_HPCRUN_STATIC_TRUE@noinst_PROGRAMS = libhpcrun.o$(EXEEXT)
-@OPT_ENABLE_HPCRUN_STATIC_TRUE@am__append_5 = libhpcrun_wrap.a \
+@OPT_ENABLE_HPCRUN_STATIC_TRUE@am__append_7 = libhpcrun_wrap.a \
 @OPT_ENABLE_HPCRUN_STATIC_TRUE@	libhpcrun_ga_wrap.a \
 @OPT_ENABLE_HPCRUN_STATIC_TRUE@	libhpcrun_gprof_wrap.a \
 @OPT_ENABLE_HPCRUN_STATIC_TRUE@	libhpcrun_io_wrap.a \
 @OPT_ENABLE_HPCRUN_STATIC_TRUE@	libhpcrun_memleak_wrap.a \
 @OPT_ENABLE_HPCRUN_STATIC_TRUE@	libhpcrun_pthread_wrap.a \
 @OPT_ENABLE_HPCRUN_STATIC_TRUE@	libhpctoolkit.a
-@OPT_ENABLE_HPCRUN_STATIC_TRUE@am__append_6 = scripts/hpclink
-@OPT_ENABLE_MPI_WRAP_TRUE@am__append_7 = libhpcrun_mpi.la
+@OPT_ENABLE_HPCRUN_STATIC_TRUE@am__append_8 = scripts/hpclink
+@OPT_ENABLE_MPI_WRAP_TRUE@am__append_9 = libhpcrun_mpi.la
 
 # 	gpu/gpu-api.c
 #	trampoline/common/trampoline.c
-@HOST_CPU_PPC_TRUE@am__append_8 = \
+@HOST_CPU_PPC_TRUE@am__append_10 = \
 @HOST_CPU_PPC_TRUE@        trampoline/common/trampoline_eager.c
 
-@HOST_CPU_PPC_FALSE@am__append_9 = \
+@HOST_CPU_PPC_FALSE@am__append_11 = \
 @HOST_CPU_PPC_FALSE@        trampoline/common/trampoline_lazy.c
 
-@OPT_ENABLE_PERF_EVENT_TRUE@am__append_10 = \
+@OPT_ENABLE_PERF_EVENT_TRUE@am__append_12 = \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/event_custom.c  \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/linux_perf.c    \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/perf_event_open.c     \
@@ -161,15 +161,16 @@ pkglibexec_PROGRAMS =
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/perf_mmap.c     \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/perf_skid.c
 
-@OPT_ENABLE_PERF_EVENT_TRUE@am__append_11 = -DHPCRUN_SS_LINUX_PERF
-@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_TRUE@am__append_12 = sample-sources/perf/perfmon-util.c
-@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_FALSE@am__append_13 = sample-sources/perf/perfmon-util-dummy.c
-@OPT_ENABLE_KERNEL_4_3_TRUE@@OPT_ENABLE_PERF_EVENT_TRUE@am__append_14 = sample-sources/perf/kernel_blocking.c
-@OPT_ENABLE_KERNEL_4_3_FALSE@@OPT_ENABLE_PERF_EVENT_TRUE@am__append_15 = sample-sources/perf/kernel_blocking_stub.c
-@OPT_PAPI_CUPTI_TRUE@am__append_16 = sample-sources/papi-c-cupti.c
+@OPT_ENABLE_PERF_EVENT_TRUE@am__append_13 = -DHPCRUN_SS_LINUX_PERF
+@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_TRUE@am__append_14 = sample-sources/perf/perfmon-util.c
+@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_FALSE@am__append_15 = sample-sources/perf/perfmon-util-dummy.c
+@OPT_ENABLE_KERNEL_4_3_TRUE@@OPT_ENABLE_PERF_EVENT_TRUE@am__append_16 = sample-sources/perf/kernel_blocking.c
+@OPT_ENABLE_KERNEL_4_3_FALSE@@OPT_ENABLE_PERF_EVENT_TRUE@am__append_17 = sample-sources/perf/kernel_blocking_stub.c
+@OPT_ENABLE_RTLD_AUDIT_FALSE@am__append_18 = audit/fake-auditor.c
+@OPT_PAPI_CUPTI_TRUE@am__append_19 = sample-sources/papi-c-cupti.c
 
 #MY_OPENCL_FILES =
-@ENABLE_OPENCL_TRUE@am__append_17 = \
+@ENABLE_OPENCL_TRUE@am__append_20 = \
 @ENABLE_OPENCL_TRUE@	sample-sources/opencl.c 		\
 @ENABLE_OPENCL_TRUE@	gpu/opencl/opencl-intercept.c		\
 @ENABLE_OPENCL_TRUE@	gpu/opencl/opencl-api.c			\
@@ -180,25 +181,22 @@ pkglibexec_PROGRAMS =
 #
 # BG/Q backend requires special treatment to avoid deadlocks
 #
-@OPT_BGQ_BACKEND_TRUE@am__append_18 = -DUSE_HW_THREAD_ID -DNONZERO_THRESHOLD
-@OPT_BGQ_BACKEND_TRUE@am__append_19 = -I$(srcdir)/utilities/bgq-cnk
-@OPT_BGQ_BACKEND_TRUE@am__append_20 = -I$(srcdir)/utilities/bgq-cnk
-@OPT_ENABLE_MPI_WRAP_TRUE@am__append_21 = mpi-overrides.c
-@OPT_ENABLE_MPI_WRAP_TRUE@am__append_22 = mpi-overrides.c
-@OPT_LIBUNWIND_STATIC_FPIC_TRUE@am__append_23 = $(OUR_LIBUNWIND_A)
-@OPT_LIBUNWIND_STATIC_FPIC_FALSE@am__append_24 = $(LIBUNWIND_LDFLAGS_DYN)
-@OPT_LZMA_STATIC_FPIC_TRUE@am__append_25 = $(OUR_LZMA_A)
-@OPT_LZMA_STATIC_FPIC_FALSE@am__append_26 = $(LZMA_LDFLAGS_DYN)
+@OPT_BGQ_BACKEND_TRUE@am__append_21 = -DUSE_HW_THREAD_ID -DNONZERO_THRESHOLD
+@OPT_BGQ_BACKEND_TRUE@am__append_22 = -I$(srcdir)/utilities/bgq-cnk
+@OPT_BGQ_BACKEND_TRUE@am__append_23 = -I$(srcdir)/utilities/bgq-cnk
+@OPT_ENABLE_MPI_WRAP_TRUE@am__append_24 = mpi-overrides.c
+@OPT_ENABLE_MPI_WRAP_TRUE@am__append_25 = mpi-overrides.c
+@OPT_LIBUNWIND_STATIC_FPIC_TRUE@am__append_26 = $(OUR_LIBUNWIND_A)
+@OPT_LIBUNWIND_STATIC_FPIC_FALSE@am__append_27 = $(LIBUNWIND_LDFLAGS_DYN)
+@OPT_LZMA_STATIC_FPIC_TRUE@am__append_28 = $(OUR_LZMA_A)
+@OPT_LZMA_STATIC_FPIC_FALSE@am__append_29 = $(LZMA_LDFLAGS_DYN)
 
 #-----------------------------------------------------------
 # whirled peas
 #-----------------------------------------------------------
-@HOST_OS_LINUX_TRUE@am__append_27 = $(MY_LINUX_DYNAMIC_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_28 = $(MY_MIPS_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_29 = $(MY_MIPS_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_30 = $(MY_MIPS_INCLUDE_DIRS)
-@HOST_CPU_MIPS_TRUE@am__append_31 = $(MY_MIPS_INCLUDE_DIRS)
-@HOST_CPU_MIPS_TRUE@am__append_32 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_OS_LINUX_TRUE@am__append_30 = $(MY_LINUX_DYNAMIC_FILES)
+@HOST_CPU_MIPS_TRUE@am__append_31 = $(MY_MIPS_FILES)
+@HOST_CPU_MIPS_TRUE@am__append_32 = $(MY_MIPS_FILES)
 @HOST_CPU_MIPS_TRUE@am__append_33 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_34 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_35 = $(MY_MIPS_INCLUDE_DIRS)
@@ -207,17 +205,17 @@ pkglibexec_PROGRAMS =
 @HOST_CPU_MIPS_TRUE@am__append_38 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_39 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_40 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_41 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_42 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_43 = $(MY_MIPS_INCLUDE_DIRS)
 
 # Note: setting CCASFLAGS here is a no-op hack with the side effect of
 # prefixing the tramp.s file names so they will be compiled separately
 # for .o and .so targets.  CFLAGS does this for the .c files, but
 # CFLAGS doesn't apply to .s files.  See the automake docs section
 # 8.3.9.2, Objects created with both libtool and without.
-@HOST_CPU_PPC_TRUE@am__append_41 = $(MY_PPC_FILES)
-@HOST_CPU_PPC_TRUE@am__append_42 = $(MY_PPC_FILES)
-@HOST_CPU_PPC_TRUE@am__append_43 = $(MY_PPC_INCLUDE_DIRS)
-@HOST_CPU_PPC_TRUE@am__append_44 = $(MY_PPC_INCLUDE_DIRS)
-@HOST_CPU_PPC_TRUE@am__append_45 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_PPC_TRUE@am__append_44 = $(MY_PPC_FILES)
+@HOST_CPU_PPC_TRUE@am__append_45 = $(MY_PPC_FILES)
 @HOST_CPU_PPC_TRUE@am__append_46 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_47 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_48 = $(MY_PPC_INCLUDE_DIRS)
@@ -228,15 +226,15 @@ pkglibexec_PROGRAMS =
 @HOST_CPU_PPC_TRUE@am__append_53 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_54 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_55 = $(MY_PPC_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_56 = $(MY_X86_FILES)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_57 = $(MY_X86_FILES)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_58 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_59 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_60 = $(XED2_HPCRUN_LIBS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_61 = $(XED2_HPCLINK_LIBS) 
+@HOST_CPU_PPC_TRUE@am__append_56 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_PPC_TRUE@am__append_57 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_PPC_TRUE@am__append_58 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_59 = $(MY_X86_FILES)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_60 = $(MY_X86_FILES)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_61 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_62 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_63 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_64 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_63 = $(XED2_HPCRUN_LIBS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_64 = $(XED2_HPCLINK_LIBS) 
 @HOST_CPU_X86_FAMILY_TRUE@am__append_65 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_66 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_67 = $(MY_X86_INCLUDE_DIRS)
@@ -246,11 +244,11 @@ pkglibexec_PROGRAMS =
 @HOST_CPU_X86_FAMILY_TRUE@am__append_71 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_72 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_73 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_IA64_TRUE@am__append_74 = $(MY_IA64_FILES)
-@HOST_CPU_IA64_TRUE@am__append_75 = $(MY_IA64_FILES)
-@HOST_CPU_IA64_TRUE@am__append_76 = $(MY_IA64_INCLUDE_DIRS)
-@HOST_CPU_IA64_TRUE@am__append_77 = $(MY_IA64_INCLUDE_DIRS)
-@HOST_CPU_IA64_TRUE@am__append_78 = $(MY_IA64_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_74 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_75 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_76 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_IA64_TRUE@am__append_77 = $(MY_IA64_FILES)
+@HOST_CPU_IA64_TRUE@am__append_78 = $(MY_IA64_FILES)
 @HOST_CPU_IA64_TRUE@am__append_79 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_80 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_81 = $(MY_IA64_INCLUDE_DIRS)
@@ -259,11 +257,11 @@ pkglibexec_PROGRAMS =
 @HOST_CPU_IA64_TRUE@am__append_84 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_85 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_86 = $(MY_IA64_INCLUDE_DIRS)
-@HOST_CPU_AARCH64_TRUE@am__append_87 = $(MY_AARCH64_FILES)
-@HOST_CPU_AARCH64_TRUE@am__append_88 = $(MY_AARCH64_FILES)
-@HOST_CPU_AARCH64_TRUE@am__append_89 = $(MY_AARCH64_INCLUDE_DIRS)
-@HOST_CPU_AARCH64_TRUE@am__append_90 = $(MY_AARCH64_INCLUDE_DIRS)
-@HOST_CPU_AARCH64_TRUE@am__append_91 = $(MY_AARCH64_INCLUDE_DIRS)
+@HOST_CPU_IA64_TRUE@am__append_87 = $(MY_IA64_INCLUDE_DIRS)
+@HOST_CPU_IA64_TRUE@am__append_88 = $(MY_IA64_INCLUDE_DIRS)
+@HOST_CPU_IA64_TRUE@am__append_89 = $(MY_IA64_INCLUDE_DIRS)
+@HOST_CPU_AARCH64_TRUE@am__append_90 = $(MY_AARCH64_FILES)
+@HOST_CPU_AARCH64_TRUE@am__append_91 = $(MY_AARCH64_FILES)
 @HOST_CPU_AARCH64_TRUE@am__append_92 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_93 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_94 = $(MY_AARCH64_INCLUDE_DIRS)
@@ -274,43 +272,46 @@ pkglibexec_PROGRAMS =
 @HOST_CPU_AARCH64_TRUE@am__append_99 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_100 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_101 = $(MY_AARCH64_INCLUDE_DIRS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_102 = $(MY_PAPI_FILES)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_103 = $(PAPI_INC_FLGS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_104 = $(PAPI_LD_FLGS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_105 = -DHPCRUN_SS_PAPI
-@OPT_ENABLE_CUPTI_TRUE@am__append_106 = $(MY_CUPTI_FILES)
-@OPT_ENABLE_CUPTI_TRUE@am__append_107 = $(MY_CUPTI_FILES)
-@OPT_ENABLE_CUPTI_TRUE@am__append_108 = $(CUPTI_INC_FLGS)
-@OPT_ENABLE_CUPTI_TRUE@am__append_109 = -DHPCRUN_SS_NVIDIA
-@OPT_PAPI_CUPTI_TRUE@am__append_110 = $(CUPTI_INC_FLGS)
-@OPT_PAPI_CUPTI_TRUE@am__append_111 = -DHPCRUN_SS_PAPI_C_CUPTI
-@OPT_PAPI_STATIC_TRUE@am__append_112 = $(MY_PAPI_FILES)
-@OPT_PAPI_STATIC_TRUE@am__append_113 = $(PAPI_INC_FLGS)
-@OPT_PAPI_STATIC_TRUE@am__append_114 = $(PAPI_LD_FLGS)
-@OPT_PAPI_STATIC_TRUE@am__append_115 = -DHPCRUN_SS_PAPI
-@OPT_ENABLE_UPC_TRUE@am__append_116 = $(MY_UPC_FILES)
-@OPT_ENABLE_UPC_TRUE@am__append_117 = $(MY_UPC_FILES)
-@OPT_ENABLE_UPC_TRUE@am__append_118 = $(OPT_UPC_IFLAGS)
-@OPT_ENABLE_UPC_TRUE@am__append_119 = $(OPT_UPC_IFLAGS)
-@OPT_ENABLE_UPC_TRUE@am__append_120 = $(OPT_UPC_LDFLAGS)
-@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_121 = -DLUSH_PTHREADS
-@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_122 = -DLUSH_PTHREADS
-@OPT_ENABLE_CUDA_TRUE@am__append_123 = $(MY_CUDA_FILES)
-@OPT_ENABLE_CUDA_TRUE@am__append_124 = -DENABLE_CUDA
-@OPT_ENABLE_CUDA_TRUE@am__append_125 = $(OPT_CUDA_IFLAGS)
+@HOST_CPU_AARCH64_TRUE@am__append_102 = $(MY_AARCH64_INCLUDE_DIRS)
+@HOST_CPU_AARCH64_TRUE@am__append_103 = $(MY_AARCH64_INCLUDE_DIRS)
+@HOST_CPU_AARCH64_TRUE@am__append_104 = $(MY_AARCH64_INCLUDE_DIRS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_105 = $(MY_PAPI_FILES)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_106 = $(PAPI_INC_FLGS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_107 = $(PAPI_LD_FLGS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_108 = -DHPCRUN_SS_PAPI
+@OPT_ENABLE_CUPTI_TRUE@am__append_109 = $(MY_CUPTI_FILES)
+@OPT_ENABLE_CUPTI_TRUE@am__append_110 = $(MY_CUPTI_FILES)
+@OPT_ENABLE_CUPTI_TRUE@am__append_111 = $(CUPTI_INC_FLGS)
+@OPT_ENABLE_CUPTI_TRUE@am__append_112 = -DHPCRUN_SS_NVIDIA
+@OPT_PAPI_CUPTI_TRUE@am__append_113 = $(CUPTI_INC_FLGS)
+@OPT_PAPI_CUPTI_TRUE@am__append_114 = -DHPCRUN_SS_PAPI_C_CUPTI
+@OPT_PAPI_STATIC_TRUE@am__append_115 = $(MY_PAPI_FILES)
+@OPT_PAPI_STATIC_TRUE@am__append_116 = $(PAPI_INC_FLGS)
+@OPT_PAPI_STATIC_TRUE@am__append_117 = $(PAPI_LD_FLGS)
+@OPT_PAPI_STATIC_TRUE@am__append_118 = -DHPCRUN_SS_PAPI
+@OPT_ENABLE_UPC_TRUE@am__append_119 = $(MY_UPC_FILES)
+@OPT_ENABLE_UPC_TRUE@am__append_120 = $(MY_UPC_FILES)
+@OPT_ENABLE_UPC_TRUE@am__append_121 = $(OPT_UPC_IFLAGS)
+@OPT_ENABLE_UPC_TRUE@am__append_122 = $(OPT_UPC_IFLAGS)
+@OPT_ENABLE_UPC_TRUE@am__append_123 = $(OPT_UPC_LDFLAGS)
+@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_124 = -DLUSH_PTHREADS
+@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_125 = -DLUSH_PTHREADS
 @OPT_ENABLE_CUDA_TRUE@am__append_126 = $(MY_CUDA_FILES)
-@OPT_ENABLE_ROCM_TRUE@am__append_127 = $(MY_ROCM_FILES)
-@OPT_ENABLE_ROCM_TRUE@am__append_128 = -DENABLE_ROCM
-@OPT_ENABLE_ROCM_TRUE@am__append_129 = $(OPT_ROCM_IFLAGS)
-@OPT_ENABLE_ROCM_TRUE@am__append_130 = -DHPCRUN_SS_AMD
-@OPT_ENABLE_LEVEL0_TRUE@am__append_131 = $(MY_LEVEL0_FILES)
-@OPT_ENABLE_LEVEL0_TRUE@am__append_132 = -DENABLE_LEVEL0
-@OPT_ENABLE_LEVEL0_TRUE@am__append_133 = $(OPT_LEVEL0_IFLAGS)
-@OPT_ENABLE_LEVEL0_TRUE@am__append_134 = -DHPCRUN_SS_LEVEL0
-@ENABLE_OPENCL_TRUE@am__append_135 = $(OPENCL_IFLAGS)
-@ENABLE_OPENCL_TRUE@am__append_136 = -DHPCRUN_SS_OPENCL
-@OPT_ENABLE_LUSH_TRUE@@OPT_WITH_CILK_TRUE@am__append_137 = libagent-cilk.la
-@OPT_ENABLE_LUSH_TRUE@am__append_138 = libagent-pthread.la \
+@OPT_ENABLE_CUDA_TRUE@am__append_127 = -DENABLE_CUDA
+@OPT_ENABLE_CUDA_TRUE@am__append_128 = $(OPT_CUDA_IFLAGS)
+@OPT_ENABLE_CUDA_TRUE@am__append_129 = $(MY_CUDA_FILES)
+@OPT_ENABLE_ROCM_TRUE@am__append_130 = $(MY_ROCM_FILES)
+@OPT_ENABLE_ROCM_TRUE@am__append_131 = -DENABLE_ROCM
+@OPT_ENABLE_ROCM_TRUE@am__append_132 = $(OPT_ROCM_IFLAGS)
+@OPT_ENABLE_ROCM_TRUE@am__append_133 = -DHPCRUN_SS_AMD
+@OPT_ENABLE_LEVEL0_TRUE@am__append_134 = $(MY_LEVEL0_FILES)
+@OPT_ENABLE_LEVEL0_TRUE@am__append_135 = -DENABLE_LEVEL0
+@OPT_ENABLE_LEVEL0_TRUE@am__append_136 = $(OPT_LEVEL0_IFLAGS)
+@OPT_ENABLE_LEVEL0_TRUE@am__append_137 = -DHPCRUN_SS_LEVEL0
+@ENABLE_OPENCL_TRUE@am__append_138 = $(OPENCL_IFLAGS)
+@ENABLE_OPENCL_TRUE@am__append_139 = -DHPCRUN_SS_OPENCL
+@OPT_ENABLE_LUSH_TRUE@@OPT_WITH_CILK_TRUE@am__append_140 = libagent-cilk.la
+@OPT_ENABLE_LUSH_TRUE@am__append_141 = libagent-pthread.la \
 @OPT_ENABLE_LUSH_TRUE@	libagent-tbb.la
 subdir = src/tool/hpcrun
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -458,8 +459,8 @@ am__DEPENDENCIES_1 =
 @OPT_LZMA_STATIC_FPIC_FALSE@	$(am__DEPENDENCIES_1)
 libhpcrun_la_DEPENDENCIES = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
 	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
-	$(am__DEPENDENCIES_1) $(am__append_23) $(am__DEPENDENCIES_2) \
-	$(am__append_25) $(am__DEPENDENCIES_3)
+	$(am__DEPENDENCIES_1) $(am__append_26) $(am__DEPENDENCIES_2) \
+	$(am__append_28) $(am__DEPENDENCIES_3)
 am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	disabled.c closure-registry.c cct_insert_backtrace.c \
 	cct_backtrace_finalize.c env.c epoch.c files.c \
@@ -529,7 +530,8 @@ am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	gpu/opencl/opencl-api.c gpu/opencl/opencl-memory-manager.c \
 	gpu/opencl/opencl-activity-translate.c \
 	fnbounds/fnbounds_client.c fnbounds/fnbounds_dynamic.c \
-	monitor-exts/openmp.c custom-init-dynamic.c os/linux/dylib.c \
+	monitor-exts/openmp.c custom-init-dynamic.c \
+	audit/fake-auditor.c os/linux/dylib.c \
 	unwind/common/default_validation_summary.c \
 	trampoline/ppc64/ppc64-tramp.s \
 	utilities/arch/ppc64/ppc64-context-pc.c \
@@ -702,36 +704,37 @@ am__objects_15 = utilities/libhpcrun_la-first_func.lo \
 	$(am__objects_8) $(am__objects_9) $(am__objects_10) \
 	$(am__objects_11) $(am__objects_12) $(am__objects_13) \
 	$(am__objects_14)
-am__objects_16 = fnbounds/libhpcrun_la-fnbounds_client.lo \
+@OPT_ENABLE_RTLD_AUDIT_FALSE@am__objects_16 = audit/libhpcrun_la-fake-auditor.lo
+am__objects_17 = fnbounds/libhpcrun_la-fnbounds_client.lo \
 	fnbounds/libhpcrun_la-fnbounds_dynamic.lo \
 	monitor-exts/libhpcrun_la-openmp.lo \
-	libhpcrun_la-custom-init-dynamic.lo
-am__objects_17 = os/linux/libhpcrun_la-dylib.lo
-@HOST_OS_LINUX_TRUE@am__objects_18 = $(am__objects_17)
-am__objects_19 =  \
+	libhpcrun_la-custom-init-dynamic.lo $(am__objects_16)
+am__objects_18 = os/linux/libhpcrun_la-dylib.lo
+@HOST_OS_LINUX_TRUE@am__objects_19 = $(am__objects_18)
+am__objects_20 =  \
 	unwind/common/libhpcrun_la-default_validation_summary.lo
-@HOST_CPU_MIPS_TRUE@am__objects_20 = $(am__objects_19)
-am__objects_21 = trampoline/ppc64/libhpcrun_la-ppc64-tramp.lo \
+@HOST_CPU_MIPS_TRUE@am__objects_21 = $(am__objects_20)
+am__objects_22 = trampoline/ppc64/libhpcrun_la-ppc64-tramp.lo \
 	utilities/arch/ppc64/libhpcrun_la-ppc64-context-pc.lo
-@HOST_CPU_PPC_TRUE@am__objects_22 = $(am__objects_21)
-am__objects_23 = trampoline/x86-family/libhpcrun_la-x86-tramp.lo \
+@HOST_CPU_PPC_TRUE@am__objects_23 = $(am__objects_22)
+am__objects_24 = trampoline/x86-family/libhpcrun_la-x86-tramp.lo \
 	utilities/arch/x86-family/libhpcrun_la-x86-context-pc.lo
-@HOST_CPU_X86_FAMILY_TRUE@am__objects_24 = $(am__objects_23)
-am__objects_25 = trampoline/ia64/libhpcrun_la-ia64-tramp.lo \
+@HOST_CPU_X86_FAMILY_TRUE@am__objects_25 = $(am__objects_24)
+am__objects_26 = trampoline/ia64/libhpcrun_la-ia64-tramp.lo \
 	utilities/arch/ia64/libhpcrun_la-ia64-context-pc.lo
-@HOST_CPU_IA64_TRUE@am__objects_26 = $(am__objects_25)
-am__objects_27 = trampoline/aarch64/libhpcrun_la-aarch64-tramp.lo \
+@HOST_CPU_IA64_TRUE@am__objects_27 = $(am__objects_26)
+am__objects_28 = trampoline/aarch64/libhpcrun_la-aarch64-tramp.lo \
 	utilities/arch/libunwind/libhpcrun_la-libunwind-context-pc.lo
-@HOST_CPU_AARCH64_TRUE@am__objects_28 = $(am__objects_27)
-@OPT_PAPI_CUPTI_TRUE@am__objects_29 = sample-sources/libhpcrun_la-papi-c-cupti.lo
-@OPT_PAPI_COMPONENT_FALSE@am__objects_30 =  \
+@HOST_CPU_AARCH64_TRUE@am__objects_29 = $(am__objects_28)
+@OPT_PAPI_CUPTI_TRUE@am__objects_30 = sample-sources/libhpcrun_la-papi-c-cupti.lo
+@OPT_PAPI_COMPONENT_FALSE@am__objects_31 =  \
 @OPT_PAPI_COMPONENT_FALSE@	sample-sources/libhpcrun_la-papi.lo \
-@OPT_PAPI_COMPONENT_FALSE@	$(am__objects_29)
-@OPT_PAPI_COMPONENT_TRUE@am__objects_30 = sample-sources/libhpcrun_la-papi-c.lo \
+@OPT_PAPI_COMPONENT_FALSE@	$(am__objects_30)
+@OPT_PAPI_COMPONENT_TRUE@am__objects_31 = sample-sources/libhpcrun_la-papi-c.lo \
 @OPT_PAPI_COMPONENT_TRUE@	sample-sources/libhpcrun_la-papi-c-extended-info.lo \
-@OPT_PAPI_COMPONENT_TRUE@	$(am__objects_29)
-@OPT_PAPI_DYNAMIC_TRUE@am__objects_31 = $(am__objects_30)
-@OPT_ENABLE_CUPTI_TRUE@am__objects_32 =  \
+@OPT_PAPI_COMPONENT_TRUE@	$(am__objects_30)
+@OPT_PAPI_DYNAMIC_TRUE@am__objects_32 = $(am__objects_31)
+@OPT_ENABLE_CUPTI_TRUE@am__objects_33 =  \
 @OPT_ENABLE_CUPTI_TRUE@	sample-sources/libhpcrun_la-nvidia.lo \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_la-cubin-hash-map.lo \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_la-cubin-id-map.lo \
@@ -742,18 +745,18 @@ am__objects_27 = trampoline/aarch64/libhpcrun_la-aarch64-tramp.lo \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_la-cupti-analysis.lo \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_la-cupti-api.lo \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_la-cupti-gpu-api.lo
-@OPT_ENABLE_CUPTI_TRUE@am__objects_33 = $(am__objects_32)
-am__objects_34 = sample-sources/libhpcrun_la-upc.lo
-@OPT_ENABLE_UPC_TRUE@am__objects_35 = $(am__objects_34)
-am__objects_36 =
-@OPT_ENABLE_ROCM_TRUE@am__objects_37 =  \
+@OPT_ENABLE_CUPTI_TRUE@am__objects_34 = $(am__objects_33)
+am__objects_35 = sample-sources/libhpcrun_la-upc.lo
+@OPT_ENABLE_UPC_TRUE@am__objects_36 = $(am__objects_35)
+am__objects_37 =
+@OPT_ENABLE_ROCM_TRUE@am__objects_38 =  \
 @OPT_ENABLE_ROCM_TRUE@	sample-sources/libhpcrun_la-amd.lo \
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-activity-translate.lo \
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-roctracer-api.lo \
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-debug-api.lo \
 @OPT_ENABLE_ROCM_TRUE@	gpu/amd/libhpcrun_la-rocm-binary-processing.lo
-@OPT_ENABLE_ROCM_TRUE@am__objects_38 = $(am__objects_37)
-@OPT_ENABLE_LEVEL0_TRUE@am__objects_39 =  \
+@OPT_ENABLE_ROCM_TRUE@am__objects_39 = $(am__objects_38)
+@OPT_ENABLE_LEVEL0_TRUE@am__objects_40 =  \
 @OPT_ENABLE_LEVEL0_TRUE@	sample-sources/libhpcrun_la-level0.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-api.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-command-list-context-map.lo \
@@ -762,24 +765,24 @@ am__objects_36 =
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-data-node.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-event-map.lo \
 @OPT_ENABLE_LEVEL0_TRUE@	gpu/level0/libhpcrun_la-level0-handle-map.lo
-@OPT_ENABLE_LEVEL0_TRUE@am__objects_40 = $(am__objects_39)
-am__objects_41 = unwind/common/libhpcrun_la-backtrace.lo \
+@OPT_ENABLE_LEVEL0_TRUE@am__objects_41 = $(am__objects_40)
+am__objects_42 = unwind/common/libhpcrun_la-backtrace.lo \
 	unwind/common/libhpcrun_la-unw-throw.lo
-am__objects_42 = $(am__objects_41) \
+am__objects_43 = $(am__objects_42) \
 	unwind/common/libhpcrun_la-binarytree_uwi.lo \
 	unwind/common/libhpcrun_la-interval_t.lo \
 	unwind/common/libhpcrun_la-libunw_intervals.lo \
 	unwind/common/libhpcrun_la-stack_troll.lo \
 	unwind/common/libhpcrun_la-uw_hash.lo \
 	unwind/common/libhpcrun_la-uw_recipe_map.lo
-am__objects_43 = $(am__objects_42) \
+am__objects_44 = $(am__objects_43) \
 	unwind/generic-libunwind/libhpcrun_la-libunw-unwind.lo \
 	unwind/common/libhpcrun_la-default_validation_summary.lo
-am__objects_44 = $(am__objects_42) \
+am__objects_45 = $(am__objects_43) \
 	unwind/ppc64/libhpcrun_la-ppc64-unwind.lo \
 	unwind/ppc64/libhpcrun_la-ppc64-unwind-interval.lo \
 	unwind/common/libhpcrun_la-default_validation_summary.lo
-am__objects_45 = $(am__objects_42) \
+am__objects_46 = $(am__objects_43) \
 	unwind/x86-family/libhpcrun_la-x86-all.lo \
 	unwind/x86-family/libhpcrun_la-amd-xop.lo \
 	unwind/x86-family/libhpcrun_la-x86-cold-path.lo \
@@ -799,15 +802,15 @@ am__objects_45 = $(am__objects_42) \
 	unwind/x86-family/manual-intervals/libhpcrun_la-x86-32bit-icc-variant.lo \
 	unwind/x86-family/manual-intervals/libhpcrun_la-x86-fail-intervals.lo \
 	unwind/x86-family/manual-intervals/libhpcrun_la-x86-pgi-mp_pexit.lo
-@UNW_LIBUNW_FALSE@@UNW_PPC64_FALSE@@UNW_X86_TRUE@am__objects_46 = $(am__objects_45)
-@UNW_LIBUNW_FALSE@@UNW_PPC64_TRUE@am__objects_46 = $(am__objects_44)
-@UNW_LIBUNW_TRUE@am__objects_46 = $(am__objects_43)
-am_libhpcrun_la_OBJECTS = $(am__objects_15) $(am__objects_16) \
-	$(am__objects_18) $(am__objects_20) $(am__objects_22) \
-	$(am__objects_24) $(am__objects_26) $(am__objects_28) \
-	$(am__objects_31) $(am__objects_33) $(am__objects_35) \
-	$(am__objects_36) $(am__objects_38) $(am__objects_40) \
-	$(am__objects_46) utilities/libhpcrun_la-last_func.lo
+@UNW_LIBUNW_FALSE@@UNW_PPC64_FALSE@@UNW_X86_TRUE@am__objects_47 = $(am__objects_46)
+@UNW_LIBUNW_FALSE@@UNW_PPC64_TRUE@am__objects_47 = $(am__objects_45)
+@UNW_LIBUNW_TRUE@am__objects_47 = $(am__objects_44)
+am_libhpcrun_la_OBJECTS = $(am__objects_15) $(am__objects_17) \
+	$(am__objects_19) $(am__objects_21) $(am__objects_23) \
+	$(am__objects_25) $(am__objects_27) $(am__objects_29) \
+	$(am__objects_32) $(am__objects_34) $(am__objects_36) \
+	$(am__objects_37) $(am__objects_39) $(am__objects_41) \
+	$(am__objects_47) utilities/libhpcrun_la-last_func.lo
 libhpcrun_la_OBJECTS = $(am_libhpcrun_la_OBJECTS)
 libhpcrun_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(libhpcrun_la_CFLAGS) \
@@ -815,14 +818,15 @@ libhpcrun_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am_libhpcrun_la_rpath = -rpath \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	$(pkglibdir)
 libhpcrun_audit_la_LIBADD =
-am_libhpcrun_audit_la_OBJECTS = audit/libhpcrun_audit_la-auditor.lo
+am__libhpcrun_audit_la_SOURCES_DIST = audit/auditor.c
+@OPT_ENABLE_RTLD_AUDIT_TRUE@am_libhpcrun_audit_la_OBJECTS = audit/libhpcrun_audit_la-auditor.lo
 libhpcrun_audit_la_OBJECTS = $(am_libhpcrun_audit_la_OBJECTS)
 libhpcrun_audit_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(AM_CFLAGS) $(CFLAGS) $(libhpcrun_audit_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
-@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am_libhpcrun_audit_la_rpath = -rpath \
-@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	$(pkglibdir)
+@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@@OPT_ENABLE_RTLD_AUDIT_TRUE@am_libhpcrun_audit_la_rpath = -rpath \
+@OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@@OPT_ENABLE_RTLD_AUDIT_TRUE@	$(pkglibdir)
 libhpcrun_ga_la_LIBADD =
 am_libhpcrun_ga_la_OBJECTS =  \
 	sample-sources/libhpcrun_ga_la-ga-overrides.lo
@@ -998,24 +1002,24 @@ am__libhpcrun_o_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	unwind/x86-family/manual-intervals/x86-fail-intervals.c \
 	unwind/x86-family/manual-intervals/x86-pgi-mp_pexit.c \
 	utilities/last_func.c
-@HOST_CPU_PPC_TRUE@am__objects_47 = trampoline/common/libhpcrun_o-trampoline_eager.$(OBJEXT)
-@HOST_CPU_PPC_FALSE@am__objects_48 = trampoline/common/libhpcrun_o-trampoline_lazy.$(OBJEXT)
-@OPT_ENABLE_PERF_EVENT_TRUE@am__objects_49 = sample-sources/perf/libhpcrun_o-event_custom.$(OBJEXT) \
+@HOST_CPU_PPC_TRUE@am__objects_48 = trampoline/common/libhpcrun_o-trampoline_eager.$(OBJEXT)
+@HOST_CPU_PPC_FALSE@am__objects_49 = trampoline/common/libhpcrun_o-trampoline_lazy.$(OBJEXT)
+@OPT_ENABLE_PERF_EVENT_TRUE@am__objects_50 = sample-sources/perf/libhpcrun_o-event_custom.$(OBJEXT) \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/libhpcrun_o-linux_perf.$(OBJEXT) \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/libhpcrun_o-perf_event_open.$(OBJEXT) \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/libhpcrun_o-perf-util.$(OBJEXT) \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/libhpcrun_o-perf_mmap.$(OBJEXT) \
 @OPT_ENABLE_PERF_EVENT_TRUE@	sample-sources/perf/libhpcrun_o-perf_skid.$(OBJEXT)
-@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_TRUE@am__objects_50 = sample-sources/perf/libhpcrun_o-perfmon-util.$(OBJEXT)
-@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_FALSE@am__objects_51 = sample-sources/perf/libhpcrun_o-perfmon-util-dummy.$(OBJEXT)
-@OPT_ENABLE_KERNEL_4_3_TRUE@@OPT_ENABLE_PERF_EVENT_TRUE@am__objects_52 = sample-sources/perf/libhpcrun_o-kernel_blocking.$(OBJEXT)
-@OPT_ENABLE_KERNEL_4_3_FALSE@@OPT_ENABLE_PERF_EVENT_TRUE@am__objects_53 = sample-sources/perf/libhpcrun_o-kernel_blocking_stub.$(OBJEXT)
-@ENABLE_OPENCL_TRUE@am__objects_54 = sample-sources/libhpcrun_o-opencl.$(OBJEXT) \
+@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_TRUE@am__objects_51 = sample-sources/perf/libhpcrun_o-perfmon-util.$(OBJEXT)
+@OPT_ENABLE_PERF_EVENT_TRUE@@OPT_PERFMON_FALSE@am__objects_52 = sample-sources/perf/libhpcrun_o-perfmon-util-dummy.$(OBJEXT)
+@OPT_ENABLE_KERNEL_4_3_TRUE@@OPT_ENABLE_PERF_EVENT_TRUE@am__objects_53 = sample-sources/perf/libhpcrun_o-kernel_blocking.$(OBJEXT)
+@OPT_ENABLE_KERNEL_4_3_FALSE@@OPT_ENABLE_PERF_EVENT_TRUE@am__objects_54 = sample-sources/perf/libhpcrun_o-kernel_blocking_stub.$(OBJEXT)
+@ENABLE_OPENCL_TRUE@am__objects_55 = sample-sources/libhpcrun_o-opencl.$(OBJEXT) \
 @ENABLE_OPENCL_TRUE@	gpu/opencl/libhpcrun_o-opencl-intercept.$(OBJEXT) \
 @ENABLE_OPENCL_TRUE@	gpu/opencl/libhpcrun_o-opencl-api.$(OBJEXT) \
 @ENABLE_OPENCL_TRUE@	gpu/opencl/libhpcrun_o-opencl-memory-manager.$(OBJEXT) \
 @ENABLE_OPENCL_TRUE@	gpu/opencl/libhpcrun_o-opencl-activity-translate.$(OBJEXT)
-am__objects_55 = utilities/libhpcrun_o-first_func.$(OBJEXT) \
+am__objects_56 = utilities/libhpcrun_o-first_func.$(OBJEXT) \
 	libhpcrun_o-main.$(OBJEXT) libhpcrun_o-disabled.$(OBJEXT) \
 	libhpcrun_o-closure-registry.$(OBJEXT) \
 	libhpcrun_o-cct_insert_backtrace.$(OBJEXT) \
@@ -1126,29 +1130,29 @@ am__objects_55 = utilities/libhpcrun_o-first_func.$(OBJEXT) \
 	utilities/libhpcrun_o-line_wrapping.$(OBJEXT) \
 	utilities/libhpcrun_o-timer.$(OBJEXT) \
 	utilities/libhpcrun_o-tokenize.$(OBJEXT) \
-	utilities/libhpcrun_o-unlink.$(OBJEXT) $(am__objects_47) \
-	$(am__objects_48) $(am__objects_49) $(am__objects_50) \
-	$(am__objects_51) $(am__objects_52) $(am__objects_53) \
-	$(am__objects_54)
-am__objects_56 = fnbounds/libhpcrun_o-fnbounds_static.$(OBJEXT) \
+	utilities/libhpcrun_o-unlink.$(OBJEXT) $(am__objects_48) \
+	$(am__objects_49) $(am__objects_50) $(am__objects_51) \
+	$(am__objects_52) $(am__objects_53) $(am__objects_54) \
+	$(am__objects_55)
+am__objects_57 = fnbounds/libhpcrun_o-fnbounds_static.$(OBJEXT) \
 	libhpcrun_o-custom-init-static.$(OBJEXT)
-am__objects_57 = unwind/common/libhpcrun_o-default_validation_summary.$(OBJEXT)
-@HOST_CPU_MIPS_TRUE@am__objects_58 = $(am__objects_57)
-am__objects_59 = trampoline/ppc64/libhpcrun_o-ppc64-tramp.$(OBJEXT) \
+am__objects_58 = unwind/common/libhpcrun_o-default_validation_summary.$(OBJEXT)
+@HOST_CPU_MIPS_TRUE@am__objects_59 = $(am__objects_58)
+am__objects_60 = trampoline/ppc64/libhpcrun_o-ppc64-tramp.$(OBJEXT) \
 	utilities/arch/ppc64/libhpcrun_o-ppc64-context-pc.$(OBJEXT)
-@HOST_CPU_PPC_TRUE@am__objects_60 = $(am__objects_59)
-am__objects_61 =  \
+@HOST_CPU_PPC_TRUE@am__objects_61 = $(am__objects_60)
+am__objects_62 =  \
 	trampoline/x86-family/libhpcrun_o-x86-tramp.$(OBJEXT) \
 	utilities/arch/x86-family/libhpcrun_o-x86-context-pc.$(OBJEXT)
-@HOST_CPU_X86_FAMILY_TRUE@am__objects_62 = $(am__objects_61)
-am__objects_63 = trampoline/ia64/libhpcrun_o-ia64-tramp.$(OBJEXT) \
+@HOST_CPU_X86_FAMILY_TRUE@am__objects_63 = $(am__objects_62)
+am__objects_64 = trampoline/ia64/libhpcrun_o-ia64-tramp.$(OBJEXT) \
 	utilities/arch/ia64/libhpcrun_o-ia64-context-pc.$(OBJEXT)
-@HOST_CPU_IA64_TRUE@am__objects_64 = $(am__objects_63)
-am__objects_65 =  \
+@HOST_CPU_IA64_TRUE@am__objects_65 = $(am__objects_64)
+am__objects_66 =  \
 	trampoline/aarch64/libhpcrun_o-aarch64-tramp.$(OBJEXT) \
 	utilities/arch/libunwind/libhpcrun_o-libunwind-context-pc.$(OBJEXT)
-@HOST_CPU_AARCH64_TRUE@am__objects_66 = $(am__objects_65)
-@OPT_ENABLE_CUPTI_TRUE@am__objects_67 = sample-sources/libhpcrun_o-nvidia.$(OBJEXT) \
+@HOST_CPU_AARCH64_TRUE@am__objects_67 = $(am__objects_66)
+@OPT_ENABLE_CUPTI_TRUE@am__objects_68 = sample-sources/libhpcrun_o-nvidia.$(OBJEXT) \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_o-cubin-hash-map.$(OBJEXT) \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_o-cubin-id-map.$(OBJEXT) \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_o-cubin-symbols.$(OBJEXT) \
@@ -1158,33 +1162,33 @@ am__objects_65 =  \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_o-cupti-analysis.$(OBJEXT) \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_o-cupti-api.$(OBJEXT) \
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/libhpcrun_o-cupti-gpu-api.$(OBJEXT)
-@OPT_ENABLE_CUPTI_TRUE@am__objects_68 = $(am__objects_67)
-@OPT_PAPI_CUPTI_TRUE@am__objects_69 = sample-sources/libhpcrun_o-papi-c-cupti.$(OBJEXT)
-@OPT_PAPI_COMPONENT_FALSE@am__objects_70 = sample-sources/libhpcrun_o-papi.$(OBJEXT) \
-@OPT_PAPI_COMPONENT_FALSE@	$(am__objects_69)
-@OPT_PAPI_COMPONENT_TRUE@am__objects_70 = sample-sources/libhpcrun_o-papi-c.$(OBJEXT) \
+@OPT_ENABLE_CUPTI_TRUE@am__objects_69 = $(am__objects_68)
+@OPT_PAPI_CUPTI_TRUE@am__objects_70 = sample-sources/libhpcrun_o-papi-c-cupti.$(OBJEXT)
+@OPT_PAPI_COMPONENT_FALSE@am__objects_71 = sample-sources/libhpcrun_o-papi.$(OBJEXT) \
+@OPT_PAPI_COMPONENT_FALSE@	$(am__objects_70)
+@OPT_PAPI_COMPONENT_TRUE@am__objects_71 = sample-sources/libhpcrun_o-papi-c.$(OBJEXT) \
 @OPT_PAPI_COMPONENT_TRUE@	sample-sources/libhpcrun_o-papi-c-extended-info.$(OBJEXT) \
-@OPT_PAPI_COMPONENT_TRUE@	$(am__objects_69)
-@OPT_PAPI_STATIC_TRUE@am__objects_71 = $(am__objects_70)
-am__objects_72 = sample-sources/libhpcrun_o-upc.$(OBJEXT)
-@OPT_ENABLE_UPC_TRUE@am__objects_73 = $(am__objects_72)
-am__objects_74 = unwind/common/libhpcrun_o-backtrace.$(OBJEXT) \
+@OPT_PAPI_COMPONENT_TRUE@	$(am__objects_70)
+@OPT_PAPI_STATIC_TRUE@am__objects_72 = $(am__objects_71)
+am__objects_73 = sample-sources/libhpcrun_o-upc.$(OBJEXT)
+@OPT_ENABLE_UPC_TRUE@am__objects_74 = $(am__objects_73)
+am__objects_75 = unwind/common/libhpcrun_o-backtrace.$(OBJEXT) \
 	unwind/common/libhpcrun_o-unw-throw.$(OBJEXT)
-am__objects_75 = $(am__objects_74) \
+am__objects_76 = $(am__objects_75) \
 	unwind/common/libhpcrun_o-binarytree_uwi.$(OBJEXT) \
 	unwind/common/libhpcrun_o-interval_t.$(OBJEXT) \
 	unwind/common/libhpcrun_o-libunw_intervals.$(OBJEXT) \
 	unwind/common/libhpcrun_o-stack_troll.$(OBJEXT) \
 	unwind/common/libhpcrun_o-uw_hash.$(OBJEXT) \
 	unwind/common/libhpcrun_o-uw_recipe_map.$(OBJEXT)
-am__objects_76 = $(am__objects_75) \
+am__objects_77 = $(am__objects_76) \
 	unwind/generic-libunwind/libhpcrun_o-libunw-unwind.$(OBJEXT) \
 	unwind/common/libhpcrun_o-default_validation_summary.$(OBJEXT)
-am__objects_77 = $(am__objects_75) \
+am__objects_78 = $(am__objects_76) \
 	unwind/ppc64/libhpcrun_o-ppc64-unwind.$(OBJEXT) \
 	unwind/ppc64/libhpcrun_o-ppc64-unwind-interval.$(OBJEXT) \
 	unwind/common/libhpcrun_o-default_validation_summary.$(OBJEXT)
-am__objects_78 = $(am__objects_75) \
+am__objects_79 = $(am__objects_76) \
 	unwind/x86-family/libhpcrun_o-x86-all.$(OBJEXT) \
 	unwind/x86-family/libhpcrun_o-amd-xop.$(OBJEXT) \
 	unwind/x86-family/libhpcrun_o-x86-cold-path.$(OBJEXT) \
@@ -1204,14 +1208,14 @@ am__objects_78 = $(am__objects_75) \
 	unwind/x86-family/manual-intervals/libhpcrun_o-x86-32bit-icc-variant.$(OBJEXT) \
 	unwind/x86-family/manual-intervals/libhpcrun_o-x86-fail-intervals.$(OBJEXT) \
 	unwind/x86-family/manual-intervals/libhpcrun_o-x86-pgi-mp_pexit.$(OBJEXT)
-@UNW_LIBUNW_FALSE@@UNW_PPC64_FALSE@@UNW_X86_TRUE@am__objects_79 = $(am__objects_78)
-@UNW_LIBUNW_FALSE@@UNW_PPC64_TRUE@am__objects_79 = $(am__objects_77)
-@UNW_LIBUNW_TRUE@am__objects_79 = $(am__objects_76)
-am_libhpcrun_o_OBJECTS = $(am__objects_55) $(am__objects_56) \
-	$(am__objects_58) $(am__objects_60) $(am__objects_62) \
-	$(am__objects_64) $(am__objects_66) $(am__objects_68) \
-	$(am__objects_71) $(am__objects_73) $(am__objects_36) \
-	$(am__objects_79) utilities/libhpcrun_o-last_func.$(OBJEXT)
+@UNW_LIBUNW_FALSE@@UNW_PPC64_FALSE@@UNW_X86_TRUE@am__objects_80 = $(am__objects_79)
+@UNW_LIBUNW_FALSE@@UNW_PPC64_TRUE@am__objects_80 = $(am__objects_78)
+@UNW_LIBUNW_TRUE@am__objects_80 = $(am__objects_77)
+am_libhpcrun_o_OBJECTS = $(am__objects_56) $(am__objects_57) \
+	$(am__objects_59) $(am__objects_61) $(am__objects_63) \
+	$(am__objects_65) $(am__objects_67) $(am__objects_69) \
+	$(am__objects_72) $(am__objects_74) $(am__objects_37) \
+	$(am__objects_80) utilities/libhpcrun_o-last_func.$(OBJEXT)
 libhpcrun_o_OBJECTS = $(am_libhpcrun_o_OBJECTS)
 libhpcrun_o_DEPENDENCIES = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
 	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) $(OUR_LIBUNWIND_A) \
@@ -1294,7 +1298,8 @@ DIST_SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(am__libagent_cilk_la_SOURCES_DIST) \
 	$(am__libagent_pthread_la_SOURCES_DIST) \
 	$(am__libagent_tbb_la_SOURCES_DIST) \
-	$(am__libhpcrun_la_SOURCES_DIST) $(libhpcrun_audit_la_SOURCES) \
+	$(am__libhpcrun_la_SOURCES_DIST) \
+	$(am__libhpcrun_audit_la_SOURCES_DIST) \
 	$(libhpcrun_ga_la_SOURCES) $(libhpcrun_gprof_la_SOURCES) \
 	$(libhpcrun_io_la_SOURCES) $(libhpcrun_memleak_la_SOURCES) \
 	$(libhpcrun_mpi_la_SOURCES) $(libhpcrun_pthread_la_SOURCES) \
@@ -1592,6 +1597,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@
@@ -1690,14 +1696,14 @@ PYTHON = python
 @OPT_BGQ_BACKEND_TRUE@SUBDIRS = utilities/bgq-cnk
 plugin_srcdir = $(srcdir)/plugins
 plugin_instdir = $(pkglibdir)/plugins
-bin_SCRIPTS = $(am__append_4) $(am__append_6)
+bin_SCRIPTS = $(am__append_6) $(am__append_8)
 pkglibexec_SCRIPTS = $(am__append_1)
 include_HEADERS = $(am__append_2)
-pkglib_LIBRARIES = $(am__append_5)
-pkglib_LTLIBRARIES = $(am__append_3) $(am__append_7) $(am__append_137) \
-	$(am__append_138)
-BUILT_SOURCES = $(am__append_21)
-CLEANFILES = $(am__append_22)
+pkglib_LIBRARIES = $(am__append_7)
+pkglib_LTLIBRARIES = $(am__append_3) $(am__append_4) $(am__append_5) \
+	$(am__append_9) $(am__append_140) $(am__append_141)
+BUILT_SOURCES = $(am__append_24)
+CLEANFILES = $(am__append_25)
 PAPI_INC_FLGS = @OPT_PAPI_IFLAGS@ 
 PAPI_LD_FLGS = @OPT_PAPI_LDFLAGS@
 CUPTI_INC_FLGS = @OPT_CUPTI_IFLAGS@
@@ -1783,10 +1789,10 @@ UNW_MIPS_INCLUDE_DIRS = \
 
 UNW_MIPS_LD_FLAGS = 
 MY_CPP_DEFINES = -D_GNU_SOURCE -DINLINE_FN=1 -DLOCAL_BUILD=1 \
-	-D__HIP_PLATFORM_HCC__=1 $(am__append_11) $(am__append_18) \
-	$(am__append_105) $(am__append_109) $(am__append_111) \
-	$(am__append_115) $(am__append_130) $(am__append_134) \
-	$(am__append_136)
+	-D__HIP_PLATFORM_HCC__=1 $(am__append_13) $(am__append_21) \
+	$(am__append_108) $(am__append_112) $(am__append_114) \
+	$(am__append_118) $(am__append_133) $(am__append_137) \
+	$(am__append_139)
 MY_BASE_FILES = utilities/first_func.c main.h main.c disabled.c \
 	closure-registry.c cct_insert_backtrace.c \
 	cct_backtrace_finalize.c env.c epoch.c files.c \
@@ -1839,16 +1845,13 @@ MY_BASE_FILES = utilities/first_func.c main.h main.c disabled.c \
 	utilities/hpcrun-nanotime.c utilities/ip-normalized.h \
 	utilities/ip-normalized.c utilities/line_wrapping.c \
 	utilities/timer.c utilities/tokenize.h utilities/tokenize.c \
-	utilities/unlink.h utilities/unlink.c $(am__append_8) \
-	$(am__append_9) $(am__append_10) $(am__append_12) \
-	$(am__append_13) $(am__append_14) $(am__append_15) \
-	$(am__append_17)
-MY_DYNAMIC_FILES = \
-	fnbounds/fnbounds_client.c	\
-	fnbounds/fnbounds_dynamic.c	\
-	monitor-exts/openmp.c		\
-        custom-init-dynamic.c
-
+	utilities/unlink.h utilities/unlink.c $(am__append_10) \
+	$(am__append_11) $(am__append_12) $(am__append_14) \
+	$(am__append_15) $(am__append_16) $(am__append_17) \
+	$(am__append_20)
+MY_DYNAMIC_FILES = fnbounds/fnbounds_client.c \
+	fnbounds/fnbounds_dynamic.c monitor-exts/openmp.c \
+	custom-init-dynamic.c $(am__append_18)
 MY_STATIC_FILES = \
 	fnbounds/fnbounds_static.c      \
         custom-init-static.c
@@ -1878,10 +1881,10 @@ MY_AARCH64_FILES = \
 	utilities/arch/libunwind/libunwind-context-pc.c
 
 @OPT_PAPI_COMPONENT_FALSE@MY_PAPI_FILES = sample-sources/papi.c \
-@OPT_PAPI_COMPONENT_FALSE@	$(am__append_16)
+@OPT_PAPI_COMPONENT_FALSE@	$(am__append_19)
 @OPT_PAPI_COMPONENT_TRUE@MY_PAPI_FILES = sample-sources/papi-c.c \
 @OPT_PAPI_COMPONENT_TRUE@	sample-sources/papi-c-extended-info.c \
-@OPT_PAPI_COMPONENT_TRUE@	$(am__append_16)
+@OPT_PAPI_COMPONENT_TRUE@	$(am__append_19)
 @OPT_ENABLE_CUPTI_TRUE@MY_CUPTI_FILES = sample-sources/nvidia.c	\
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/cubin-hash-map.c		\
 @OPT_ENABLE_CUPTI_TRUE@	gpu/nvidia/cubin-id-map.c		\
@@ -1947,18 +1950,18 @@ MY_AARCH64_INCLUDE_DIRS = \
 	-I$(srcdir)/utilities/arch/aarch64
 
 libhpcrun_la_SOURCES = $(MY_BASE_FILES) $(MY_DYNAMIC_FILES) \
-	$(am__append_27) $(am__append_28) $(am__append_41) \
-	$(am__append_56) $(am__append_74) $(am__append_87) \
-	$(am__append_102) $(am__append_106) $(am__append_116) \
-	$(am__append_123) $(am__append_127) $(am__append_131) \
+	$(am__append_30) $(am__append_31) $(am__append_44) \
+	$(am__append_59) $(am__append_77) $(am__append_90) \
+	$(am__append_105) $(am__append_109) $(am__append_119) \
+	$(am__append_126) $(am__append_130) $(am__append_134) \
 	$(UNW_SOURCE_FILES) utilities/last_func.c
-libhpcrun_audit_la_SOURCES = \
-	audit/auditor.c
+@OPT_ENABLE_RTLD_AUDIT_TRUE@libhpcrun_audit_la_SOURCES = \
+@OPT_ENABLE_RTLD_AUDIT_TRUE@	audit/auditor.c
 
 libhpcrun_o_SOURCES = $(MY_BASE_FILES) $(MY_STATIC_FILES) \
-	$(am__append_29) $(am__append_42) $(am__append_57) \
-	$(am__append_75) $(am__append_88) $(am__append_107) \
-	$(am__append_112) $(am__append_117) $(am__append_126) \
+	$(am__append_32) $(am__append_45) $(am__append_60) \
+	$(am__append_78) $(am__append_91) $(am__append_110) \
+	$(am__append_115) $(am__append_120) $(am__append_129) \
 	$(UNW_SOURCE_FILES) utilities/last_func.c
 libhpcrun_wrap_a_SOURCES = \
 	monitor-exts/openmp.c
@@ -2003,61 +2006,61 @@ libhpctoolkit_a_SOURCES = \
 # cppflags
 #-----------------------------------------------------------
 libhpcrun_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_19) $(am__append_30) $(am__append_43) \
-	$(am__append_58) $(am__append_76) $(am__append_89) \
-	$(am__append_103) $(am__append_108) $(am__append_110) \
-	$(am__append_118) $(am__append_121) $(am__append_124) \
-	$(am__append_128) $(am__append_132) $(UNW_INCLUDE_DIRS)
-libhpcrun_audit_la_CPPFLAGS = \
-	$(MY_CPP_DEFINES)		\
-	$(MY_INCLUDE_DIRS)
+	$(am__append_22) $(am__append_33) $(am__append_46) \
+	$(am__append_61) $(am__append_79) $(am__append_92) \
+	$(am__append_106) $(am__append_111) $(am__append_113) \
+	$(am__append_121) $(am__append_124) $(am__append_127) \
+	$(am__append_131) $(am__append_135) $(UNW_INCLUDE_DIRS)
+@OPT_ENABLE_RTLD_AUDIT_TRUE@libhpcrun_audit_la_CPPFLAGS = \
+@OPT_ENABLE_RTLD_AUDIT_TRUE@	$(MY_CPP_DEFINES)		\
+@OPT_ENABLE_RTLD_AUDIT_TRUE@	$(MY_INCLUDE_DIRS)
 
 libhpcrun_o_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_20) $(am__append_31) \
-	$(am__append_44) $(am__append_59) $(am__append_77) \
-	$(am__append_90) $(am__append_113) $(am__append_119) \
-	$(am__append_122) $(UNW_INCLUDE_DIRS)
+	$(MY_INCLUDE_DIRS) $(am__append_23) $(am__append_34) \
+	$(am__append_47) $(am__append_62) $(am__append_80) \
+	$(am__append_93) $(am__append_116) $(am__append_122) \
+	$(am__append_125) $(UNW_INCLUDE_DIRS)
 libhpcrun_wrap_a_CPPFLAGS = \
 	-DHPCRUN_STATIC_LINK		\
 	$(MY_CPP_DEFINES)		\
 	$(MY_INCLUDE_DIRS)
 
 libhpcrun_ga_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_32) $(am__append_45) $(am__append_62) \
-	$(am__append_78) $(am__append_91) $(UNW_INCLUDE_DIRS)
+	$(am__append_35) $(am__append_48) $(am__append_65) \
+	$(am__append_81) $(am__append_94) $(UNW_INCLUDE_DIRS)
 libhpcrun_ga_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_33) $(am__append_46) \
-	$(am__append_63) $(am__append_79) $(am__append_92) \
+	$(MY_INCLUDE_DIRS) $(am__append_36) $(am__append_49) \
+	$(am__append_66) $(am__append_82) $(am__append_95) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_gprof_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_47) $(am__append_64) $(am__append_93)
+	$(am__append_50) $(am__append_67) $(am__append_96)
 libhpcrun_gprof_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_48) \
-	$(am__append_65) $(am__append_94)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_51) \
+	$(am__append_68) $(am__append_97)
 libhpcrun_io_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_34) $(am__append_49) $(am__append_66) \
-	$(am__append_80) $(am__append_95) $(UNW_INCLUDE_DIRS)
+	$(am__append_37) $(am__append_52) $(am__append_69) \
+	$(am__append_83) $(am__append_98) $(UNW_INCLUDE_DIRS)
 libhpcrun_io_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_35) $(am__append_50) \
-	$(am__append_67) $(am__append_81) $(am__append_96) \
+	$(MY_INCLUDE_DIRS) $(am__append_38) $(am__append_53) \
+	$(am__append_70) $(am__append_84) $(am__append_99) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_36) $(am__append_51) $(am__append_68) \
-	$(am__append_82) $(am__append_97) $(UNW_INCLUDE_DIRS)
+	$(am__append_39) $(am__append_54) $(am__append_71) \
+	$(am__append_85) $(am__append_100) $(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_37) \
-	$(am__append_52) $(am__append_69) $(am__append_83) \
-	$(am__append_98) $(UNW_INCLUDE_DIRS)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_40) \
+	$(am__append_55) $(am__append_72) $(am__append_86) \
+	$(am__append_101) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_38) $(am__append_53) $(am__append_70) \
-	$(am__append_84) $(am__append_99) $(UNW_INCLUDE_DIRS)
+	$(am__append_41) $(am__append_56) $(am__append_73) \
+	$(am__append_87) $(am__append_102) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_39) \
-	$(am__append_54) $(am__append_71) $(am__append_85) \
-	$(am__append_100) $(UNW_INCLUDE_DIRS)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_42) \
+	$(am__append_57) $(am__append_74) $(am__append_88) \
+	$(am__append_103) $(UNW_INCLUDE_DIRS)
 libhpcrun_mpi_la_CPPFLAGS = $(MY_CPP_DEFINES) -I$(MPI_INC) \
-	$(MY_INCLUDE_DIRS) $(am__append_40) $(am__append_55) \
-	$(am__append_72) $(am__append_86) $(am__append_101) \
+	$(MY_INCLUDE_DIRS) $(am__append_43) $(am__append_58) \
+	$(am__append_75) $(am__append_89) $(am__append_104) \
 	$(UNW_INCLUDE_DIRS)
 libhpctoolkit_la_CPPFLAGS = \
 	$(MY_CPP_DEFINES)		\
@@ -2073,8 +2076,8 @@ libhpctoolkit_a_CPPFLAGS = \
 # cflags
 #-----------------------------------------------------------
 libhpcrun_la_CFLAGS = $(CFLAGS) $(HOST_CFLAGS) $(PERFMON_CFLAGS) \
-	$(am__append_125) $(am__append_129) $(am__append_133) \
-	$(am__append_135) $(GOTCHA_IFLAGS)
+	$(am__append_128) $(am__append_132) $(am__append_136) \
+	$(am__append_138) $(GOTCHA_IFLAGS)
 libhpcrun_o_CFLAGS = $(CFLAGS) $(HOST_CFLAGS) $(PERFMON_CFLAGS)
 libhpcrun_wrap_a_CFLAGS = $(CFLAGS) $(HOST_CFLAGS)
 libhpcrun_ga_la_CFLAGS = $(CFLAGS) $(HOST_CFLAGS)
@@ -2104,23 +2107,23 @@ SUPPORT_LEAN_A = $(top_builddir)/src/lib/support-lean/.libs/libHPCsupport-lean.a
 # with or without -fPIC, but the dynamic case requies -fPIC.
 OUR_LIBUNWIND_A = $(top_builddir)/src/extern/libunwind/libunwind.a
 OUR_LZMA_A = $(top_builddir)/src/extern/lzma/liblzma.a
-libhpcrun_la_LDFLAGS = -Wl,-Bsymbolic $(am__append_60) \
-	$(am__append_104) $(am__append_120) $(GOTCHA_LDFLAGS) \
+libhpcrun_la_LDFLAGS = -Wl,-Bsymbolic $(am__append_63) \
+	$(am__append_107) $(am__append_123) $(GOTCHA_LDFLAGS) \
 	$(UNW_DYNAMIC_LD_FLAGS)
-libhpcrun_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
+@OPT_ENABLE_RTLD_AUDIT_TRUE@libhpcrun_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
 libhpcrun_ga_la_LDFLAGS = -Wl,-Bsymbolic
 libhpcrun_gprof_la_LDFLAGS = -Wl,-Bsymbolic
 libhpcrun_io_la_LDFLAGS = -Wl,-Bsymbolic
 libhpcrun_memleak_la_LDFLAGS = -Wl,-Bsymbolic
 libhpcrun_pthread_la_LDFLAGS = -Wl,-Bsymbolic
 libhpcrun_mpi_la_LDFLAGS = -Wl,-Bsymbolic
-libhpcrun_o_LDFLAGS = $(am__append_61) $(am__append_114) \
+libhpcrun_o_LDFLAGS = $(am__append_64) $(am__append_117) \
 	$(UNW_STATIC_LD_FLAGS)
 libhpcrun_la_LIBADD = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
 	-L$(LIBMONITOR_LIB) -lmonitor -lpthread -lrt -L$(LIBELF_LIB) \
 	-lelf $(PERFMON_LDFLAGS_DYN) $(OPT_ROCM_LDFLAGS) \
-	$(MBEDTLS_LIBS) $(am__append_23) $(am__append_24) \
-	$(am__append_25) $(am__append_26)
+	$(MBEDTLS_LIBS) $(am__append_26) $(am__append_27) \
+	$(am__append_28) $(am__append_29)
 libhpcrun_o_LDADD = \
 	$(PROF_LEAN_A)  \
 	$(SUPPORT_LEAN_A)  \
@@ -2129,7 +2132,7 @@ libhpcrun_o_LDADD = \
 	$(OUR_LIBUNWIND_A)  \
 	$(OUR_LZMA_A)
 
-MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_73) \
+MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_76) \
 	$(UNW_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
 @HOST_CPU_PPC_TRUE@libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
@@ -2702,6 +2705,14 @@ fnbounds/libhpcrun_la-fnbounds_dynamic.lo: fnbounds/$(am__dirstamp) \
 	fnbounds/$(DEPDIR)/$(am__dirstamp)
 monitor-exts/libhpcrun_la-openmp.lo: monitor-exts/$(am__dirstamp) \
 	monitor-exts/$(DEPDIR)/$(am__dirstamp)
+audit/$(am__dirstamp):
+	@$(MKDIR_P) audit
+	@: > audit/$(am__dirstamp)
+audit/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) audit/$(DEPDIR)
+	@: > audit/$(DEPDIR)/$(am__dirstamp)
+audit/libhpcrun_la-fake-auditor.lo: audit/$(am__dirstamp) \
+	audit/$(DEPDIR)/$(am__dirstamp)
 os/linux/$(am__dirstamp):
 	@$(MKDIR_P) os/linux
 	@: > os/linux/$(am__dirstamp)
@@ -2993,12 +3004,6 @@ utilities/libhpcrun_la-last_func.lo: utilities/$(am__dirstamp) \
 
 libhpcrun.la: $(libhpcrun_la_OBJECTS) $(libhpcrun_la_DEPENDENCIES) $(EXTRA_libhpcrun_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(libhpcrun_la_LINK) $(am_libhpcrun_la_rpath) $(libhpcrun_la_OBJECTS) $(libhpcrun_la_LIBADD) $(LIBS)
-audit/$(am__dirstamp):
-	@$(MKDIR_P) audit
-	@: > audit/$(am__dirstamp)
-audit/$(DEPDIR)/$(am__dirstamp):
-	@$(MKDIR_P) audit/$(DEPDIR)
-	@: > audit/$(DEPDIR)/$(am__dirstamp)
 audit/libhpcrun_audit_la-auditor.lo: audit/$(am__dirstamp) \
 	audit/$(DEPDIR)/$(am__dirstamp)
 
@@ -3734,6 +3739,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libhpctoolkit_a-hpctoolkit.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libhpctoolkit_la-hpctoolkit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@audit/$(DEPDIR)/libhpcrun_audit_la-auditor.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@audit/$(DEPDIR)/libhpcrun_la-fake-auditor.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@cct/$(DEPDIR)/libhpcrun_la-cct-node-vector.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@cct/$(DEPDIR)/libhpcrun_la-cct.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@cct/$(DEPDIR)/libhpcrun_la-cct_bundle.Plo@am__quote@
@@ -5253,6 +5259,13 @@ libhpcrun_la-custom-init-dynamic.lo: custom-init-dynamic.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='custom-init-dynamic.c' object='libhpcrun_la-custom-init-dynamic.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o libhpcrun_la-custom-init-dynamic.lo `test -f 'custom-init-dynamic.c' || echo '$(srcdir)/'`custom-init-dynamic.c
+
+audit/libhpcrun_la-fake-auditor.lo: audit/fake-auditor.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT audit/libhpcrun_la-fake-auditor.lo -MD -MP -MF audit/$(DEPDIR)/libhpcrun_la-fake-auditor.Tpo -c -o audit/libhpcrun_la-fake-auditor.lo `test -f 'audit/fake-auditor.c' || echo '$(srcdir)/'`audit/fake-auditor.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) audit/$(DEPDIR)/libhpcrun_la-fake-auditor.Tpo audit/$(DEPDIR)/libhpcrun_la-fake-auditor.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='audit/fake-auditor.c' object='audit/libhpcrun_la-fake-auditor.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -c -o audit/libhpcrun_la-fake-auditor.lo `test -f 'audit/fake-auditor.c' || echo '$(srcdir)/'`audit/fake-auditor.c
 
 os/linux/libhpcrun_la-dylib.lo: os/linux/dylib.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_la_CFLAGS) $(CFLAGS) -MT os/linux/libhpcrun_la-dylib.lo -MD -MP -MF os/linux/$(DEPDIR)/libhpcrun_la-dylib.Tpo -c -o os/linux/libhpcrun_la-dylib.lo `test -f 'os/linux/dylib.c' || echo '$(srcdir)/'`os/linux/dylib.c

--- a/src/tool/hpcrun/audit/audit-api.h
+++ b/src/tool/hpcrun/audit/audit-api.h
@@ -50,6 +50,8 @@
 #include <link.h>
 #include <stdbool.h>
 
+#include "include/hpctoolkit-config.h"
+
 // The entirety of this file only makes sense in the dynamic case, so
 // error if someone tries to use it in the static case.
 #ifdef HPCRUN_STATIC_LINK
@@ -59,9 +61,6 @@
 // Structure used to represent an active link map entry. Most informational
 // fields are filled by the auditor.
 typedef struct auditor_map_entry_t {
-  // Link map structure used by ld.so.
-  const struct link_map* map;
-
   // Full path to the mapped library, after passing through realpath and
   // handling the main application name.
   char* path;
@@ -121,5 +120,13 @@ typedef void (*auditor_attach_pfn_t)(const auditor_exports_t*, auditor_hooks_t*)
 extern void hpcrun_auditor_attach(const auditor_exports_t*, auditor_hooks_t*);
 
 extern const auditor_exports_t* auditor_exports;
+
+// Called by the mainlib to initialize the auditor in the event that
+// one of the other interfaces has been called already.
+#ifdef ENABLE_RTLD_AUDIT
+#define hpcrun_init_auditor() ({})
+#else
+extern void hpcrun_init_auditor();
+#endif
 
 #endif  // AUDIT_AUDITAPI_H

--- a/src/tool/hpcrun/audit/auditor.c
+++ b/src/tool/hpcrun/audit/auditor.c
@@ -75,7 +75,7 @@ static auditor_hooks_t hooks;
 static auditor_attach_pfn_t pfn_init = NULL;
 static uintptr_t* mainlib_cookie = NULL;
 
-static void mainlib_connected();
+static void mainlib_connected(const char*);
 static auditor_exports_t exports = {
   .mainlib_connected = mainlib_connected,
   .pipe = pipe, .close = close, .waitpid = waitpid,
@@ -122,7 +122,6 @@ unsigned int la_version(unsigned int version) {
 static void hook_open(uintptr_t* cookie, struct link_map* map) {
   // Allocate some space for our extra bits, and fill it.
   auditor_map_entry_t* entry = malloc(sizeof *entry);
-  entry->map = map;
 
   // Normally the path is map->l_name, but sometimes that string is empty
   // which indicates the main executable. So we get it the other way.
@@ -288,7 +287,7 @@ unsigned int la_objopen(struct link_map* map, Lmid_t lmid, uintptr_t* cookie) {
 }
 
 // Transition from connecting to connected, once the mainlib is ready.
-static void mainlib_connected(const char* vdso_path) {
+void mainlib_connected(const char* vdso_path) {
   if(state != state_connecting) return;
 
   // Reverse the stack of buffered notifications, so they get reported in order.

--- a/src/tool/hpcrun/audit/fake-auditor.c
+++ b/src/tool/hpcrun/audit/fake-auditor.c
@@ -1,0 +1,330 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// $HeadURL$
+// $Id$
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2020, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "audit-api.h"
+
+#include <monitor.h>
+
+#include <dlfcn.h>
+#include <elf.h>
+#include <pthread.h>
+#include <string.h>
+#include <sched.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/auxv.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static bool verbose = false;
+static const char* vdso_path = NULL;
+
+// We keep a record of all the base addresses of currently loaded stuff, to
+// know when stuff was added or removed.
+typedef struct shadow_map_entry_t {
+  struct shadow_map_entry_t* next;
+  ElfW(Addr) addr;
+  bool seen;
+  bool new;
+  auditor_map_entry_t entry;
+} shadow_map_entry_t;
+static shadow_map_entry_t* shadow_map;
+pthread_mutex_t shadow_lock;
+
+// Storage for all the bits we need
+static auditor_exports_t exports;
+static auditor_hooks_t hooks;
+
+static void mainlib_connected(const char*);
+static bool update_shadow();
+
+static void* (*real_dlopen)(const char*, int) = NULL;
+static void* (*real_dlmopen)(Lmid_t, const char*, int) = NULL;
+static int (*real_dlclose)(void*) = NULL;
+
+// Scan the phdrs for an entry that looks like ours, and nab the DYNAMIC section
+static ElfW(Addr) self_baseaddr;
+static const ElfW(Dyn)* self_dynamic;
+static int self_scan_dl(struct dl_phdr_info* map, size_t sz, void* vp) {
+  if(map->dlpi_addr != self_baseaddr) return 0;
+  for(size_t i = 0; i < map->dlpi_phnum; i++) {
+    if(map->dlpi_phdr[i].p_type == PT_DYNAMIC) {
+      self_dynamic = (const void*)map->dlpi_addr + map->dlpi_phdr[i].p_vaddr;
+      return 1;
+    }
+  }
+  return 1;
+}
+
+// Initialization can happen from multiple locations, but always looks like this:
+static bool initialized = false;
+void hpcrun_init_auditor() {
+  if(initialized) return;
+  initialized = true;
+
+  pthread_mutexattr_t mattr;
+  pthread_mutexattr_init(&mattr);
+  pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&shadow_lock, &mattr);
+  pthread_mutexattr_destroy(&mattr);
+
+  real_dlopen = dlsym(RTLD_NEXT, "dlopen");
+  real_dlclose = dlsym(RTLD_NEXT, "dlclose");
+  real_dlmopen = dlsym(RTLD_NEXT, "dlmopen");
+
+  exports.pipe = NULL;
+  exports.close = NULL;
+  exports.waitpid = NULL;
+  exports.clone = NULL;
+  exports.execve = NULL;
+
+  // Find our DYNAMIC section, and scan it for NEEDED entries to fill the exports
+  Dl_info selfinfo;
+  dladdr(&hpcrun_init_auditor, &selfinfo);
+  self_baseaddr = (uintptr_t)selfinfo.dli_fbase;
+  dl_iterate_phdr(self_scan_dl, NULL);
+  const char* strtab = NULL;
+  for(const ElfW(Dyn)* d = self_dynamic; d->d_tag != DT_NULL; d++) {
+    if(d->d_tag != DT_STRTAB) continue;
+    strtab = (const void*)d->d_un.d_ptr;
+    break;
+  }
+  if(strtab != NULL) {
+    for(const ElfW(Dyn)* d = self_dynamic; d->d_tag != DT_NULL; d++) {
+      if(d->d_tag != DT_NEEDED) continue;
+      void* lib = real_dlopen(&strtab[d->d_un.d_val], RTLD_LAZY|RTLD_NOLOAD);
+      if(!lib) continue;
+      // Skip libmonitor, otherwise we'll spin out of control
+      if(!dlsym(lib, "monitor_initialize") && !dlsym(lib, "monitor_is_threaded")) {
+        if(!exports.pipe) exports.pipe = dlsym(lib, "pipe");
+        if(!exports.close) exports.close = dlsym(lib, "close");
+        if(!exports.waitpid) exports.waitpid = dlsym(lib, "waitpid");
+        if(!exports.clone) exports.clone = dlsym(lib, "clone");
+        if(!exports.execve) exports.execve = dlsym(lib, "execve");
+      }
+      real_dlclose(lib);
+    }
+  }
+
+  // If any exports are remaining, just link them into our best options
+  if(!exports.pipe) exports.pipe = pipe;
+  if(!exports.close) exports.close = close;
+  if(!exports.waitpid) exports.waitpid = waitpid;
+  if(!exports.clone) exports.clone = clone;
+  if(!exports.execve) exports.execve = monitor_real_execve;
+
+  exports.mainlib_connected = mainlib_connected;
+
+  verbose = getenv("HPCRUN_AUDIT_DEBUG");
+  vdso_path = "[vdso]";  // Set later to something more reasonable.
+
+  // Generate the purified environment before the app changes it
+  // NOTE: Consider removing only ourselves to allow for Spindle-like optimizations.
+  // TODO: Export to another file for sharing with auditor.c.
+  {
+    size_t envsz = 0;
+    for(char** e = environ; *e != NULL; e++) envsz++;
+    exports.pure_environ = malloc((envsz+1)*sizeof exports.pure_environ[0]);
+    size_t idx = 0;
+    for(char** e = environ; *e != NULL; e++) {
+      if(strncmp(*e, "LD_PRELOAD=", 11) == 0) continue;
+      if(strncmp(*e, "LD_AUDIT=", 9) == 0) continue;
+      exports.pure_environ[idx++] = *e;
+    }
+    exports.pure_environ[idx] = NULL;
+  }
+
+  // Attach to the rest of the world.
+  if(verbose)
+    fprintf(stderr, "[fake audit] Attaching to mainlib\n");
+  hpcrun_auditor_attach(&exports, &hooks);
+}
+
+// The earliest we can do anything without LD_AUDIT is with the constructor
+__attribute__((constructor))
+static void hpcrun_constructor_init_fake_auditor() {
+  hpcrun_init_auditor();
+
+  // Since we're late to the party, we can kick bits off right now
+  if(verbose)
+    fprintf(stderr, "[fake audit] Beginning initialization\n");
+  hooks.initialize();
+}
+
+// Whenever things change, we scan through with dl_iterate_phdr, update the
+// shadow map and call the hook. Note that this is not async-signal-safe.
+static int update_shadow_dl(struct dl_phdr_info*, size_t, void*);
+struct update_shadow_args {
+  bool dirty;
+};
+bool update_shadow() {
+  pthread_mutex_lock(&shadow_lock);
+  for(shadow_map_entry_t* m = shadow_map; m != NULL; m = m->next)
+    m->seen = false;
+  struct update_shadow_args args = {
+    .dirty = false,
+  };
+  dl_iterate_phdr(update_shadow_dl, &args);
+  if(args.dirty) {
+    for(shadow_map_entry_t* m = shadow_map, *p = NULL; m != NULL;
+        p = m, m = m ? m->next : shadow_map) {
+      if(!m->seen) {
+        if(verbose)
+          fprintf(stderr, "[fake audit] Delivering objclose for `%s'\n", m->entry.path);
+        hooks.close(&m->entry);
+        if(p) p->next = m->next;
+        else shadow_map = m->next;
+        free(m);
+        m = p;
+      } else if(m->new) {
+        if(verbose)
+          fprintf(stderr, "[fake audit] Delivering objopen for `%s'\n", m->entry.path);
+        hooks.open(&m->entry);
+        m->new = false;
+      }
+    }
+  }
+  pthread_mutex_unlock(&shadow_lock);
+  return args.dirty;
+}
+int update_shadow_dl(struct dl_phdr_info* map, size_t sz, void* args_vp) {
+  struct update_shadow_args* args = args_vp;
+  shadow_map_entry_t* entry;
+  // Make sure we can actually use this entry
+  if(sz < offsetof(struct dl_phdr_info, dlpi_phnum)
+          + sizeof entry->entry.dl_info.dlpi_phnum)
+    return 0;
+  // First check whether we have this entry already
+  for(shadow_map_entry_t* m = shadow_map; m != NULL; m = m->next) {
+    if(m->addr == map->dlpi_addr) {
+      m->seen = true;
+      return 0;
+    }
+  }
+
+  entry = malloc(sizeof *entry);
+  entry->addr = map->dlpi_addr;
+  entry->seen = true;
+  entry->new = true;
+
+  entry->entry.path = NULL;
+  if(map->dlpi_addr == getauxval(AT_SYSINFO_EHDR))
+    entry->entry.path = realpath(vdso_path, NULL);
+  else if(map->dlpi_name[0] == '\0')
+    entry->entry.path = realpath((const char*)getauxval(AT_EXECFN), NULL);
+  else
+    entry->entry.path = realpath(map->dlpi_name, NULL);
+
+  entry->entry.ehdr = map->dlpi_addr != 0 ? (void*)map->dlpi_addr
+    : (void*)(uintptr_t)(map->dlpi_phdr[0].p_vaddr - map->dlpi_phdr[0].p_offset);
+
+  uintptr_t start = UINTPTR_MAX;
+  uintptr_t end = 0;
+  for(size_t i = 0; i < map->dlpi_phnum; i++) {
+    if((map->dlpi_phdr[i].p_flags & PF_X) != 0 && map->dlpi_phdr[i].p_memsz > 0) {
+      if(map->dlpi_phdr[i].p_vaddr < start) start = map->dlpi_phdr[i].p_vaddr;
+      if(map->dlpi_phdr[i].p_vaddr + map->dlpi_phdr[i].p_memsz > end)
+        end = map->dlpi_phdr[i].p_vaddr + map->dlpi_phdr[i].p_memsz;
+    }
+  }
+  entry->entry.start = (void*)map->dlpi_addr + start;
+  entry->entry.end = (void*)map->dlpi_addr + end;
+
+  entry->entry.dl_info = *map;
+  entry->entry.dl_info_sz = sz;
+
+  entry->next = shadow_map;
+  shadow_map = entry;
+  args->dirty = true;
+  return 0;
+}
+
+// Notification from the rest of the world that we have begun!
+void mainlib_connected(const char* new_vdso_path) {
+  vdso_path = new_vdso_path;
+  update_shadow();
+}
+
+// The remainder here is overloads for dl* that update as per the usual
+void* dlopen(const char* fn, int flags) {
+  if(!real_dlopen)
+    return ((void*(*)(const char*, int))dlsym(RTLD_NEXT, "dlopen"))(fn, flags);
+  void* out = real_dlopen(fn, flags);
+  if((flags & RTLD_NOLOAD) == 0 && update_shadow()) {
+    if(verbose)
+      fprintf(stderr, "[fake audit] Notifying stability (additive: 1)\n");
+    hooks.stable(true);
+  }
+  return out;
+}
+void* dlmopen(Lmid_t lmid, const char* fn, int flags) {
+  if(!real_dlmopen)
+    return ((void*(*)(Lmid_t, const char*, int))dlsym(RTLD_NEXT, "dlmopen"))(lmid, fn, flags);
+  void* out = real_dlmopen(lmid, fn, flags);
+  // TODO: Scan the (potentially newly created) link map for entries
+  if((flags & RTLD_NOLOAD) == 0 && update_shadow()) {
+    if(verbose)
+      fprintf(stderr, "[fake audit] Notifying stability (additive: 1)\n");
+    hooks.stable(true);
+  }
+  return out;
+}
+int dlclose(void* handle) {
+  if(!real_dlclose)
+    return ((int(*)(void*))dlsym(RTLD_NEXT, "dlclose"))(handle);
+  int out = real_dlclose(handle);
+  if(update_shadow()) {
+    if(verbose)
+      fprintf(stderr, "[fake audit] Notifying stability (additive: 0)\n");
+    hooks.stable(false);
+  }
+  return out;
+}

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -870,6 +870,8 @@ monitor_init_process(int *argc, char **argv, void* data)
 
   hpcrun_wait();
 
+  hpcrun_init_auditor();
+
 #if 0
   // temporary patch to avoid deadlock within PAMI's optimized implementation
     // of all-to-all. a problem was observed when PAMI's optimized all-to-all

--- a/src/tool/hpcrun/scripts/hpcrun.in
+++ b/src/tool/hpcrun/scripts/hpcrun.in
@@ -508,7 +508,7 @@ export HPCRUN_FNBOUNDS_CMD
 
 export LD_LIBRARY_PATH="${hpc_ld_library_path}:${LD_LIBRARY_PATH}"
 export LD_PRELOAD="${preload_list} ${LD_PRELOAD}"
-export LD_AUDIT="${hpcrun_dir}/libhpcrun_audit.so:${LD_AUDIT}"
+@export_ld_audit@
 export HPCRUN_AUDIT_MAIN_LIB="${hpcrun_dir}/libhpcrun.so"
 
 exec "$@"

--- a/src/tool/hpcrun/utilities/bgq-cnk/Makefile.in
+++ b/src/tool/hpcrun/utilities/bgq-cnk/Makefile.in
@@ -394,6 +394,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcserver/Makefile.in
+++ b/src/tool/hpcserver/Makefile.in
@@ -456,6 +456,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcserver/mpi/Makefile.in
+++ b/src/tool/hpcserver/mpi/Makefile.in
@@ -464,6 +464,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpcstruct/Makefile.in
+++ b/src/tool/hpcstruct/Makefile.in
@@ -488,6 +488,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/hpctracedump/Makefile.in
+++ b/src/tool/hpctracedump/Makefile.in
@@ -434,6 +434,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/misc/Makefile.in
+++ b/src/tool/misc/Makefile.in
@@ -389,6 +389,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@

--- a/src/tool/xprof/Makefile.in
+++ b/src/tool/xprof/Makefile.in
@@ -455,6 +455,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 exec_prefix = @exec_prefix@
+export_ld_audit = @export_ld_audit@
 hash_fcn = @hash_fcn@
 hash_value = @hash_value@
 host = @host@


### PR DESCRIPTION
Allow disabling the LD_AUDIT-based infrastructure using --disable-rtld-audit

Using this flag allows for hpcrun to still function on systems where LD_AUDIT
support in Glibc is currently non-functional. There will be R*PATH issues when
this is used, similar to the state of hpcrun previous to all this.

Note that with both this and the previous LD_AUDIT commit, libmonitor should be
configured with --disable-dlfns, regardless of the --enable-rtld-audit setting.