### PR TITLE
ROCm support fix and GPU tracing fix

### DIFF
--- a/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-activity-translate.c
@@ -47,7 +47,7 @@
 
 #include "roctracer-activity-translate.h"
 
-#define DEBUG 1
+#define DEBUG 0
 
 #include <hpcrun/gpu/gpu-print.h>
 
@@ -133,12 +133,13 @@ roctracer_activity_translate
  roctracer_record_t *record
 )
 {
-//#if DEBUG
   const char * name = roctracer_op_string(record->domain, record->op, record->kind);
-//#endif
   memset(ga, 0, sizeof(gpu_activity_t));
 
   if (record->domain == ACTIVITY_DOMAIN_HIP_OPS) {
+    // TODO: I cannot find the corresponding enum in AMD toolchain
+    // to identify different types of activities.
+    // At this point, match the string name
     if (strcmp(name, "KernelExecution") == 0) {
       convert_kernel_launch(ga, record);
     } else if (strcmp(name, "CopyDeviceToDevice") == 0) {
@@ -155,82 +156,7 @@ roctracer_activity_translate
     }
   } else if (record->domain == ACTIVITY_DOMAIN_HIP_API) {
     // Ignore API tracing records
-    /*
-    switch(record->kind){
-    case HIP_API_ID_hipMemcpyDtoD:
-    case HIP_API_ID_hipMemcpyDtoDAsync:
-      convert_memcpy(ga, record, GPU_MEMCPY_D2D);
-      break;
-    case HIP_API_ID_hipMemcpy2DToArray:
-      convert_memcpy(ga, record, GPU_MEMCPY_D2D);
-      break;
-    case HIP_API_ID_hipMemcpyAtoH:
-      convert_memcpy(ga, record, GPU_MEMCPY_A2H);
-      break;
-    case HIP_API_ID_hipMemcpyHtoD:
-    case HIP_API_ID_hipMemcpyHtoDAsync:
-      convert_memcpy(ga, record, GPU_MEMCPY_H2D);
-      break;
-    case HIP_API_ID_hipMemcpyHtoA:
-      convert_memcpy(ga, record, GPU_MEMCPY_H2A);
-      break;
-    case HIP_API_ID_hipMemcpyDtoH:
-    case HIP_API_ID_hipMemcpyDtoHAsync:
-      convert_memcpy(ga, record, GPU_MEMCPY_D2H);
-      break;
-    case HIP_API_ID_hipMemcpyAsync:
-    case HIP_API_ID_hipMemcpyFromSymbol:
-    case HIP_API_ID_hipMemcpy3D:
-    case HIP_API_ID_hipMemcpy2D:
-    case HIP_API_ID_hipMemcpyPeerAsync:
-    case HIP_API_ID_hipMemcpyFromArray:
-    case HIP_API_ID_hipMemcpy2DAsync:
-    case HIP_API_ID_hipMemcpyToArray:
-    case HIP_API_ID_hipMemcpyToSymbol:
-    case HIP_API_ID_hipMemcpyPeer:
-    case HIP_API_ID_hipMemcpyParam2D:
-    case HIP_API_ID_hipMemcpy:
-    case HIP_API_ID_hipMemcpyToSymbolAsync:
-    case HIP_API_ID_hipMemcpyFromSymbolAsync:
-      convert_memcpy(ga, record, GPU_MEMCPY_UNK);
-      break;
-    case HIP_API_ID_hipModuleLaunchKernel:
-    case HIP_API_ID_hipLaunchCooperativeKernel:
-    case HIP_API_ID_hipHccModuleLaunchKernel:
-    case HIP_API_ID_hipExtModuleLaunchKernel:
-    case HIP_API_ID_hipLaunchKernel:
-      convert_kernel_launch(ga, record);
-      break;
-    case HIP_API_ID_hipCtxSynchronize:
-      convert_sync(ga, record, GPU_SYNC_UNKNOWN);
-      break;
-    case HIP_API_ID_hipStreamSynchronize:
-      convert_sync(ga, record, GPU_SYNC_STREAM);
-      break;
-    case HIP_API_ID_hipStreamWaitEvent:
-      convert_sync(ga, record, GPU_SYNC_STREAM_EVENT_WAIT);
-      break;
-    case HIP_API_ID_hipDeviceSynchronize:
-      convert_sync(ga, record, GPU_SYNC_UNKNOWN);
-      break;
-    case HIP_API_ID_hipEventSynchronize:
-      convert_sync(ga, record, GPU_SYNC_EVENT);
-      break;
-    case HIP_API_ID_hipMemset3DAsync:
-    case HIP_API_ID_hipMemset2D:
-    case HIP_API_ID_hipMemset2DAsync:
-    case HIP_API_ID_hipMemset:
-    case HIP_API_ID_hipMemsetD8:
-    case HIP_API_ID_hipMemset3D:
-    case HIP_API_ID_hipMemsetAsync:
-    case HIP_API_ID_hipMemsetD32Async:
-      convert_memset(ga, record);
-      break;
-    default:
-      convert_unknown(ga);
-      PRINT("roctracer buffer event: Unhandled HIP OPS activity %s, duration %d\n", name, record->end_ns - record->begin_ns);
-    }
-    */    
+    convert_unknown(ga);
   } else {
     convert_unknown(ga);
     PRINT("roctracer buffer enent: Unhandled activity %s, domain %u, op %u, kind %u\n", 

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -223,22 +223,6 @@ gpu_trace_stream_append
                            td->prev_dLCA, time);
 }
 
-
-static void
-gpu_trace_first
-(
- thread_data_t* td,
- cct_node_t *no_activity,
- uint64_t start
-)
-{
-  if (td->gpu_trace_first_time == 0) {
-    td->gpu_trace_first_time = start - 1;
-    gpu_trace_stream_append(td, no_activity, start - 1);
-  }
-}
-
-
 static uint64_t
 gpu_trace_start_adjust
 (

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -455,11 +455,11 @@ consume_one_trace_item
   }
 
   if (append) {
-    gpu_trace_first(td, no_activity, start);
-
+    gpu_trace_stream_append(td, no_activity, start - 1);
     gpu_trace_stream_append(td, leaf, start);
 
-    gpu_trace_stream_append(td, no_activity, end);
+    gpu_trace_stream_append(td, leaf, end);
+    gpu_trace_stream_append(td, no_activity, end + 1);
 
     PRINT("%p Append trace activity [%lu, %lu]\n", td, start, end);
   }

--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -402,7 +402,6 @@ hpcrun_thread_data_init(int id, cct_ctxt_t* thr_ctxt, int is_child, size_t n_sou
   // ----------------------------------------
   // gpu trace line support
   // ----------------------------------------
-  td->gpu_trace_first_time = 0;
   td->gpu_trace_prev_time = 0;
 
 #ifdef ENABLE_CUDA

--- a/src/tool/hpcrun/thread_data.h
+++ b/src/tool/hpcrun/thread_data.h
@@ -285,7 +285,6 @@ typedef struct thread_data_t {
   gpu_data_t gpu_data;
 #endif
   
-  uint64_t gpu_trace_first_time;
   uint64_t gpu_trace_prev_time;
  
 } thread_data_t;


### PR DESCRIPTION
1. Do not record time stamps of HIP API executed on the host side. Record the time stamps of actual GPU operations from the GPU.
2. Fix GPU tracing, which requires matched time stamps for GPU operations and "no activity". This is a problem for all GPU platforms.