### PR TITLE
unify support for recording and analyzing GPU binaries

### DIFF
--- a/src/include/gpu-binary.h
+++ b/src/include/gpu-binary.h
@@ -1,0 +1,60 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2020, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+#ifndef gpu_binary_h
+#define gpu_binary_h
+
+
+
+//*****************************************************************************
+// macros
+//*****************************************************************************
+
+
+#define GPU_BINARY_NAME           "gpubin"
+
+#define GPU_BINARY_SUFFIX         "." GPU_BINARY_NAME 
+#define GPU_BINARY_DIRECTORY      GPU_BINARY_NAME "s"
+
+#endif
+

--- a/src/include/gpu-binary.h
+++ b/src/include/gpu-binary.h
@@ -50,11 +50,12 @@
 // macros
 //*****************************************************************************
 
-
 #define GPU_BINARY_NAME           "gpubin"
 
 #define GPU_BINARY_SUFFIX         "." GPU_BINARY_NAME 
 #define GPU_BINARY_DIRECTORY      GPU_BINARY_NAME "s"
+
+
 
 #endif
 

--- a/src/lib/prof-lean/crypto-hash.c
+++ b/src/lib/prof-lean/crypto-hash.c
@@ -51,7 +51,7 @@
 //
 // Purpose:
 //   compute a cryptographic hash of a sequence of bytes. this is used
-//   to name information presented to hpcrun in memory (e.g. an NVIDIA cubin) 
+//   to name information presented to hpcrun in memory (e.g. a GPU binary) 
 //   that needs to be saved for post-mortem analysis.
 //
 //***************************************************************************

--- a/src/lib/prof-lean/crypto-hash.h
+++ b/src/lib/prof-lean/crypto-hash.h
@@ -51,7 +51,7 @@
 //
 // Purpose:
 //   compute a cryptographic hash of a sequence of bytes. this is used
-//   to name information presented to hpcrun in memory (e.g. an NVIDIA cubin) 
+//   to name information presented to hpcrun in memory (e.g. a GPU binary) 
 //   that needs to be saved for post-mortem analysis.
 //
 //***************************************************************************

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
@@ -57,6 +57,8 @@
 // local includes
 //******************************************************************************
 
+#include <include/gpu-binary.h>
+
 #include "rocm-debug-api.h"
 #include "rocm-binary-processing.h"
 #include <hpcrun/files.h>
@@ -248,9 +250,10 @@ parse_amd_gpu_binary_uri
   char gpu_file_path[PATH_MAX];
   size_t used = 0;
   used += sprintf(&gpu_file_path[used], "%s", hpcrun_files_output_directory());
