### PR TITLE
Enhance hpcrun_reify_metric_set to eagerly allocate metrics_kind

### DIFF
--- a/src/tool/hpcrun/cct2metrics.c
+++ b/src/tool/hpcrun/cct2metrics.c
@@ -117,12 +117,14 @@ hpcrun_reify_metric_set(cct_node_id_t cct_id, int metric_id)
   TMSG(CCT2METRICS, "REIFY: %p", cct_id);
   metric_data_list_t* rv = hpcrun_get_metric_data_list(cct_id);
   if (rv == NULL) {
+    // First time initialze
     TMSG(CCT2METRICS, " -- Metric kind was null, allocating new metric kind");
     rv = hpcrun_new_metric_data_list(metric_id);
     cct2metrics_assoc(cct_id, rv);
-  }
-  else
+  } else {
+    rv = hpcrun_reify_metric_data_list_kind(rv, metric_id);
     TMSG(CCT2METRICS, " -- Metric kind found = %p", rv);
+  }
   return rv;
 }
 

--- a/src/tool/hpcrun/metrics.c
+++ b/src/tool/hpcrun/metrics.c
@@ -514,6 +514,24 @@ hpcrun_new_metric_data_list(int metric_id)
 }
 
 metric_data_list_t *
+hpcrun_reify_metric_data_list_kind(metric_data_list_t* rv, int metric_id)
+{
+  kind_info_t *kind = metric_data[metric_id].kind;
+  metric_data_list_t *curr = NULL;
+  metric_data_list_t *prev = NULL;
+  for (curr = rv; curr != NULL && curr->kind != kind; curr = curr->next) {
+    prev = curr;
+  }
+  if (curr == NULL) {
+    curr = hpcrun_new_metric_data_list(metric_id);
+    if (prev != NULL) {
+      prev->next = curr;
+    }
+  }
+  return curr;
+}
+
+metric_data_list_t *
 hpcrun_new_metric_data_list_kind(kind_info_t *kind)
 {
   metric_data_list_t *curr = hpcrun_malloc(sizeof(metric_data_list_t));

--- a/src/tool/hpcrun/metrics.h
+++ b/src/tool/hpcrun/metrics.h
@@ -116,6 +116,8 @@ void hpcrun_metrics_data_finalize();
 
 int hpcrun_get_num_kind_metrics(void);
 
+metric_data_list_t* hpcrun_reify_metric_data_list_kind(metric_data_list_t* rv, int metric_id);
+
 metric_desc_t* hpcrun_id2metric(int id);
 
 void hpcrun_metrics_data_dump();


### PR DESCRIPTION
The existing hpctoolkit **doesn't** have the bug I mentioned in the meeting last week. Originally, I thought hpcrun incorrectly attributes metrics if there are multiple metrics kind because the allocation interface `hpcrun_reify_metric_set` does not consider the case when different `metric_id`s are passed for the same `cct_id`. 

However, the bug actually was resolved by myself back to 2019 in this commit:

https://github.com/HPCToolkit/hpctoolkit/commit/0a4707c8be275fd5427269c2e89c4c1501921932

This commit guarantees the correctness of metrics attribution by lazy initialization of all the metric kinds. The following code change propose a solution to early initialize metric kinds directly in `hpcrun_reify_metric_set`. Hope this change could make the code clearer. 

If needed, I can remove the previous code and test if early initialization is enough.