### PR TITLE
AMD GPU support improvement

### DIFF
--- a/src/tool/hpcrun/gpu/amd/rocm-debug-api.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-debug-api.c
@@ -317,8 +317,8 @@ rocm_debug_api_init
 )
 {
   // Fill in call back functions for rocm debug api
-  callbacks.allocate_memory = hpcrun_malloc;
-  callbacks.deallocate_memory = hpcrun_free;
+  callbacks.allocate_memory = malloc;
+  callbacks.deallocate_memory = free;
   callbacks.get_os_pid = hpcrun_self_process;
   callbacks.enable_notify_shared_library = hpcrun_enable_notify_shared_library;
   callbacks.disable_notify_shared_library = hpcrun_disable_notify_shared_library;

--- a/src/tool/hpcrun/gpu/amd/rocm-debug-api.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-debug-api.c
@@ -60,8 +60,6 @@
 #include <hpcrun/sample-sources/libdl.h>
 #include <hpcrun/memory/hpcrun-malloc.h>
 
-#include <monitor.h> // enable and disable threads
-
 //******************************************************************************
 // macros
 //******************************************************************************
@@ -309,10 +307,6 @@ rocm_debug_api_init
   void
 )
 {
-  // rocm debug api library creates a new thread through std::thread.
-  // This breaks automatic thread ignoring code because we only check
-  // the caller of pthread_create. So, we manually ignore the new thread.
-  monitor_disable_new_threads();
   // Fill in call back functions for rocm debug api
   callbacks.allocate_memory = malloc;
   callbacks.deallocate_memory = free;
@@ -336,7 +330,6 @@ rocm_debug_api_fini
 )
 {
   HPCRUN_ROCM_DEBUG_CALL(amd_dbgapi_process_detach, (self));
-  monitor_enable_new_threads();
 }
 
 void

--- a/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
@@ -51,24 +51,6 @@
 
 #include <hpcrun/gpu/gpu-print.h>
 
-
-
-//******************************************************************************
-// private operations
-//******************************************************************************
-
-// HSA_OP_ID_COPY is defined in hcc/include/hc_prof_runtime.h.
-// However, this file will include C++ code, making it impossible
-// to compile with a C compiler.
-// HSA_OP_ID_COPY is a constant with value 1 at the moment.
-
-// FIXME: when amd fixes their header files, include the header file rather than
-// replicating the declaration here
-
-#define HSA_OP_ID_COPY  1
-
-
-
 //******************************************************************************
 // private operations
 //******************************************************************************
@@ -155,6 +137,7 @@ roctracer_activity_translate
   const char * name = roctracer_op_string(record->domain, record->op, record->kind);
 #endif
   memset(ga, 0, sizeof(gpu_activity_t));
+
   if (record->domain == ACTIVITY_DOMAIN_HIP_API) {
     switch(record->op){
     case HIP_API_ID_hipMemcpyDtoD:
@@ -228,18 +211,17 @@ roctracer_activity_translate
       break;
     default:
       convert_unknown(ga);
-      PRINT("Unhandled HIP activity %s\n", name);
+      PRINT("roctracer buffer event: Unhandled HIP API activity %s\n", name);
     }
-  } else if (record->domain == ACTIVITY_DOMAIN_HCC_OPS) {
-    if (record->op == HSA_OP_ID_COPY){
-      convert_memcpy(ga, record, GPU_MEMCPY_UNK);
-    } else {
-      convert_unknown(ga);
-      PRINT("Unhandled HIP activity %s\n", name);
+  } else if (record->domain == ACTIVITY_DOMAIN_HIP_OPS) {
+    // Async HIP events
+    switch (record->op) {
+
     }
   } else {
     convert_unknown(ga);
-    PRINT("Unhandled HIP activity %s\n", name);
+    PRINT("roctracer buffer enent: Unhandled activity %s, domain %u, op %u, kind %u\n", 
+      name, record->domain, record->op, record->kind);
   }
   cstack_ptr_set(&(ga->next), 0);
 }

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -398,13 +398,8 @@ roctracer_subscriber_callback
 				 gpu_placeholder_type_sync);
     is_valid_op = true;
     break;
-  case HIP_API_ID_hipModuleGetFunction:
-    PRINT("hipModuleGetFunction %s\n", data->args.hipModuleGetFunction.kname);
-    break;
-  case HIP_API_ID_hipModuleLoad:
-    PRINT("hipMOoduleLoad %p\n", data->args.hipModuleLoad.module);
-    break;
   default:
+    PRINT("HIP API tracing: Unhandled op %u, domain %u\n", callback_id, domain);
     break;
   }
 

