### PR TITLE
Demand new thread data for gpu_trace_stream

### DIFF
--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -345,12 +345,16 @@ gpu_trace_stream_acquire
  void
 )
 {
+  bool demand_new_thread = true;
+  bool has_trace = true;
+
   thread_data_t *td = NULL;
 
   int id = gpu_trace_stream_id();
 
   // XXX(Keren): This API calls allocate_and_init_thread_data to bind td with the current thread
-  hpcrun_threadMgr_data_get_safe(id, NULL, &td, true);
+
+  hpcrun_threadMgr_data_get_safe(id, NULL, &td, has_trace, demand_new_thread);
 
   return td;
 }

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -762,6 +762,7 @@ logit(cct_node_t* n, cct_op_arg_t arg, size_t l)
 void*
 hpcrun_thread_init(int id, local_thread_data_t* local_thread_data, bool has_trace)
 {
+  bool demand_new_thread = false;
   cct_ctxt_t* thr_ctxt = local_thread_data ? local_thread_data->thr_ctxt : NULL;
 
   hpcrun_mmap_init();
@@ -773,7 +774,7 @@ hpcrun_thread_init(int id, local_thread_data_t* local_thread_data, bool has_trac
   // ----------------------------------------
 
   thread_data_t* td = NULL;
-  hpcrun_threadMgr_data_get_safe(id, thr_ctxt, &td, has_trace);
+  hpcrun_threadMgr_data_get_safe(id, thr_ctxt, &td, has_trace, demand_new_thread);
   hpcrun_set_thread_data(td);
 
   td->inside_hpcrun = 1;  // safe enter, disable signals

--- a/src/tool/hpcrun/threadmgr.c
+++ b/src/tool/hpcrun/threadmgr.c
@@ -271,7 +271,8 @@ hpcrun_threadMgr_data_get_safe
  int id,
  cct_ctxt_t *thr_ctxt,
  thread_data_t **data,
- bool has_trace
+ bool has_trace,
+ bool demand_new_thread
 )
 {
   thread_data_t *td_self;
@@ -279,11 +280,11 @@ hpcrun_threadMgr_data_get_safe
 
   if (hpcrun_td_avail()) {
     td_self = hpcrun_get_thread_data();
-    res = hpcrun_threadMgr_data_get(id, thr_ctxt, data, has_trace);
+    res = hpcrun_threadMgr_data_get(id, thr_ctxt, data, has_trace, demand_new_thread);
     hpcrun_set_thread_data(td_self);
   }
   else{
-    res = hpcrun_threadMgr_data_get(id, thr_ctxt, data, has_trace);
+    res = hpcrun_threadMgr_data_get(id, thr_ctxt, data, has_trace, demand_new_thread);
   }
   return res;
 }
@@ -303,13 +304,13 @@ hpcrun_threadMgr_data_get_safe
  *   Side effect: Overwrites pthread_specific data
  *****/
 bool
-hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace)
+hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace, bool demand_new_thread)
 {
   // -----------------------------------------------------------------
   // if we don't want coalesce threads, just allocate it and return
   // -----------------------------------------------------------------
 
-  if (!is_compact_thread()) {
+  if (!is_compact_thread() || demand_new_thread) {
     *data = allocate_and_init_thread_data(id, thr_ctxt, has_trace);
     return true;
   }

--- a/src/tool/hpcrun/threadmgr.h
+++ b/src/tool/hpcrun/threadmgr.h
@@ -76,10 +76,10 @@ void hpcrun_threadmgr_thread_delete();
 int hpcrun_threadmgr_thread_count();
 
 bool
-hpcrun_threadMgr_data_get_safe(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace);
+hpcrun_threadMgr_data_get_safe(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace, bool demand_new_thread);
 
 bool
-hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace);
+hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace, bool demand_new_thread);
 
 void
 hpcrun_threadMgr_non_compact_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace);


### PR DESCRIPTION
Ensure that cpu_thread never becomes a prefix of gpu thread.