-  used += sprintf(&gpu_file_path[used], "%s", "/amd/");
+  used += sprintf(&gpu_file_path[used], "%s", "/" GPU_BINARY_DIRECTORY "/");
   mkdir(gpu_file_path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-  used += sprintf(&gpu_file_path[used], "%s.%llx.rocm-gpu", filename, offset);
+  used += sprintf(&gpu_file_path[used], "%s.%llx" GPU_BINARY_SUFFIX, 
+		  filename, offset);
 
   // We directly return if we have write down this URI
   int wfd;

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -76,6 +76,8 @@
 // local includes
 //***************************************************************************
 
+#include <include/gpu-binary.h>
+
 #include <lib/prof-lean/spinlock.h>
 
 #include <hpcrun/files.h>
@@ -676,12 +678,12 @@ cupti_load_callback_cuda
   size_t i;
   size_t used = 0;
   used += sprintf(&file_name[used], "%s", hpcrun_files_output_directory());
-  used += sprintf(&file_name[used], "%s", "/cubins/");
+  used += sprintf(&file_name[used], "%s", "/" GPU_BINARY_DIRECTORY "/");
   mkdir(file_name, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
   for (i = 0; i < hash_len; ++i) {
     used += sprintf(&file_name[used], "%02x", hash[i]);
   }
-  used += sprintf(&file_name[used], "%s", ".cubin");
+  used += sprintf(&file_name[used], "%s", GPU_BINARY_SUFFIX);
   TMSG(CUPTI, "cubin_id %d hash %s", cubin_id, file_name);
 
   // Write a file if does not exist

--- a/src/tool/hpcstruct/Args.cpp
+++ b/src/tool/hpcstruct/Args.cpp
@@ -118,7 +118,7 @@ directory that contains program structure files for GPU binaries, these program\
 structure files will be used to help attribute any GPU performance measurements.\n\
 \n\
 hpcstruct is designed primarily for highly optimized binaries created from\n\
-C, C++, Fortran, and CUDA source code. Because hpcstruct's algorithms exploit a\n\
+C, C++, Fortran, CUDA, and HIP source code. Because hpcstruct's algorithms exploit a\n\
 binary's debugging information, for best results, binary should be compiled\n\
 with standard debugging information or at a minimum, line map information.\n\
 See the HPCToolkit manual for more information.\n\

--- a/src/tool/hpcstruct/Args.cpp
+++ b/src/tool/hpcstruct/Args.cpp
@@ -107,10 +107,10 @@ To improve attribution of performance measurements to program source code, one c
 pass one or more program structure files to HPCToolkit's analysis tool hpcprof\n\
 along with one or more HPCToolkit performance measurement directories.\n\
 \n\
-During execution of a GPU-accelerated application on an NVIDIA GPU, HPCToolkit\n\
-records NVIDIA 'cubin' GPU binaries in the application's measurement directory.\n\
-To attribute performance to GPU functions in a GPU-accelerated application, one\n\
-should apply hpcstruct to the application's HPCToolkit measurement directory to\n\
+During execution of a GPU-accelerated application, HPCToolkit records\n\
+GPU binaries in the application's measurement directory. To attribute\n\
+performance to GPU functions in a GPU-accelerated application, one should \n\
+apply hpcstruct to the application's HPCToolkit measurement directory to\n\
 analyze all GPU binaries recorded within. When analyzing a measurement directory\n\
 that includes GPU binaries, any program structure files produced will be recorded\n\
 inside the measurement directory. When hpcprof is applied to a measurement\n\
@@ -144,10 +144,9 @@ Options: Parallel usage\n\
 \n\
 Options: Structure recovery\n\
   --gpucfg <yes/no>    Compute loop nesting structure for GPU machine code.\n\
-                       Currently, this applies only to NVIDIA CUDA binaries\n\
-                       (cubins). Loop nesting structure is only useful with\n\
+                       Loop nesting structure is only useful with\n\
                        instruction-level measurements collected using PC\n\
-                       sampling. {no} \n\
+                       sampling or instrumentation. {no} \n\
   -I <path>, --include <path>\n\
                        Use <path> when resolving source file names. For a\n\
                        recursive search, append a '*' after the last slash,\n\

--- a/src/tool/hpcstruct/Makefile.am
+++ b/src/tool/hpcstruct/Makefile.am
@@ -147,7 +147,7 @@ endif
 MYCLEAN = @HOST_LIBTREPOSITORY@
 
 GENHEADERS = \
-	cubins-analysis.h \
+	gpubin-analysis.h \
 	usage.h
 
 #----------------------------------------------------------------------

--- a/src/tool/hpcstruct/Makefile.in
+++ b/src/tool/hpcstruct/Makefile.in
@@ -597,7 +597,7 @@ DOT_LDADD = \
 @HOST_CPU_X86_FAMILY_TRUE@MY_LIB_XED = $(XED2_LIB_FLAGS)
 MYCLEAN = @HOST_LIBTREPOSITORY@
 GENHEADERS = \
-	cubins-analysis.h \
+	gpubin-analysis.h \
 	usage.h
 
 noinst_HEADERS = $(GENHEADERS)

--- a/src/tool/hpcstruct/gpubin-analysis.txt
+++ b/src/tool/hpcstruct/gpubin-analysis.txt
@@ -2,8 +2,8 @@
 # a helper template makefile used by hpcstruct at runtime
 #
 # if hpcstruct is passed the name of a measurements directory that contains
-# a gpubin subdirectory, this makefile will be used to orchestrate parallel
-# analysis of all gpubin within the subdirectory.
+# a gpubins subdirectory, this makefile will be used to orchestrate parallel
+# analysis of all gpubins within the subdirectory.
 #
 # to simplify things at execution time, this makefile will be incorporated
 # into hpcstruct as a string and written to a temporary file if it is needed.
@@ -18,13 +18,13 @@ C := $(wildcard $(GPUBIN_DIR)/*.gpubin)
 
 
 #-------------------------------------------------------------------------------
-# $(S): hpcstruct files for gpubin
+# $(S): hpcstruct files for gpubins
 #-------------------------------------------------------------------------------
 S := $(patsubst $(GPUBIN_DIR)/%,$(STRUCTS_DIR)/%.hpcstruct,$(C))
 
 
 #-------------------------------------------------------------------------------
-# $(W): warning files that may be generated during structure analysis of gpubin
+# $(W): warning files that may be generated during structure analysis of gpubins
 #-------------------------------------------------------------------------------
 W := $(patsubst %.hpcstruct,%.warnings,$(S))
 
@@ -73,7 +73,7 @@ $(STRUCTS_DIR)/%.hpcstruct: $(GPUBIN_DIR)/%
 
 
 #-------------------------------------------------------------------------------
-# analyze all gpubin to create structure files
+# analyze all gpubins to create structure files
 #-------------------------------------------------------------------------------
 all:
 	make -j 1  THREADS=$(JOBS)  PAR_SIZE=$(GPU_SIZE)  analyze

--- a/src/tool/hpcstruct/gpubin-analysis.txt
+++ b/src/tool/hpcstruct/gpubin-analysis.txt
@@ -2,8 +2,8 @@
 # a helper template makefile used by hpcstruct at runtime
 #
 # if hpcstruct is passed the name of a measurements directory that contains
-# a cubins subdirectory, this makefile will be used to orchestrate parallel
-# analysis of all cubins within the subdirectory.
+# a gpubin subdirectory, this makefile will be used to orchestrate parallel
+# analysis of all gpubin within the subdirectory.
 #
 # to simplify things at execution time, this makefile will be incorporated
 # into hpcstruct as a string and written to a temporary file if it is needed.
@@ -12,19 +12,19 @@
 #*******************************************************************************
 
 #-------------------------------------------------------------------------------
-# $(C): cubin files
+# $(C): gpubin files
 #-------------------------------------------------------------------------------
-C := $(wildcard $(CUBINS_DIR)/*.cubin)
+C := $(wildcard $(GPUBIN_DIR)/*.gpubin)
 
 
 #-------------------------------------------------------------------------------
-# $(S): hpcstruct files for cubins
+# $(S): hpcstruct files for gpubin
 #-------------------------------------------------------------------------------
-S := $(patsubst $(CUBINS_DIR)/%,$(STRUCTS_DIR)/%.hpcstruct,$(C))
+S := $(patsubst $(GPUBIN_DIR)/%,$(STRUCTS_DIR)/%.hpcstruct,$(C))
 
 
 #-------------------------------------------------------------------------------
-# $(W): warning files that may be generated during structure analysis of cubins
+# $(W): warning files that may be generated during structure analysis of gpubin
 #-------------------------------------------------------------------------------
 W := $(patsubst %.hpcstruct,%.warnings,$(S))
 
@@ -39,25 +39,25 @@ W := $(patsubst %.hpcstruct,%.warnings,$(S))
 
 
 #-------------------------------------------------------------------------------
-# rule  for analyzing a cubin
-# 1. analyze a cubin file in $(CUBINS_DIR)
+# rule  for analyzing a gpubin
+# 1. analyze a gpubin file in $(GPUBIN_DIR)
 # 2. produce a hpcstruct file in $(STRUCTS_DIR)
 # 3. leave a warnings file in $(STRUCTS_DIR) if trouble arises
-# 4. announce when analysis of a cubin begins and ends
+# 4. announce when analysis of a gpubin begins and ends
 #-------------------------------------------------------------------------------
-$(STRUCTS_DIR)/%.hpcstruct: $(CUBINS_DIR)/%
-	@cubin_name=`basename -s x $<`
+$(STRUCTS_DIR)/%.hpcstruct: $(GPUBIN_DIR)/%
+	@gpubin_name=`basename -s x $<`
 	struct_name=$@
-	warn_name=$(STRUCTS_DIR)/$$cubin_name.warnings
+	warn_name=$(STRUCTS_DIR)/$$gpubin_name.warnings
 	if test `size $< | tail -1 | awk '{ print $$1 }'` -gt $(PAR_SIZE) ; then
 		if test $(THREADS) -gt 1 ; then
-			echo msg: begin parallel analysis of $$cubin_name \\($(THREADS) threads\\)
+			echo msg: begin parallel analysis of $$gpubin_name \\($(THREADS) threads\\)
 		else
-			echo msg: begin serial analysis of $$cubin_name
+			echo msg: begin serial analysis of $$gpubin_name
 		fi
-		hpcstruct -j $(THREADS) --gpucfg $(CUBIN_CFG) -o $$struct_name $< > $$warn_name 2>&1
+		hpcstruct -j $(THREADS) --gpucfg $(GPUBIN_CFG) -o $$struct_name $< > $$warn_name 2>&1
 		if test -s $$warn_name ; then
-			echo WARNING: incomplete analysis of $$cubin_name\\; see $$warn_name for details
+			echo WARNING: incomplete analysis of $$gpubin_name\\; see $$warn_name for details
 			if test ! -s $$struct_name ; then
 				rm -f $$struct_name
 			fi
@@ -65,15 +65,15 @@ $(STRUCTS_DIR)/%.hpcstruct: $(CUBINS_DIR)/%
 			rm -f $$warn_name
 		fi
 		if test $(THREADS) -gt 1 ; then
-			echo msg: end parallel analysis of $$cubin_name
+			echo msg: end parallel analysis of $$gpubin_name
 		else
-			echo msg: end serial analysis of $$cubin_name
+			echo msg: end serial analysis of $$gpubin_name
 		fi
 	fi
 
 
 #-------------------------------------------------------------------------------
-# analyze all cubins to create structure files
+# analyze all gpubin to create structure files
 #-------------------------------------------------------------------------------
 all:
 	make -j 1  THREADS=$(JOBS)  PAR_SIZE=$(GPU_SIZE)  analyze


### PR DESCRIPTION
- now record AMD and NVIDIA GPU binaries in a directory "gpubins" with the suffix "gpubin"
- adjust hpcstruct to analyze contents of gpubins directory