### PR TITLE
Avoid creating the background tracing thread when -t is not specified

### DIFF
--- a/src/tool/hpcrun/gpu/gpu-activity-process.c
+++ b/src/tool/hpcrun/gpu/gpu-activity-process.c
@@ -92,7 +92,9 @@ gpu_context_stream_trace
  gpu_trace_item_t *ti
 )
 {
-  gpu_context_id_map_stream_process(context_id, stream_id, gpu_trace_produce, ti);
+  if (hpcrun_trace_isactive()) {
+    gpu_context_id_map_stream_process(context_id, stream_id, gpu_trace_produce, ti);
+  }
 }
 
 
@@ -103,8 +105,9 @@ gpu_context_trace
  gpu_trace_item_t *ti
 )
 {
-  gpu_context_id_map_context_process(context_id, gpu_trace_produce, ti);
-
+  if (hpcrun_trace_isactive()) {
+    gpu_context_id_map_context_process(context_id, gpu_trace_produce, ti);
+  }
 }
 
 


### PR DESCRIPTION
Surprisingly, it reduces the execution monitoring overhead by 36%, and the end to end overhead by 60%.

@dejangrubisic Can you help me verify the benefits on gpu.cs and llnl.cs? I only ran it on gpu.cs. Just use `hpcrun -e gpu=nvidia`, and https://github.com/HPCToolkit/hpctoolkit-tutorial-examples/tree/master/examples/gpu/laghos
