### PR TITLE
introduced how arg in device_finalizer_fn

### DIFF
--- a/src/tool/hpcrun/control-knob.c
+++ b/src/tool/hpcrun/control-knob.c
@@ -48,7 +48,7 @@ control_knob_register(char *name, char *value, control_knob_type type)
 
 static void
 control_knob_default_register(){
-  control_knob_register("STREAMS_PER_THREAD", "4", ck_int);
+  control_knob_register("STREAMS_PER_TRACING_THREAD", "4", ck_int);
   control_knob_register("MAX_COMPLETION_CALLBACK_THREADS", "1000", ck_int);
 }
 

--- a/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
@@ -57,7 +57,7 @@
 #include "gpu-operation-channel-set.h"
 #include "gpu-trace.h"
 #include "gpu-print.h"
-
+#include "monitor.h"
 
 
 //******************************************************************************
@@ -108,8 +108,9 @@ gpu_operation_record
 
   current_operation_channels_count = atomic_load(&operation_channels_count);
   gpu_operation_channel_set_process(current_operation_channels_count);
-
-  gpu_trace_fini(NULL, 0);
+  
+  // even if this is not normal exit, gpu-trace-fini will behave as if it is a normal exit
+  gpu_trace_fini(NULL, MONITOR_EXIT_NORMAL);
   atomic_store(&gpu_trace_finished, true);
 
   return NULL;

--- a/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
@@ -108,9 +108,8 @@ gpu_operation_record
 
   current_operation_channels_count = atomic_load(&operation_channels_count);
   gpu_operation_channel_set_process(current_operation_channels_count);
-  gpu_operation_channel_set_await(current_operation_channels_count);
 
-  gpu_trace_fini(NULL);
+  gpu_trace_fini(NULL, 0);
   atomic_store(&gpu_trace_finished, true);
 
   return NULL;

--- a/src/tool/hpcrun/gpu/gpu-trace-demultiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-trace-demultiplexer.c
@@ -55,7 +55,6 @@
 #include "gpu-print.h"
 
 
-
 //******************************************************************************
 // type declarations
 //******************************************************************************
@@ -110,7 +109,7 @@ gpu_trace_demultiplexer_init
  void
 )
 {
-  control_knob_value_get_int("STREAMS_PER_THREAD", &streams_per_thread);
+  control_knob_value_get_int("STREAMS_PER_TRACING_THREAD", &streams_per_thread);
   trace_channel_set_list_head = gpu_trace_channel_set_create();
   trace_channel_set_list_tail = trace_channel_set_list_head;
 

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -361,10 +361,7 @@ gpu_trace_record
     gpu_trace_channel_set_process(channel_set);
 
   }
-
   gpu_trace_channel_set_process(channel_set);
-  gpu_trace_channel_set_await(channel_set);
-
   gpu_trace_channel_set_release(channel_set);
   return NULL;
 }

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -334,7 +334,8 @@ gpu_trace_init
 void
 gpu_trace_fini
 (
- void *arg
+ void *arg,
+ int how
 )
 {
   PRINT("gpu_trace_fini called\n");

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -65,6 +65,7 @@
 #include <lib/prof-lean/stdatomic.h>
 
 #include <hpcrun/cct/cct.h>
+#include <hpcrun/utilities/hpcrun-nanotime.h>
 #include <hpcrun/control-knob.h>
 #include <hpcrun/thread_data.h>
 #include <hpcrun/threadmgr.h>
@@ -88,7 +89,7 @@
 
 #define DEBUG 0
 #include "gpu-print.h"
-
+#define TRACE_CHANNEL_SLEEP 5000000 // in ns
 
 
 //******************************************************************************
@@ -359,10 +360,11 @@ gpu_trace_record
   while (!atomic_load(&stop_trace_flag)) {
     //getting data from a trace channel
     gpu_trace_channel_set_process(channel_set);
-
+    hpcrun_nanosleep(TRACE_CHANNEL_SLEEP);
   }
   gpu_trace_channel_set_process(channel_set);
   gpu_trace_channel_set_release(channel_set);
+
   return NULL;
 }
 

--- a/src/tool/hpcrun/gpu/gpu-trace.h
+++ b/src/tool/hpcrun/gpu/gpu-trace.h
@@ -97,14 +97,15 @@ gpu_trace_init
 void
 gpu_trace_fini
 (
-void *arg
+ void *arg,
+ int how
 );
 
 
 void *
 gpu_trace_record
 (
-void *args
+ void *args
 );
 
 

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -112,7 +112,6 @@
 #include "device-initializers.h"
 #include "device-finalizers.h"
 #include "module-ignore-map.h"
-#include "control-knob.h"
 #include "epoch.h"
 #include "thread_data.h"
 #include "threadmgr.h"

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -923,11 +923,10 @@ monitor_init_process(int *argc, char **argv, void* data)
   auditor_exports->mainlib_connected(get_saved_vdso_path());
 #endif
 
-  control_knob_init();
-
   hpcrun_registered_sources_init();
 
   hpcrun_do_custom_init();
+
 
   // for debugging, limit the life of the execution with an alarm.
   char* life  = getenv("HPCRUN_LIFETIME");

--- a/src/tool/hpcrun/sample_sources_registered.c
+++ b/src/tool/hpcrun/sample_sources_registered.c
@@ -145,6 +145,8 @@ hpcrun_registered_sources_init(void)
     METHOD_CALL(ss, init);
     TMSG(SS_COMMON, "sample source \"%s\": init", ss->name);
   }
+  
+  control_knob_init();
 }
 
 void

--- a/src/tool/hpcrun/sample_sources_registered.c
+++ b/src/tool/hpcrun/sample_sources_registered.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "control-knob.h"
 #include "sample_sources_registered.h"
 #include <sample-sources/sample_source_obj.h>
 #include <sample-sources/ss-obj-name.h>

--- a/src/tool/hpcrun/utilities/hpcrun-nanotime.c
+++ b/src/tool/hpcrun/utilities/hpcrun-nanotime.c
@@ -48,9 +48,9 @@
 // system includes
 //*****************************************************************************
 
-#include <time.h>
 #include <assert.h>
-
+#include <errno.h>
+#include <time.h>
 
 //*****************************************************************************
 // local includes
@@ -85,4 +85,27 @@ hpcrun_nanotime()
   uint64_t now_ns = now_sec * NS_PER_SEC + now.tv_nsec;
 
   return now_ns;
+}
+
+
+int32_t
+hpcrun_nanosleep
+(
+  uint32_t nsec
+)
+{
+  struct timespec time_wait = {.tv_sec=0, .tv_nsec=nsec};
+  struct timespec time_rem = {.tv_sec=0, .tv_nsec=0};
+  int32_t ret;
+  
+  for(;;){
+    ret = nanosleep(&time_wait, &time_rem);
+    if (! (ret < 0 && errno == EINTR)){
+      // normal non-signal return
+      break;
+    }
+  time_wait = time_rem;
+  }
+
+  return ret;
 }

--- a/src/tool/hpcrun/utilities/hpcrun-nanotime.h
+++ b/src/tool/hpcrun/utilities/hpcrun-nanotime.h
@@ -65,5 +65,10 @@ hpcrun_nanotime
   void
 );
 
+int32_t
+hpcrun_nanosleep
+(
+  uint32_t nsec
+);
 
 #endif


### PR DESCRIPTION
Adaptation to Keren's change of finalizer function, and deleting gpu_operation_channel_set_await as unnecessery