### PR TITLE
Fix PLT optimization for dlopen'd libraries

### DIFF
--- a/src/tool/hpcrun/audit/audit-api.h
+++ b/src/tool/hpcrun/audit/audit-api.h
@@ -79,6 +79,9 @@ typedef struct auditor_map_entry_t {
 
   // Corrosponding load_module_t for this here thing.
   struct load_module_t* load_module;
+
+  // link_map entry for this library, if that makes sense for this entry.
+  struct link_map* map;
 } auditor_map_entry_t;
 
 typedef struct auditor_hooks_t {

--- a/src/tool/hpcrun/audit/auditor.c
+++ b/src/tool/hpcrun/audit/auditor.c
@@ -145,8 +145,6 @@ static auditor_exports_t exports = {
   .clone = clone, .execve = execve
 };
 
-static struct buffered_entry_t* obj_update_list = NULL;
-
 
 
 //******************************************************************************
@@ -168,6 +166,7 @@ static ElfW(Addr) * get_plt_got_start(ElfW(Dyn) * dyn_init) {
 static void hook_open(uintptr_t* cookie, struct link_map* map, enum audit_open_flags ao_flags) {
   // Allocate some space for our extra bits, and fill it.
   auditor_map_entry_t* entry = malloc(sizeof *entry);
+  entry->map = map;
 
   // Normally the path is map->l_name, but sometimes that string is empty
   // which indicates the main executable. So we get it the other way.
@@ -359,15 +358,19 @@ static void optimize_object_plt(struct link_map* map) {
   }
 }
 
-static void update_objects_gotplt() {
-  // Iterate every object and update pltgot
-  for (struct buffered_entry_t* entry = obj_update_list; entry != NULL;) {
-    optimize_object_plt(entry->map);
-    struct buffered_entry_t* prev = entry;
-    entry = entry->next;
-    free(prev);
-  }
-  obj_update_list = NULL;
+uintptr_t la_symbind32(Elf32_Sym *sym, unsigned int ndx,
+                       uintptr_t *refcook, uintptr_t *defcook,
+                       unsigned int *flags, const char *symname) {
+  if(dl_runtime_resolver_ptr != NULL)
+    optimize_object_plt(state < state_connected ? (struct link_map*)*refcook : ((auditor_map_entry_t*)*refcook)->map);
+  return sym->st_value;
+}
+uintptr_t la_symbind64(Elf64_Sym *sym, unsigned int ndx,
+                       uintptr_t *refcook, uintptr_t *defcook,
+                       unsigned int *flags, const char *symname) {
+  if(dl_runtime_resolver_ptr != NULL)
+    optimize_object_plt(state < state_connected ? (struct link_map*)*refcook : ((auditor_map_entry_t*)*refcook)->map);
+  return sym->st_value;
 }
 
 
@@ -470,13 +473,6 @@ unsigned int la_version(unsigned int version) {
 
 
 unsigned int la_objopen(struct link_map* map, Lmid_t lmid, uintptr_t* cookie) {
-  if (dl_runtime_resolver_ptr) {
-    // We record the open objects and then later overwrite ldso pointers
-    struct buffered_entry_t* new_entry = (struct  buffered_entry_t*)malloc(sizeof(struct buffered_entry_t));
-    new_entry->map = map;
-    new_entry->next = obj_update_list;
-    obj_update_list = new_entry;
-  }
   switch(state) {
   case state_awaiting: {
     // If this is libhpcrun.so, nab the initialization bits and transition.
@@ -507,17 +503,17 @@ unsigned int la_objopen(struct link_map* map, Lmid_t lmid, uintptr_t* cookie) {
       .map = map, .lmid = lmid, .cookie = cookie, .next = buffer,
     };
     buffer = entry;
-    return 0;
+    return LA_FLG_BINDFROM | LA_FLG_BINDTO;
   }
   case state_connected:
     // If we're already connected, just call the hook.
     hook_open(cookie, map, AO_NONE);
-    return 0;
+    return LA_FLG_BINDFROM | LA_FLG_BINDTO;
   case state_disconnected:
     // We just ignore things that happen after disconnection.
     if(verbose)
       fprintf(stderr, "[audit] objopen after disconnection: `%s'\n", map->l_name);
-    return 0;
+    return LA_FLG_BINDFROM | LA_FLG_BINDTO;
   }
   abort();  // unreachable
 }
@@ -527,10 +523,6 @@ void la_activity(uintptr_t* cookie, unsigned int flag) {
   static unsigned int previous = LA_ACT_CONSISTENT;
 
   if(flag == LA_ACT_CONSISTENT) {
-    if (dl_runtime_resolver_ptr && obj_update_list != NULL) {
-      update_objects_gotplt();
-    }
-
     // If we've hit consistency and know where libhpcrun is, initialize it.
     switch(state) {
     case state_awaiting:


### PR DESCRIPTION
Test code:
```
#--- Makefile
all: main libfoo.so libbar.so
clean:
	rm -f main libfoo.so libbar.so

libbar.so: bar.c
	gcc -o $@ $^ -shared
libfoo.so: foo.c libbar.so
	gcc -o $@ -shared -Wl,-rpath=`realpath .` -L. $< -lbar
main: main.c libbar.so
	gcc -o $@ -Wl,-rpath=`realpath .` -L. $< -lbar -ldl

//--- main.c
#include <dlfcn.h>
extern void bar();
int main() {
  bar();
  void* h = dlopen("libfoo.so", RTLD_LAZY);
  void (*foo)() = dlsym(h, "foo");
  foo();
  dlclose(h);
}

//--- foo.c
extern void bar();
void foo() {
  bar();
  for(int i = 0; i < 1<<28; i++) bar();
}

//--- bar.c
void bar() {}
```

Output:
```console
$ \time ./main
0.46user 0.00system 0:00.46elapsed 99%CPU (0avgtext+0avgdata 1188maxresident)k
0inputs+0outputs (0major+87minor)pagefaults 0swaps
$ \time hpcrun -e REALTIME@0 ./main  # Before
22.56user 0.02system 0:22.62elapsed 99%CPU (0avgtext+0avgdata 11192maxresident)k
0inputs+144outputs (0major+12466minor)pagefaults 0swaps
$ \time hpcrun -e REALTIME@0 ./main  # After
0.50user 0.01system 0:00.53elapsed 96%CPU (0avgtext+0avgdata 9168maxresident)k
0inputs+96outputs (0major+12468minor)pagefaults 0swaps
```