### PR TITLE
Opencl wrappers

### DIFF
--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -524,6 +524,11 @@ MY_OPENCL_FILES = \
 	gpu/opencl/opencl-h2d-map.c \
 	gpu/opencl/opencl-queue-map.c \
 	gpu/opencl/opencl-context-map.c
+
+pkglib_LTLIBRARIES += libhpcrun_opencl.la
+libhpcrun_opencl_la_CPPFLAGS  = -I$(top_srcdir)/src $(OPENCL_IFLAGS)
+libhpcrun_opencl_la_SOURCES   = gpu/opencl/opencl-api-wrappers.c
+libhpcrun_opencl_la_LDFLAGS   = -Wl,-Bsymbolic
 endif
 
 if OPT_ENABLE_GTPIN

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -168,24 +168,24 @@ host_triplet = @host@
 @OPT_ENABLE_KERNEL_4_3_TRUE@@OPT_ENABLE_PERF_EVENT_TRUE@am__append_14 = sample-sources/perf/kernel_blocking.c
 @OPT_ENABLE_KERNEL_4_3_FALSE@@OPT_ENABLE_PERF_EVENT_TRUE@am__append_15 = sample-sources/perf/kernel_blocking_stub.c
 @OPT_PAPI_CUPTI_TRUE@am__append_16 = sample-sources/papi-c-cupti.c
-@OPT_ENABLE_LEVEL0_TRUE@am__append_17 = libhpcrun_level0.la
+@OPT_ENABLE_OPENCL_TRUE@am__append_17 = libhpcrun_opencl.la
+@OPT_ENABLE_LEVEL0_TRUE@am__append_18 = libhpcrun_level0.la
 
 #
 # BG/Q backend requires special treatment to avoid deadlocks
 #
-@OPT_BGQ_BACKEND_TRUE@am__append_18 = -DUSE_HW_THREAD_ID -DNONZERO_THRESHOLD
-@OPT_BGQ_BACKEND_TRUE@am__append_19 = -I$(srcdir)/utilities/bgq-cnk
+@OPT_BGQ_BACKEND_TRUE@am__append_19 = -DUSE_HW_THREAD_ID -DNONZERO_THRESHOLD
 @OPT_BGQ_BACKEND_TRUE@am__append_20 = -I$(srcdir)/utilities/bgq-cnk
-@OPT_ENABLE_MPI_WRAP_TRUE@am__append_21 = mpi-overrides.c
+@OPT_BGQ_BACKEND_TRUE@am__append_21 = -I$(srcdir)/utilities/bgq-cnk
 @OPT_ENABLE_MPI_WRAP_TRUE@am__append_22 = mpi-overrides.c
+@OPT_ENABLE_MPI_WRAP_TRUE@am__append_23 = mpi-overrides.c
 
 #-----------------------------------------------------------
 # whirled peas
 #-----------------------------------------------------------
