### PR TITLE
Don't try to init the auditor in the static case.

### DIFF
--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -857,7 +857,9 @@ monitor_init_process(int *argc, char **argv, void* data)
 
   hpcrun_wait();
 
+#ifndef HPCRUN_STATIC_LINK
   hpcrun_init_auditor();
+#endif
 
 #if 0
   // temporary patch to avoid deadlock within PAMI's optimized implementation


### PR DESCRIPTION
In practice this generates a warning during compilation and an error during the link phase of `hpclink`.