### PR TITLE
Monitor and tracing threads are not tracked by libmonitor and they ar…

### DIFF
--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -65,6 +65,9 @@
 #include <hpcrun/sample-sources/libdl.h>
 
 #include <hpcrun/utilities/hpcrun-nanotime.h>
+#include <monitor.h>
+
+
 
 //******************************************************************************
 // macros
@@ -471,6 +474,8 @@ roctracer_buffer_completion_callback
  void* arg
 )
 {
+  hpcrun_thread_init_mem_pool_once();
+
   roctracer_buffer_completion_notify();
   roctracer_record_t* record = (roctracer_record_t*)(begin);
   roctracer_record_t* end_record = (roctracer_record_t*)(end);

--- a/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
@@ -93,6 +93,7 @@ gpu_init_operation_channel(){
 }
 
 
+// OpenCL Monitoring thread
 static void *
 gpu_operation_record
 (
@@ -100,6 +101,8 @@ gpu_operation_record
 )
 {
   int current_operation_channels_count;
+  
+  hpcrun_thread_init_mem_pool_once();
 
   while (!atomic_load(&stop_operation_flag)){
     current_operation_channels_count = atomic_load(&operation_channels_count);
@@ -133,9 +136,11 @@ gpu_operation_multiplexer_create
 
   gpu_operation_channel_set_alloc(max_completion_cb_threads);
 
-  // You are the first to create monitor thread
+  monitor_disable_new_threads();
+  // Create monitor thread
   pthread_create(&thread, NULL, (pthread_start_routine_t) gpu_operation_record,
                  NULL);
+  monitor_enable_new_threads();
 }
 
 

--- a/src/tool/hpcrun/gpu/gpu-trace-demultiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-trace-demultiplexer.c
@@ -54,6 +54,7 @@
 #include "gpu-trace-demultiplexer.h"
 #include "gpu-print.h"
 
+#include <monitor.h>
 
 //******************************************************************************
 // type declarations
@@ -95,10 +96,13 @@ gpu_trace_channel_set_create
   new_channel_set->next = NULL;
   new_channel_set->channel_set_ptr = gpu_trace_channel_set_alloc(streams_per_thread);
   atomic_store(&new_channel_set->channel_index, 0);
-
+  
+  monitor_disable_new_threads();
+  // Create tracing thread
   pthread_create(&new_channel_set->thread, NULL, (pthread_start_routine_t) gpu_trace_record,
                  new_channel_set);
-
+  monitor_enable_new_threads();
+  
   return new_channel_set;
 }
 

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -358,6 +358,9 @@ gpu_trace_record
 {
   gpu_trace_channel_set_t *channel_set = (gpu_trace_channel_set_t *) args;
 
+  hpcrun_thread_init_mem_pool_once();
+  atomic_fetch_add(&active_streams_counter, 1);
+
   while (!atomic_load(&stop_trace_flag)) {
     //getting data from a trace channel
     gpu_trace_channel_set_process(channel_set);
@@ -378,14 +381,7 @@ gpu_trace_create
 {
   // Init variables
   gpu_trace_t *trace = gpu_trace_alloc();
-
-  // Create a new thread for the stream without libmonitor watching
-  monitor_disable_new_threads();
-
   trace->thread = gpu_trace_demultiplexer_push(trace->trace_channel);
-  atomic_fetch_add(&active_streams_counter, 1);
-
-  monitor_enable_new_threads();
 
   return trace;
 }

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -1250,6 +1250,9 @@ cupti_buffer_completion_callback
  size_t validSize
 )
 {
+  
+  hpcrun_thread_init_mem_pool_once();
+
   // handle notifications
   cupti_buffer_completion_notify();
 

--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -200,6 +200,31 @@ hpcrun_threaded_data(void)
 }
 
 
+void
+hpcrun_thread_init_mem_pool_once(void){
+  static bool is_initialized = false;
+
+  if (is_initialized == false){
+    hpcrun_mmap_init();
+
+    // ----------------------------------------
+    // call thread manager to get a thread data. If there is unused thread data,
+    //  we can recycle it, otherwise we need to allocate a new one.
+    // If we allocate a new one, we need to initialize the data and trace file.
+    // ----------------------------------------
+
+    int id = 0;
+    thread_data_t* td = NULL;
+    bool has_trace = false;
+    bool demand_new_thread = true;
+
+    hpcrun_threadMgr_data_get_safe(id, NULL, &td, has_trace, demand_new_thread);
+    hpcrun_set_thread_data(td);
+    is_initialized = true;
+  }
+}
+
+
 //***************************************************************************
 // 
 //***************************************************************************

--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -63,6 +63,7 @@
 #include "epoch.h"
 #include "handling_sample.h"
 
+#include <hpcrun/threadmgr.h>
 #include "thread_data.h"
 #include "trace.h"
 
@@ -91,6 +92,7 @@ static thread_data_t _local_td;
 static pthread_key_t _hpcrun_key;
 static int use_getspecific = 0;
 
+static __thread bool mem_pool_initialized = false;
 
 void
 hpcrun_init_pthread_key(void)
@@ -202,9 +204,8 @@ hpcrun_threaded_data(void)
 
 void
 hpcrun_thread_init_mem_pool_once(void){
-  static bool is_initialized = false;
 
-  if (is_initialized == false){
+  if (mem_pool_initialized == false){
     hpcrun_mmap_init();
 
     // ----------------------------------------
@@ -220,7 +221,7 @@ hpcrun_thread_init_mem_pool_once(void){
 
     hpcrun_threadMgr_data_get_safe(id, NULL, &td, has_trace, demand_new_thread);
     hpcrun_set_thread_data(td);
-    is_initialized = true;
+    mem_pool_initialized = true;
   }
 }
 

--- a/src/tool/hpcrun/thread_data.h
+++ b/src/tool/hpcrun/thread_data.h
@@ -307,7 +307,7 @@ extern thread_data_t* hpcrun_safe_get_td(void);
 
 void hpcrun_unthreaded_data(void);
 void hpcrun_threaded_data(void);
-
+ void hpcrun_thread_init_mem_pool_once(void);
 
 extern thread_data_t* hpcrun_allocate_thread_data(int id);
 


### PR DESCRIPTION
I added monitor_enable/disable_new_threads for each of the tracing threads and OpenCL monitor thread, together with pool allocation that we talked about in the meeting. Could you please check if this looks good. It compiles and generates expected DB for cu_multi_context_multi_stream example.