-@HOST_OS_LINUX_TRUE@am__append_23 = $(MY_LINUX_DYNAMIC_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_24 = $(MY_MIPS_FILES)
+@HOST_OS_LINUX_TRUE@am__append_24 = $(MY_LINUX_DYNAMIC_FILES)
 @HOST_CPU_MIPS_TRUE@am__append_25 = $(MY_MIPS_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_26 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_26 = $(MY_MIPS_FILES)
 @HOST_CPU_MIPS_TRUE@am__append_27 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_28 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_29 = $(MY_MIPS_INCLUDE_DIRS)
@@ -196,15 +196,15 @@ host_triplet = @host@
 @HOST_CPU_MIPS_TRUE@am__append_34 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_35 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_36 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_37 = $(MY_MIPS_INCLUDE_DIRS)
 
 # Note: setting CCASFLAGS here is a no-op hack with the side effect of
 # prefixing the tramp.s file names so they will be compiled separately
 # for .o and .so targets.  CFLAGS does this for the .c files, but
 # CFLAGS doesn't apply to .s files.  See the automake docs section
 # 8.3.9.2, Objects created with both libtool and without.
-@HOST_CPU_PPC_TRUE@am__append_37 = $(MY_PPC_FILES)
 @HOST_CPU_PPC_TRUE@am__append_38 = $(MY_PPC_FILES)
-@HOST_CPU_PPC_TRUE@am__append_39 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_PPC_TRUE@am__append_39 = $(MY_PPC_FILES)
 @HOST_CPU_PPC_TRUE@am__append_40 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_41 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_42 = $(MY_PPC_INCLUDE_DIRS)
@@ -217,13 +217,13 @@ host_triplet = @host@
 @HOST_CPU_PPC_TRUE@am__append_49 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_50 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_51 = $(MY_PPC_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_52 = $(MY_X86_FILES)
+@HOST_CPU_PPC_TRUE@am__append_52 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_53 = $(MY_X86_FILES)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_54 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_54 = $(MY_X86_FILES)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_55 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_56 = $(XED2_HPCRUN_LIBS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_57 = $(XED2_HPCLINK_LIBS) 
-@HOST_CPU_X86_FAMILY_TRUE@am__append_58 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_56 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_57 = $(XED2_HPCRUN_LIBS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_58 = $(XED2_HPCLINK_LIBS) 
 @HOST_CPU_X86_FAMILY_TRUE@am__append_59 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_60 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_61 = $(MY_X86_INCLUDE_DIRS)
@@ -235,9 +235,9 @@ host_triplet = @host@
 @HOST_CPU_X86_FAMILY_TRUE@am__append_67 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_68 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_69 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_IA64_TRUE@am__append_70 = $(MY_IA64_FILES)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_70 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_71 = $(MY_IA64_FILES)
-@HOST_CPU_IA64_TRUE@am__append_72 = $(MY_IA64_INCLUDE_DIRS)
+@HOST_CPU_IA64_TRUE@am__append_72 = $(MY_IA64_FILES)
 @HOST_CPU_IA64_TRUE@am__append_73 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_74 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_75 = $(MY_IA64_INCLUDE_DIRS)
@@ -248,9 +248,9 @@ host_triplet = @host@
 @HOST_CPU_IA64_TRUE@am__append_80 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_81 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_82 = $(MY_IA64_INCLUDE_DIRS)
-@HOST_CPU_AARCH64_TRUE@am__append_83 = $(MY_AARCH64_FILES)
+@HOST_CPU_IA64_TRUE@am__append_83 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_84 = $(MY_AARCH64_FILES)
-@HOST_CPU_AARCH64_TRUE@am__append_85 = $(MY_AARCH64_INCLUDE_DIRS)
+@HOST_CPU_AARCH64_TRUE@am__append_85 = $(MY_AARCH64_FILES)
 @HOST_CPU_AARCH64_TRUE@am__append_86 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_87 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_88 = $(MY_AARCH64_INCLUDE_DIRS)
@@ -263,49 +263,50 @@ host_triplet = @host@
 @HOST_CPU_AARCH64_TRUE@am__append_95 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_96 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_97 = $(MY_AARCH64_INCLUDE_DIRS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_98 = $(MY_PAPI_FILES)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_99 = $(PAPI_INC_FLGS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_100 = $(PAPI_LD_FLGS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_101 = -DHPCRUN_SS_PAPI
-@OPT_ENABLE_CUPTI_TRUE@am__append_102 = $(MY_CUPTI_FILES)
+@HOST_CPU_AARCH64_TRUE@am__append_98 = $(MY_AARCH64_INCLUDE_DIRS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_99 = $(MY_PAPI_FILES)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_100 = $(PAPI_INC_FLGS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_101 = $(PAPI_LD_FLGS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_102 = -DHPCRUN_SS_PAPI
 @OPT_ENABLE_CUPTI_TRUE@am__append_103 = $(MY_CUPTI_FILES)
-@OPT_ENABLE_CUPTI_TRUE@am__append_104 = $(CUPTI_INC_FLGS)
-@OPT_ENABLE_CUPTI_TRUE@am__append_105 = -DHPCRUN_SS_NVIDIA
-@OPT_PAPI_CUPTI_TRUE@am__append_106 = $(CUPTI_INC_FLGS)
-@OPT_PAPI_CUPTI_TRUE@am__append_107 = -DHPCRUN_SS_PAPI_C_CUPTI
-@OPT_PAPI_STATIC_TRUE@am__append_108 = $(MY_PAPI_FILES)
-@OPT_PAPI_STATIC_TRUE@am__append_109 = $(PAPI_INC_FLGS)
-@OPT_PAPI_STATIC_TRUE@am__append_110 = $(OPT_PAPI_LIBS_STAT)
-@OPT_PAPI_STATIC_TRUE@am__append_111 = -DHPCRUN_SS_PAPI
-@OPT_ENABLE_UPC_TRUE@am__append_112 = $(MY_UPC_FILES)
+@OPT_ENABLE_CUPTI_TRUE@am__append_104 = $(MY_CUPTI_FILES)
+@OPT_ENABLE_CUPTI_TRUE@am__append_105 = $(CUPTI_INC_FLGS)
+@OPT_ENABLE_CUPTI_TRUE@am__append_106 = -DHPCRUN_SS_NVIDIA
+@OPT_PAPI_CUPTI_TRUE@am__append_107 = $(CUPTI_INC_FLGS)
+@OPT_PAPI_CUPTI_TRUE@am__append_108 = -DHPCRUN_SS_PAPI_C_CUPTI
+@OPT_PAPI_STATIC_TRUE@am__append_109 = $(MY_PAPI_FILES)
+@OPT_PAPI_STATIC_TRUE@am__append_110 = $(PAPI_INC_FLGS)
+@OPT_PAPI_STATIC_TRUE@am__append_111 = $(OPT_PAPI_LIBS_STAT)
+@OPT_PAPI_STATIC_TRUE@am__append_112 = -DHPCRUN_SS_PAPI
 @OPT_ENABLE_UPC_TRUE@am__append_113 = $(MY_UPC_FILES)
-@OPT_ENABLE_UPC_TRUE@am__append_114 = $(OPT_UPC_IFLAGS)
+@OPT_ENABLE_UPC_TRUE@am__append_114 = $(MY_UPC_FILES)
 @OPT_ENABLE_UPC_TRUE@am__append_115 = $(OPT_UPC_IFLAGS)
-@OPT_ENABLE_UPC_TRUE@am__append_116 = $(OPT_UPC_LDFLAGS)
-@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_117 = -DLUSH_PTHREADS
+@OPT_ENABLE_UPC_TRUE@am__append_116 = $(OPT_UPC_IFLAGS)
+@OPT_ENABLE_UPC_TRUE@am__append_117 = $(OPT_UPC_LDFLAGS)
 @OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_118 = -DLUSH_PTHREADS
-@OPT_ENABLE_CUDA_TRUE@am__append_119 = $(MY_CUDA_FILES)
-@OPT_ENABLE_CUDA_TRUE@am__append_120 = -DENABLE_CUDA
-@OPT_ENABLE_CUDA_TRUE@am__append_121 = $(OPT_CUDA_IFLAGS)
-@OPT_ENABLE_CUDA_TRUE@am__append_122 = $(MY_CUDA_FILES)
-@OPT_ENABLE_ROCM_TRUE@am__append_123 = $(MY_ROCM_FILES)
-@OPT_ENABLE_ROCM_TRUE@am__append_124 = -DENABLE_ROCM
-@OPT_ENABLE_ROCM_TRUE@am__append_125 = $(OPT_ROCM_IFLAGS)
-@OPT_ENABLE_ROCM_TRUE@am__append_126 = -DHPCRUN_SS_AMD
-@OPT_ENABLE_LEVEL0_TRUE@am__append_127 = $(MY_LEVEL0_FILES)
-@OPT_ENABLE_LEVEL0_TRUE@am__append_128 = -DENABLE_LEVEL0
-@OPT_ENABLE_LEVEL0_TRUE@am__append_129 = $(OPT_LEVEL0_IFLAGS)
-@OPT_ENABLE_LEVEL0_TRUE@am__append_130 = -DHPCRUN_SS_LEVEL0
-@OPT_ENABLE_OPENCL_TRUE@am__append_131 = $(MY_OPENCL_FILES)
-@OPT_ENABLE_OPENCL_TRUE@am__append_132 = -DENABLE_OPENCL
-@OPT_ENABLE_OPENCL_TRUE@am__append_133 = $(OPT_OPENCL_IFLAGS)
-@OPT_ENABLE_OPENCL_TRUE@am__append_134 = -DHPCRUN_SS_OPENCL
-@OPT_ENABLE_GTPIN_TRUE@am__append_135 = $(MY_GTPIN_FILES)
-@OPT_ENABLE_GTPIN_TRUE@am__append_136 = -DENABLE_GTPIN -DGTPIN_LIBDIR=$(OPT_GTPIN_LIBDIR)
-@OPT_ENABLE_GTPIN_TRUE@am__append_137 = $(OPT_GTPIN_IFLAGS)
-@OPT_ENABLE_GTPIN_TRUE@am__append_138 = -DHPCRUN_SS_GTPIN
-@OPT_ENABLE_LUSH_TRUE@@OPT_WITH_CILK_TRUE@am__append_139 = libagent-cilk.la
-@OPT_ENABLE_LUSH_TRUE@am__append_140 = libagent-pthread.la \
+@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_119 = -DLUSH_PTHREADS
+@OPT_ENABLE_CUDA_TRUE@am__append_120 = $(MY_CUDA_FILES)
+@OPT_ENABLE_CUDA_TRUE@am__append_121 = -DENABLE_CUDA
+@OPT_ENABLE_CUDA_TRUE@am__append_122 = $(OPT_CUDA_IFLAGS)
+@OPT_ENABLE_CUDA_TRUE@am__append_123 = $(MY_CUDA_FILES)
+@OPT_ENABLE_ROCM_TRUE@am__append_124 = $(MY_ROCM_FILES)
+@OPT_ENABLE_ROCM_TRUE@am__append_125 = -DENABLE_ROCM
+@OPT_ENABLE_ROCM_TRUE@am__append_126 = $(OPT_ROCM_IFLAGS)
+@OPT_ENABLE_ROCM_TRUE@am__append_127 = -DHPCRUN_SS_AMD
+@OPT_ENABLE_LEVEL0_TRUE@am__append_128 = $(MY_LEVEL0_FILES)
+@OPT_ENABLE_LEVEL0_TRUE@am__append_129 = -DENABLE_LEVEL0
+@OPT_ENABLE_LEVEL0_TRUE@am__append_130 = $(OPT_LEVEL0_IFLAGS)
+@OPT_ENABLE_LEVEL0_TRUE@am__append_131 = -DHPCRUN_SS_LEVEL0
+@OPT_ENABLE_OPENCL_TRUE@am__append_132 = $(MY_OPENCL_FILES)
+@OPT_ENABLE_OPENCL_TRUE@am__append_133 = -DENABLE_OPENCL
+@OPT_ENABLE_OPENCL_TRUE@am__append_134 = $(OPT_OPENCL_IFLAGS)
+@OPT_ENABLE_OPENCL_TRUE@am__append_135 = -DHPCRUN_SS_OPENCL
+@OPT_ENABLE_GTPIN_TRUE@am__append_136 = $(MY_GTPIN_FILES)
+@OPT_ENABLE_GTPIN_TRUE@am__append_137 = -DENABLE_GTPIN -DGTPIN_LIBDIR=$(OPT_GTPIN_LIBDIR)
+@OPT_ENABLE_GTPIN_TRUE@am__append_138 = $(OPT_GTPIN_IFLAGS)
+@OPT_ENABLE_GTPIN_TRUE@am__append_139 = -DHPCRUN_SS_GTPIN
+@OPT_ENABLE_LUSH_TRUE@@OPT_WITH_CILK_TRUE@am__append_140 = libagent-cilk.la
+@OPT_ENABLE_LUSH_TRUE@am__append_141 = libagent-pthread.la \
 @OPT_ENABLE_LUSH_TRUE@	libagent-tbb.la
 subdir = src/tool/hpcrun
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -913,6 +914,17 @@ libhpcrun_mpi_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(libhpcrun_mpi_la_LDFLAGS) $(LDFLAGS) -o $@
 @OPT_ENABLE_MPI_WRAP_TRUE@am_libhpcrun_mpi_la_rpath = -rpath \
 @OPT_ENABLE_MPI_WRAP_TRUE@	$(pkglibdir)
+libhpcrun_opencl_la_LIBADD =
+am__libhpcrun_opencl_la_SOURCES_DIST =  \
+	gpu/opencl/opencl-api-wrappers.c
+@OPT_ENABLE_OPENCL_TRUE@am_libhpcrun_opencl_la_OBJECTS = gpu/opencl/libhpcrun_opencl_la-opencl-api-wrappers.lo
+libhpcrun_opencl_la_OBJECTS = $(am_libhpcrun_opencl_la_OBJECTS)
+libhpcrun_opencl_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
+	$(AM_CFLAGS) $(CFLAGS) $(libhpcrun_opencl_la_LDFLAGS) \
+	$(LDFLAGS) -o $@
+@OPT_ENABLE_OPENCL_TRUE@am_libhpcrun_opencl_la_rpath = -rpath \
+@OPT_ENABLE_OPENCL_TRUE@	$(pkglibdir)
 libhpcrun_pthread_la_LIBADD =
 am_libhpcrun_pthread_la_OBJECTS = sample-sources/libhpcrun_pthread_la-pthread-blame-overrides.lo
 libhpcrun_pthread_la_OBJECTS = $(am_libhpcrun_pthread_la_OBJECTS)
@@ -1335,8 +1347,9 @@ SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(libhpcrun_fake_audit_la_SOURCES) $(libhpcrun_ga_la_SOURCES) \
 	$(libhpcrun_gprof_la_SOURCES) $(libhpcrun_io_la_SOURCES) \
 	$(libhpcrun_level0_la_SOURCES) $(libhpcrun_memleak_la_SOURCES) \
-	$(libhpcrun_mpi_la_SOURCES) $(libhpcrun_pthread_la_SOURCES) \
-	$(libhpctoolkit_la_SOURCES) $(libhpcrun_o_SOURCES)
+	$(libhpcrun_mpi_la_SOURCES) $(libhpcrun_opencl_la_SOURCES) \
+	$(libhpcrun_pthread_la_SOURCES) $(libhpctoolkit_la_SOURCES) \
+	$(libhpcrun_o_SOURCES)
 DIST_SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(libhpcrun_gprof_wrap_a_SOURCES) \
 	$(libhpcrun_io_wrap_a_SOURCES) \
@@ -1352,6 +1365,7 @@ DIST_SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(libhpcrun_gprof_la_SOURCES) $(libhpcrun_io_la_SOURCES) \
 	$(am__libhpcrun_level0_la_SOURCES_DIST) \
 	$(libhpcrun_memleak_la_SOURCES) $(libhpcrun_mpi_la_SOURCES) \
+	$(am__libhpcrun_opencl_la_SOURCES_DIST) \
 	$(libhpcrun_pthread_la_SOURCES) $(libhpctoolkit_la_SOURCES) \
 	$(am__libhpcrun_o_SOURCES_DIST)
 RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
@@ -1759,9 +1773,9 @@ pkglibexec_SCRIPTS = $(am__append_1)
 include_HEADERS = $(am__append_2)
 pkglib_LIBRARIES = $(am__append_5)
 pkglib_LTLIBRARIES = $(am__append_3) $(am__append_7) $(am__append_17) \
-	$(am__append_139) $(am__append_140)
-BUILT_SOURCES = $(am__append_21)
-CLEANFILES = $(am__append_22)
+	$(am__append_18) $(am__append_140) $(am__append_141)
+BUILT_SOURCES = $(am__append_22)
+CLEANFILES = $(am__append_23)
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@noinst_LTLIBRARIES = libhpcrun.la
 PAPI_INC_FLGS = @OPT_PAPI_IFLAGS@ 
 PAPI_LD_FLGS = @OPT_PAPI_LDFLAGS@
@@ -1848,10 +1862,10 @@ UNW_MIPS_INCLUDE_DIRS = \
 
 UNW_MIPS_LD_FLAGS = 
 MY_CPP_DEFINES = -D_GNU_SOURCE -DINLINE_FN=1 -DLOCAL_BUILD=1 \
-	-D__HIP_PLATFORM_HCC__=1 $(am__append_11) $(am__append_18) \
-	$(am__append_101) $(am__append_105) $(am__append_107) \
-	$(am__append_111) $(am__append_126) $(am__append_130) \
-	$(am__append_134) $(am__append_138)
+	-D__HIP_PLATFORM_HCC__=1 $(am__append_11) $(am__append_19) \
+	$(am__append_102) $(am__append_106) $(am__append_108) \
+	$(am__append_112) $(am__append_127) $(am__append_131) \
+	$(am__append_135) $(am__append_139)
 MY_BASE_FILES = utilities/first_func.c main.h main.c disabled.c \
 	closure-registry.c cct_insert_backtrace.c \
 	cct_backtrace_finalize.c env.c epoch.c files.c \
@@ -1970,6 +1984,9 @@ MY_AARCH64_FILES = \
 @OPT_ENABLE_OPENCL_TRUE@	gpu/opencl/opencl-queue-map.c \
 @OPT_ENABLE_OPENCL_TRUE@	gpu/opencl/opencl-context-map.c
 
+@OPT_ENABLE_OPENCL_TRUE@libhpcrun_opencl_la_CPPFLAGS = -I$(top_srcdir)/src $(OPENCL_IFLAGS)
+@OPT_ENABLE_OPENCL_TRUE@libhpcrun_opencl_la_SOURCES = gpu/opencl/opencl-api-wrappers.c
+@OPT_ENABLE_OPENCL_TRUE@libhpcrun_opencl_la_LDFLAGS = -Wl,-Bsymbolic
 @OPT_ENABLE_GTPIN_TRUE@MY_GTPIN_FILES = \
 @OPT_ENABLE_GTPIN_TRUE@	gpu/instrumentation/kernel-data-map.c \
 @OPT_ENABLE_GTPIN_TRUE@	gpu/instrumentation/gtpin-instrumentation.c \
@@ -2031,11 +2048,11 @@ MY_AARCH64_INCLUDE_DIRS = \
 	-I$(srcdir)/utilities/arch/aarch64
 
 libhpcrun_la_SOURCES = $(MY_BASE_FILES) $(MY_DYNAMIC_FILES) \
-	$(am__append_23) $(am__append_24) $(am__append_37) \
-	$(am__append_52) $(am__append_70) $(am__append_83) \
-	$(am__append_98) $(am__append_102) $(am__append_112) \
-	$(am__append_119) $(am__append_123) $(am__append_127) \
-	$(am__append_131) $(am__append_135) $(UNW_SOURCE_FILES) \
+	$(am__append_24) $(am__append_25) $(am__append_38) \
+	$(am__append_53) $(am__append_71) $(am__append_84) \
+	$(am__append_99) $(am__append_103) $(am__append_113) \
+	$(am__append_120) $(am__append_124) $(am__append_128) \
+	$(am__append_132) $(am__append_136) $(UNW_SOURCE_FILES) \
 	utilities/last_func.c
 libhpcrun_fake_audit_la_SOURCES = \
 	audit/fake-auditor.c
@@ -2044,9 +2061,9 @@ libhpcrun_audit_la_SOURCES = \
 	audit/auditor.c
 
 libhpcrun_o_SOURCES = $(MY_BASE_FILES) $(MY_STATIC_FILES) \
-	$(am__append_25) $(am__append_38) $(am__append_53) \
-	$(am__append_71) $(am__append_84) $(am__append_103) \
-	$(am__append_108) $(am__append_113) $(am__append_122) \
+	$(am__append_26) $(am__append_39) $(am__append_54) \
+	$(am__append_72) $(am__append_85) $(am__append_104) \
+	$(am__append_109) $(am__append_114) $(am__append_123) \
 	$(UNW_SOURCE_FILES) utilities/last_func.c
 libhpcrun_wrap_a_SOURCES = \
 	monitor-exts/openmp.c
@@ -2091,12 +2108,12 @@ libhpctoolkit_a_SOURCES = \
 # cppflags
 #-----------------------------------------------------------
 libhpcrun_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_19) $(am__append_26) $(am__append_39) \
-	$(am__append_54) $(am__append_72) $(am__append_85) \
-	$(am__append_99) $(am__append_104) $(am__append_106) \
-	$(am__append_114) $(am__append_117) $(am__append_120) \
-	$(am__append_124) $(am__append_128) $(am__append_132) \
-	$(am__append_136) $(UNW_INCLUDE_DIRS)
+	$(am__append_20) $(am__append_27) $(am__append_40) \
+	$(am__append_55) $(am__append_73) $(am__append_86) \
+	$(am__append_100) $(am__append_105) $(am__append_107) \
+	$(am__append_115) $(am__append_118) $(am__append_121) \
+	$(am__append_125) $(am__append_129) $(am__append_133) \
+	$(am__append_137) $(UNW_INCLUDE_DIRS)
 libhpcrun_fake_audit_la_CPPFLAGS = \
 	$(MY_CPP_DEFINES)		\
 	$(MY_INCLUDE_DIRS)
@@ -2106,51 +2123,51 @@ libhpcrun_audit_la_CPPFLAGS = \
 	$(MY_INCLUDE_DIRS)
 
 libhpcrun_o_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_20) $(am__append_27) \
-	$(am__append_40) $(am__append_55) $(am__append_73) \
-	$(am__append_86) $(am__append_109) $(am__append_115) \
-	$(am__append_118) $(UNW_INCLUDE_DIRS)
+	$(MY_INCLUDE_DIRS) $(am__append_21) $(am__append_28) \
+	$(am__append_41) $(am__append_56) $(am__append_74) \
+	$(am__append_87) $(am__append_110) $(am__append_116) \
+	$(am__append_119) $(UNW_INCLUDE_DIRS)
 libhpcrun_wrap_a_CPPFLAGS = \
 	-DHPCRUN_STATIC_LINK		\
 	$(MY_CPP_DEFINES)		\
 	$(MY_INCLUDE_DIRS)
 
 libhpcrun_ga_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_28) $(am__append_41) $(am__append_58) \
-	$(am__append_74) $(am__append_87) $(UNW_INCLUDE_DIRS)
+	$(am__append_29) $(am__append_42) $(am__append_59) \
+	$(am__append_75) $(am__append_88) $(UNW_INCLUDE_DIRS)
 libhpcrun_ga_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_29) $(am__append_42) \
-	$(am__append_59) $(am__append_75) $(am__append_88) \
+	$(MY_INCLUDE_DIRS) $(am__append_30) $(am__append_43) \
+	$(am__append_60) $(am__append_76) $(am__append_89) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_gprof_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_43) $(am__append_60) $(am__append_89)
+	$(am__append_44) $(am__append_61) $(am__append_90)
 libhpcrun_gprof_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_44) \
-	$(am__append_61) $(am__append_90)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_45) \
+	$(am__append_62) $(am__append_91)
 libhpcrun_io_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_30) $(am__append_45) $(am__append_62) \
-	$(am__append_76) $(am__append_91) $(UNW_INCLUDE_DIRS)
+	$(am__append_31) $(am__append_46) $(am__append_63) \
+	$(am__append_77) $(am__append_92) $(UNW_INCLUDE_DIRS)
 libhpcrun_io_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_31) $(am__append_46) \
-	$(am__append_63) $(am__append_77) $(am__append_92) \
+	$(MY_INCLUDE_DIRS) $(am__append_32) $(am__append_47) \
+	$(am__append_64) $(am__append_78) $(am__append_93) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_32) $(am__append_47) $(am__append_64) \
-	$(am__append_78) $(am__append_93) $(UNW_INCLUDE_DIRS)
+	$(am__append_33) $(am__append_48) $(am__append_65) \
+	$(am__append_79) $(am__append_94) $(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_33) \
-	$(am__append_48) $(am__append_65) $(am__append_79) \
-	$(am__append_94) $(UNW_INCLUDE_DIRS)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_34) \
+	$(am__append_49) $(am__append_66) $(am__append_80) \
+	$(am__append_95) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_34) $(am__append_49) $(am__append_66) \
-	$(am__append_80) $(am__append_95) $(UNW_INCLUDE_DIRS)
+	$(am__append_35) $(am__append_50) $(am__append_67) \
+	$(am__append_81) $(am__append_96) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_35) \
-	$(am__append_50) $(am__append_67) $(am__append_81) \
-	$(am__append_96) $(UNW_INCLUDE_DIRS)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_36) \
+	$(am__append_51) $(am__append_68) $(am__append_82) \
+	$(am__append_97) $(UNW_INCLUDE_DIRS)
 libhpcrun_mpi_la_CPPFLAGS = $(MY_CPP_DEFINES) -I$(MPI_INC) \