--- a/src/tool/hpcrun/module-ignore-map.c
+++ b/src/tool/hpcrun/module-ignore-map.c
@@ -134,7 +134,7 @@ static const char *IGNORE_FNS[NUM_FNS] = {
   "roctracer_set_properties",  // amd roctracer library
   "amd_dbgapi_initialize",     // amd debug library
   "hipKernelNameRefByPtr",     // amd hip runtime
-  "hsa_queue_create",          // amd hsa runtime
+  "hsa_queue_create"           // amd hsa runtime
 };
 static module_ignore_entry_t modules[NUM_FNS];
 static pfq_rwlock_t modules_lock;
@@ -342,7 +342,6 @@ module_ignore_map_ignore
     munmap(buffer, stat.st_size);
     close(fd);
   }
-
   pfq_rwlock_write_unlock(&modules_lock, &me);
   return result;
 }
@@ -354,18 +353,14 @@ module_ignore_map_delete
  load_module_t* lm
 )
 {
-  if (lm == NULL || lm->dso_info == NULL) return false;
-  void* start = lm->dso_info->start_addr;
-  void* end = lm->dso_info->end_addr;
   size_t i;
   bool result = false;
   pfq_rwlock_node_t me;
   pfq_rwlock_write_lock(&modules_lock, &me);
   for (i = 0; i < NUM_FNS; ++i) {
-    if (modules[i].empty == false &&
-      modules[i].module->dso_info->start_addr <= start &&
-      modules[i].module->dso_info->end_addr >= end) {
+    if (modules[i].empty == false && modules[i].module == lm) {
       modules[i].empty = true;
+      modules[i].module = NULL;
       result = true;
       break;
     }

--- a/src/tool/hpcrun/module-ignore-map.c
+++ b/src/tool/hpcrun/module-ignore-map.c
@@ -108,7 +108,7 @@
 // where any GPU can indicate that its functions should be added to
 // the module ignore map when that type of GPU is being monitored.
 
-#define NUM_FNS 6
+#define NUM_FNS 7
 
 
 
@@ -134,6 +134,7 @@ static const char *IGNORE_FNS[NUM_FNS] = {
   "roctracer_set_properties",  // amd roctracer library
   "amd_dbgapi_initialize",     // amd debug library
   "hipKernelNameRefByPtr",     // amd hip runtime
+  "hsa_queue_create",          // amd hsa runtime
 };
 static module_ignore_entry_t modules[NUM_FNS];
 static pfq_rwlock_t modules_lock;

--- a/src/tool/hpcrun/scripts/hpcrun.in
+++ b/src/tool/hpcrun/scripts/hpcrun.in
@@ -268,7 +268,8 @@ do
 		PTHREAD_WAIT* ) preload_list="${preload_list} ${hpcrun_dir}/libhpcrun_pthread.so" ;;
 		CPU_GPU_IDLE* ) preload_list="${preload_list} ${hpcrun_dir}/libhpcrun_gpu.so" ;;
 		MPI* )     preload_list="${preload_list} ${hpcrun_dir}/libhpcrun_mpi.so" ;;
-		gpu=amd) roctracer_lib="${roctracer_lib_path}";;
+		gpu=amd) roctracer_lib="${roctracer_lib_path}"
+			 export HIP_ENABLE_DEFERRED_LOADING=0;;
 	    esac
 	    case "$HPCRUN_EVENT_LIST" in
 		'' ) HPCRUN_EVENT_LIST="$1" ;;

--- a/src/tool/hpcrun/scripts/hpcrun.in
+++ b/src/tool/hpcrun/scripts/hpcrun.in
@@ -268,7 +268,7 @@ do
 		PTHREAD_WAIT* ) preload_list="${preload_list} ${hpcrun_dir}/libhpcrun_pthread.so" ;;
 		CPU_GPU_IDLE* ) preload_list="${preload_list} ${hpcrun_dir}/libhpcrun_gpu.so" ;;
 		MPI* )     preload_list="${preload_list} ${hpcrun_dir}/libhpcrun_mpi.so" ;;
-		amd-rocm*) roctracer_lib="${roctracer_lib_path}";;
+		gpu=amd) roctracer_lib="${roctracer_lib_path}";;
 	    esac
 	    case "$HPCRUN_EVENT_LIST" in
 		'' ) HPCRUN_EVENT_LIST="$1" ;;


### PR DESCRIPTION
1. Support extraction of multiple GPU binaries
2. Suppress empty trace line caused by AMD debug api
3. Disable Rocm deferred loading in hpcrun script to ensure capturing all GPU binaries.

@jmellorcrummey I rebased on develop today (so, Jonathon's ld_audit fix is included) and tested it with PeleC on Tulip. Everything looks good. 