### PR TITLE
Fixes regarding measurement directory

### DIFF
--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
@@ -252,7 +252,7 @@ parse_amd_gpu_binary_uri
   used += sprintf(&gpu_file_path[used], "%s", hpcrun_files_output_directory());
   used += sprintf(&gpu_file_path[used], "%s", "/" GPU_BINARY_DIRECTORY "/");
   mkdir(gpu_file_path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-  used += sprintf(&gpu_file_path[used], "%s.%llx" GPU_BINARY_SUFFIX, 
+  used += sprintf(&gpu_file_path[used], "%s.%llx" GPU_BINARY_SUFFIX,
 		  filename, offset);
 
   int rfd = open(filepath, O_RDONLY);
@@ -277,10 +277,23 @@ parse_amd_gpu_binary_uri
 
   // We write down this GPU binary if necessary.
   // We may not need to create this GPU binary when reusing a measurement directory.
+  errno = 0;
   int wfd = open(gpu_file_path, O_WRONLY | O_CREAT | O_EXCL, 0644);
   if (wfd >= 0) {
-    write(wfd, (const void*)(bin->buf), bin->size);
+    errno = 0;
+    if (write(wfd, (const void*)(bin->buf), bin->size) != bin->size) {
+      // This could happen if running out of disk quota
+      int error = errno;
+      close(wfd);
+      hpcrun_abort("hpctoolkit: unable to write AMD GPU binary file %s: %s", gpu_file_path, strerror(error));
+    }
     close(wfd);
+  } else {
+    // We tolerate an existing file.
+    // Otherwise, fatal error
+    if (errno != EEXIST) {
+      hpcrun_abort("hpctoolkit: unable to create AMD GPU binary file %s: %s", gpu_file_path, strerror(errno));
+    }
   }
 
   bin->amd_gpu_module_id = hpcrun_loadModule_add(gpu_file_path);
@@ -319,10 +332,10 @@ parse_amd_gpu_binary
     char* uri = rocm_debug_api_query_uri(i);
     PRINT("uri %d, %s\n", i, uri);
 
-    // Handle file URIs 
+    // Handle file URIs
     if (strncmp(uri, "file://", strlen("file://")) == 0) {
       if (file_uri_exists(uri)) continue;
-      
+
       // Handle a new AMD GPU binary
       amd_gpu_binary_t* bin = (amd_gpu_binary_t*) malloc(sizeof(amd_gpu_binary_t));
       bin->uri = strdup(uri);

--- a/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
+++ b/src/tool/hpcrun/gpu/amd/rocm-binary-processing.c
@@ -255,13 +255,6 @@ parse_amd_gpu_binary_uri
   used += sprintf(&gpu_file_path[used], "%s.%llx" GPU_BINARY_SUFFIX, 
 		  filename, offset);
 
-  // We directly return if we have write down this URI
-  int wfd;
-  wfd = open(gpu_file_path, O_WRONLY | O_CREAT | O_EXCL, 0644);
-  if (wfd < 0) {
-    return;
-  }
-
   int rfd = open(filepath, O_RDONLY);
   if (rfd < 0) {
     PRINT("\tcannot open the file specified in the file URI\n");
@@ -281,8 +274,14 @@ parse_amd_gpu_binary_uri
     perror(NULL);
     return;
   }
-  write(wfd, (const void*)(bin->buf), bin->size);
-  close(wfd);
+
+  // We write down this GPU binary if necessary.
+  // We may not need to create this GPU binary when reusing a measurement directory.
+  int wfd = open(gpu_file_path, O_WRONLY | O_CREAT | O_EXCL, 0644);
+  if (wfd >= 0) {
+    write(wfd, (const void*)(bin->buf), bin->size);
+    close(wfd);
+  }
 
   bin->amd_gpu_module_id = hpcrun_loadModule_add(gpu_file_path);
 }

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -898,32 +898,34 @@ monitor_init_process(int *argc, char **argv, void* data)
 
   // We do not want creating the measurement directory when
   // the user only wants to see the complete event list
-  char *create_dir = getenv("HPCRUN_NO_MEASUREMENT_DIR");
+  if (getenv("HPCRUN_LIST_EVENT")) {
+    hpcrun_set_disabled();
+  }
   // We need to initialize messages related functions and set up measurement directory,
   // so that we can write vdso and prevent fnbounds print messages to the terminal.
   messages_init();
-  if (!hpcrun_get_disabled() && create_dir == NULL) {
+  if (!hpcrun_get_disabled()) {
     hpcrun_files_set_directory();
-  }
-  if (create_dir == NULL) messages_logfile_create();
+    messages_logfile_create();
 
-  // must initialize unwind recipe map before initializing fnbounds
-  // because mapping of load modules affects the recipe map.
-  hpcrun_unw_init();
+    // must initialize unwind recipe map before initializing fnbounds
+    // because mapping of load modules affects the recipe map.
+    hpcrun_unw_init();
 
-  // We need to save vdso before initializing fnbounds this
-  // is because fnbounds_init will iterate over the load map
-  // and will invoke analysis on vdso
-  if (create_dir == NULL) hpcrun_save_vdso();
+    // We need to save vdso before initializing fnbounds this
+    // is because fnbounds_init will iterate over the load map
+    // and will invoke analysis on vdso
+    hpcrun_save_vdso();
 
-  // init callbacks for each device //Module_ignore_map is here
-  hpcrun_initializer_init();
+    // init callbacks for each device //Module_ignore_map is here
+    hpcrun_initializer_init();
 
-  // fnbounds must be after module_ignore_map
-  if (create_dir == NULL) fnbounds_init();
+    // fnbounds must be after module_ignore_map
+    fnbounds_init();
 #ifndef HPCRUN_STATIC_LINK
-  if (create_dir == NULL) auditor_exports->mainlib_connected(get_saved_vdso_path());
+    auditor_exports->mainlib_connected(get_saved_vdso_path());
 #endif
+  }
 
   hpcrun_registered_sources_init();
 

--- a/src/tool/hpcrun/scripts/hpcrun.in
+++ b/src/tool/hpcrun/scripts/hpcrun.in
@@ -354,7 +354,7 @@ do
 
 	-L | -l | --list-events )
 	    export HPCRUN_EVENT_LIST=LIST
-		export HPCRUN_NO_MEASUREMENT_DIR=1
+		export HPCRUN_LIST_EVENT=1
 	    ;;
 
 	-ds | --delay-sampling )

--- a/src/tool/hpcrun/scripts/hpcrun.in
+++ b/src/tool/hpcrun/scripts/hpcrun.in
@@ -354,6 +354,7 @@ do
 
 	-L | -l | --list-events )
 	    export HPCRUN_EVENT_LIST=LIST
+		export HPCRUN_NO_MEASUREMENT_DIR=1
 	    ;;
 
 	-ds | --delay-sampling )


### PR DESCRIPTION
1. The rocm support code will directly return when finding out that the GPU binary exists, which will skip the steps to fill in data structures representing the list of GPU binaries. The fix is to just skip writing to disk but not the steps of filling the needed data structures.

2. Currently, running `hpcrun -L` will create an unwanted measurement directory. A full solution requires more thoughts on the ordering of the startup sequences. This PR includes a temporary solution that simply skips operations related creating measurement directory. 