-	$(MY_INCLUDE_DIRS) $(am__append_36) $(am__append_51) \
-	$(am__append_68) $(am__append_82) $(am__append_97) \
+	$(MY_INCLUDE_DIRS) $(am__append_37) $(am__append_52) \
+	$(am__append_69) $(am__append_83) $(am__append_98) \
 	$(UNW_INCLUDE_DIRS)
 libhpctoolkit_la_CPPFLAGS = \
 	$(MY_CPP_DEFINES)		\
@@ -2166,8 +2183,8 @@ libhpctoolkit_a_CPPFLAGS = \
 # cflags
 #-----------------------------------------------------------
 libhpcrun_la_CFLAGS = $(CFLAGS) $(HOST_CFLAGS) $(PERFMON_CFLAGS) \
-	$(am__append_121) $(am__append_125) $(am__append_129) \
-	$(am__append_133) $(am__append_137) $(GOTCHA_IFLAGS)
+	$(am__append_122) $(am__append_126) $(am__append_130) \
+	$(am__append_134) $(am__append_138) $(GOTCHA_IFLAGS)
 libhpcrun_o_CFLAGS = $(CFLAGS) $(HOST_CFLAGS) $(PERFMON_CFLAGS)
 libhpcrun_wrap_a_CFLAGS = $(CFLAGS) $(HOST_CFLAGS)
 libhpcrun_ga_la_CFLAGS = $(CFLAGS) $(HOST_CFLAGS)
@@ -2199,8 +2216,8 @@ OUR_LIBUNWIND_A = $(top_builddir)/src/extern/libunwind/libunwind.a
 OUR_LZMA_A = $(top_builddir)/src/extern/lzma/liblzma.a
 libhpcrun_la_LDFLAGS = -Wl,-Bsymbolic -L$(LIBMONITOR_LIB) -lmonitor \
 	-lpthread -lrt -L$(LIBELF_LIB) -lelf $(PERFMON_LDFLAGS_DYN) \
-	$(OPT_ROCM_LDFLAGS) $(am__append_56) $(am__append_100) \
-	$(am__append_116) $(GOTCHA_LDFLAGS) $(UNW_DYNAMIC_LD_FLAGS)
+	$(OPT_ROCM_LDFLAGS) $(am__append_57) $(am__append_101) \
+	$(am__append_117) $(GOTCHA_LDFLAGS) $(UNW_DYNAMIC_LD_FLAGS)
 libhpcrun_fake_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
 libhpcrun_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
 libhpcrun_ga_la_LDFLAGS = -Wl,-Bsymbolic
@@ -2226,9 +2243,9 @@ libhpcrun_la_LIBADD = \
 
 libhpcrun_o_LDADD = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
 	$(PERFMON_LDFLAGS_STAT) $(MBEDTLS_LIBS) $(OUR_LIBUNWIND_A) \
-	$(OUR_LZMA_A) $(am__append_57) $(am__append_110) \
+	$(OUR_LZMA_A) $(am__append_58) $(am__append_111) \
 	$(UNW_STATIC_LD_FLAGS)
-MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_69) \
+MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_70) \
 	$(UNW_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
 @HOST_CPU_PPC_TRUE@libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
@@ -3233,6 +3250,12 @@ $(DEPDIR)/$(am__dirstamp):
 
 libhpcrun_mpi.la: $(libhpcrun_mpi_la_OBJECTS) $(libhpcrun_mpi_la_DEPENDENCIES) $(EXTRA_libhpcrun_mpi_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(libhpcrun_mpi_la_LINK) $(am_libhpcrun_mpi_la_rpath) $(libhpcrun_mpi_la_OBJECTS) $(libhpcrun_mpi_la_LIBADD) $(LIBS)
+gpu/opencl/libhpcrun_opencl_la-opencl-api-wrappers.lo:  \
+	gpu/opencl/$(am__dirstamp) \
+	gpu/opencl/$(DEPDIR)/$(am__dirstamp)
+
+libhpcrun_opencl.la: $(libhpcrun_opencl_la_OBJECTS) $(libhpcrun_opencl_la_DEPENDENCIES) $(EXTRA_libhpcrun_opencl_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libhpcrun_opencl_la_LINK) $(am_libhpcrun_opencl_la_rpath) $(libhpcrun_opencl_la_OBJECTS) $(libhpcrun_opencl_la_LIBADD) $(LIBS)
 sample-sources/libhpcrun_pthread_la-pthread-blame-overrides.lo:  \
 	sample-sources/$(am__dirstamp) \
 	sample-sources/$(DEPDIR)/$(am__dirstamp)
@@ -4004,6 +4027,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/opencl/$(DEPDIR)/libhpcrun_la-opencl-h2d-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/opencl/$(DEPDIR)/libhpcrun_la-opencl-memory-manager.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/opencl/$(DEPDIR)/libhpcrun_la-opencl-queue-map.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gpu/opencl/$(DEPDIR)/libhpcrun_opencl_la-opencl-api-wrappers.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lush-agents/$(DEPDIR)/libagent_cilk_la-agent-cilk.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lush-agents/$(DEPDIR)/libagent_pthread_la-agent-pthread.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lush-agents/$(DEPDIR)/libagent_tbb_la-agent-tbb.Plo@am__quote@
@@ -6017,6 +6041,13 @@ sample-sources/libhpcrun_memleak_la-memleak-overrides.lo: sample-sources/memleak
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='./mpi-overrides.c' object='./libhpcrun_mpi_la-mpi-overrides.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_mpi_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_mpi_la_CFLAGS) $(CFLAGS) -c -o ./libhpcrun_mpi_la-mpi-overrides.lo `test -f './mpi-overrides.c' || echo '$(srcdir)/'`./mpi-overrides.c
+
+gpu/opencl/libhpcrun_opencl_la-opencl-api-wrappers.lo: gpu/opencl/opencl-api-wrappers.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_opencl_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT gpu/opencl/libhpcrun_opencl_la-opencl-api-wrappers.lo -MD -MP -MF gpu/opencl/$(DEPDIR)/libhpcrun_opencl_la-opencl-api-wrappers.Tpo -c -o gpu/opencl/libhpcrun_opencl_la-opencl-api-wrappers.lo `test -f 'gpu/opencl/opencl-api-wrappers.c' || echo '$(srcdir)/'`gpu/opencl/opencl-api-wrappers.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) gpu/opencl/$(DEPDIR)/libhpcrun_opencl_la-opencl-api-wrappers.Tpo gpu/opencl/$(DEPDIR)/libhpcrun_opencl_la-opencl-api-wrappers.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='gpu/opencl/opencl-api-wrappers.c' object='gpu/opencl/libhpcrun_opencl_la-opencl-api-wrappers.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_opencl_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o gpu/opencl/libhpcrun_opencl_la-opencl-api-wrappers.lo `test -f 'gpu/opencl/opencl-api-wrappers.c' || echo '$(srcdir)/'`gpu/opencl/opencl-api-wrappers.c
 
 sample-sources/libhpcrun_pthread_la-pthread-blame-overrides.lo: sample-sources/pthread-blame-overrides.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_pthread_la_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_pthread_la_CFLAGS) $(CFLAGS) -MT sample-sources/libhpcrun_pthread_la-pthread-blame-overrides.lo -MD -MP -MF sample-sources/$(DEPDIR)/libhpcrun_pthread_la-pthread-blame-overrides.Tpo -c -o sample-sources/libhpcrun_pthread_la-pthread-blame-overrides.lo `test -f 'sample-sources/pthread-blame-overrides.c' || echo '$(srcdir)/'`sample-sources/pthread-blame-overrides.c

--- a/src/tool/hpcrun/gpu/level0/level0-api.c
+++ b/src/tool/hpcrun/gpu/level0/level0-api.c
@@ -369,6 +369,8 @@ get_gpu_driver_and_device
 
     for(d = 0; d < deviceCount; ++d) {
       ze_device_properties_t device_properties;
+      device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+      device_properties.pNext = NULL;
       HPCRUN_LEVEL0_CALL(zeDeviceGetProperties, (allDevices[d], &device_properties));
       if(ZE_DEVICE_TYPE_GPU == device_properties.type) {
         hDriver = allDrivers[i];
@@ -425,7 +427,9 @@ level0_attribute_event
   if (data == NULL) return;
 
   // Get ready to query time stamps
-  ze_device_properties_t props = {};
+  ze_device_properties_t props;
+  props.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES ;
+  props.pNext = NULL;
   HPCRUN_LEVEL0_CALL(zeDeviceGetProperties, (hDevice, &props));
   HPCRUN_LEVEL0_CALL(zeEventQueryStatus, (event));
 
@@ -464,6 +468,8 @@ level0_get_memory_types
   // In such case, zeDriverGetMemAllocProperties will return failure.
   // So, we default the memory type to be HOST.
   ze_memory_allocation_properties_t property;
+  property.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+  property.pNext = NULL;
   if (HPCRUN_LEVEL0_CALL(zeMemGetAllocProperties, (hContext, src_ptr, &property, NULL)) == ZE_RESULT_SUCCESS) {
     *src_type_ptr = property.type;
   }
@@ -490,6 +496,8 @@ level0_event_pool_create_entry
   // This leads to one description per event pool creation.
   pool_desc->flags = desc->flags;
   pool_desc->count = desc->count;
+  pool_desc->stype = desc->stype;
+  pool_desc->pNext = desc->pNext;
 
   // We attach the time stamp flag to the event pool,
   // so that we can query time stamps for events in this pool.

--- a/src/tool/hpcrun/gpu/opencl/opencl-api-wrappers.c
+++ b/src/tool/hpcrun/gpu/opencl/opencl-api-wrappers.c
@@ -1,0 +1,214 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2020, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+//******************************************************************************
+// local includes
+//******************************************************************************
+
+#include <lib/prof-lean/hpcrun-opencl.h>
+
+//******************************************************************************
+// OpenCL public API override
+//******************************************************************************
+
+
+#ifdef ENABLE_GTPIN
+// one downside of this appproach is that we may override the callback provided by user
+cl_int
+clBuildProgram
+(
+ cl_program program,
+ cl_uint num_devices,
+ const cl_device_id* device_list,
+ const char* options,
+ void (CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+ void* user_data
+)
+{
+  return hpcrun_clBuildProgram(program, num_devices, device_list,
+			options, pfn_notify,
+			user_data);
+}
+#endif // ENABLE_GTPIN
+
+
+cl_command_queue
+clCreateCommandQueue
+(
+ cl_context context,
+ cl_device_id device,
+ cl_command_queue_properties properties,
+ cl_int *errcode_ret
+)
+{
+  return hpcrun_clCreateCommandQueue(context, device,
+        properties,errcode_ret);
+}
+
+cl_command_queue
+clCreateCommandQueueWithProperties
+(
+ cl_context context,
+ cl_device_id device,
+ const cl_queue_properties* properties,
+ cl_int* errcode_ret
+)
+{
+  return hpcrun_clCreateCommandQueueWithProperties(
+			      context, device, properties, errcode_ret);
+}
+
+
+cl_int
+clEnqueueNDRangeKernel
+(
+ cl_command_queue command_queue,
+ cl_kernel ocl_kernel,
+ cl_uint work_dim,
+ const size_t *global_work_offset,
+ const size_t *global_work_size,
+ const size_t *local_work_size,
+ cl_uint num_events_in_wait_list,
+ const cl_event *event_wait_list,
+ cl_event *event
+)
+{
+  return hpcrun_clEnqueueNDRangeKernel(
+       command_queue, ocl_kernel, work_dim, global_work_offset,
+	global_work_size, local_work_size, num_events_in_wait_list,
+	event_wait_list, event);
+}
+
+cl_int
+clEnqueueTask
+(
+ cl_command_queue command_queue,
+ cl_kernel kernel,
+ cl_uint num_events_in_wait_list,
+ const cl_event* event_wait_list,
+ cl_event* event
+)
+{
+  return hpcrun_clEnqueueTask(
+      command_queue, kernel, num_events_in_wait_list,
+      event_wait_list, event
+  );
+}
+
+
+cl_int
+clEnqueueReadBuffer
+(
+ cl_command_queue command_queue,
+ cl_mem buffer,
+ cl_bool blocking_read,
+ size_t offset,
+ size_t cb,
+ void *ptr,
+ cl_uint num_events_in_wait_list,
+ const cl_event *event_wait_list,
+ cl_event *event
+)
+{
+  return hpcrun_clEnqueueReadBuffer(
+      command_queue, buffer, blocking_read, offset,
+	  cb, ptr, num_events_in_wait_list,
+	  event_wait_list, event);
+}
+
+cl_int
+clEnqueueWriteBuffer
+(
+ cl_command_queue command_queue,
+ cl_mem buffer,
+ cl_bool blocking_write,
+ size_t offset,
+ size_t cb,
+ const void *ptr,
+ cl_uint num_events_in_wait_list,
+ const cl_event *event_wait_list,
+ cl_event *event
+)
+{
+  return hpcrun_clEnqueueWriteBuffer(
+      command_queue, buffer, blocking_write, offset, cb,
+      ptr, num_events_in_wait_list, event_wait_list, event
+  );
+}
+
+
+void*
+clEnqueueMapBuffer
+(
+ cl_command_queue command_queue,
+ cl_mem buffer,
+ cl_bool blocking_map,
+ cl_map_flags map_flags,
+ size_t offset,
+ size_t size,
+ cl_uint num_events_in_wait_list,
+ const cl_event* event_wait_list,
+ cl_event* event,
+ cl_int* errcode_ret
+)
+{
+  return hpcrun_clEnqueueMapBuffer(
+      command_queue, buffer, blocking_map, map_flags,
+      offset, size, num_events_in_wait_list,
+      event_wait_list, event, errcode_ret
+  );
+}
+
+
+cl_mem
+clCreateBuffer
+(
+ cl_context context,
+ cl_mem_flags flags,
+ size_t size,
+ void* host_ptr,
+ cl_int* errcode_ret
+)
+{
+  return hpcrun_clCreateBuffer(context, flags, size, host_ptr, errcode_ret);
+}

--- a/src/tool/hpcrun/scripts/hpcrun.in
+++ b/src/tool/hpcrun/scripts/hpcrun.in
@@ -304,8 +304,10 @@ do
 		MPI* )     preload_list="${preload_list:+${preload_list}:}${hpcrun_dir}/libhpcrun_mpi.so" ;;
 		gpu=amd) roctracer_libdir="${roctracer_libdir_path}"
 			 export HIP_ENABLE_DEFERRED_LOADING=0;;
+		gpu=opencl)	 preload_list="${preload_list:+${preload_list}:}${hpcrun_dir}/libhpcrun_opencl.so" ;;
 
 		gpu=opencl,inst) gtpin_libdir="${gtpin_lib_path}"
+			preload_list="${preload_list:+${preload_list}:}${hpcrun_dir}/libhpcrun_opencl.so"
 		    namespace_default=single_if_auditing ;;
 
 		gpu=level0,inst) gtpin_libdir="${gtpin_lib_path}"


### PR DESCRIPTION
Move OpenCL wrappers to libhpcrun_opencl.so. This also includes fixes to Level0 support for a bug that I accidentally encountered. I also compile the code with both `--with-level0` and `--with-opencl` at configure time. The same build works for dpcpp code using either level0 backend or opencl backend, meaning `SYCL_BE=PI_LEVEL_ZERO hpcrun -e gpu=level0 ...` and `SYCL_BE=PI_OPENCL hpcrun -e gpu=opencl ...` both works.

@jmellorcrummey I don't have an environment to test GTPin support ready. Can you test this branch with GTPin?

