### PR TITLE
GPU CFG construction fix for dyninst@10.2

### DIFF
--- a/src/lib/banal/gpu/DotCFG.hpp
+++ b/src/lib/banal/gpu/DotCFG.hpp
@@ -40,6 +40,18 @@ struct Inst {
 };
 
 
+#ifdef DYNINST_SUPPORTS_INTEL_GPU
+
+struct IntelInst : public Inst {
+  // Constructor for dummy inst
+  IntelInst(int offset, int size) : Inst(offset, size, Dyninst::Arch_intelGen9) {}
+
+  explicit IntelInst(int offset) : Inst(offset, 0, Dyninst::Arch_intelGen9) {}
+};
+
+#endif
+
+
 struct CudaInst : public Inst {
   // Constructor for dummy inst
   CudaInst(int offset, int size) : Inst(offset, size, Dyninst::Arch_cuda) {}
@@ -47,7 +59,7 @@ struct CudaInst : public Inst {
   explicit CudaInst(int offset) : Inst(offset, 0, Dyninst::Arch_cuda) {}
 
   // Cuda instruction constructor
-  CudaInst(std::string &inst_str) : Inst(0, 0) {
+  CudaInst(std::string &inst_str) : CudaInst(0, 0) {
     if (inst_str.find("{") != std::string::npos) {  // Dual first
       auto pos = inst_str.find("{");
       inst_str.replace(pos, 1, " ");

--- a/src/lib/banal/gpu/GPUBlock.cpp
+++ b/src/lib/banal/gpu/GPUBlock.cpp
@@ -22,7 +22,6 @@ Address GPUBlock::last() const {
 void GPUBlock::getInsns(Insns &insns) const {
 #ifdef DYNINST_SUPPORTS_INTEL_GPU
   entryID entry_id = _entry_ids_max_;
-  unsigned char dummy_inst[MAX_INST_SIZE];
 
   if (_arch == Arch_cuda) {
     entry_id = cuda_op_general;
@@ -36,20 +35,19 @@ void GPUBlock::getInsns(Insns &insns) const {
   }
 #endif  // DYNINST_SUPPORTS_INTEL_GPU
 
+  unsigned char dummy_inst[MAX_INST_SIZE];
   for (auto &inst_offset : _inst_offsets) {
-#ifdef DYNINST_SUPPORTS_INTEL_GPU
-    entryID entry_id = _entry_ids_max_;
-    InstructionAPI::Operation op(entry_id, "", _arch);
-
     auto offset = inst_offset.first;
     auto size = inst_offset.second;
 
-    InstructionAPI::Instruction inst(op, size, dummy_inst, _arch);
+#ifdef DYNINST_SUPPORTS_INTEL_GPU
+    InstructionAPI::Operation op(entry_id, "", _arch);
 #else
     // Dyninst 10.2.0 does not have cuda_op_general
-    // Just use the default constructor
-    InstructionAPI::Instruction inst;    
-#endif  // DYNINST_SUPPORTS_INTEL_GPU  
+    InstructionAPI::Operation op;
+#endif
+
+    InstructionAPI::Instruction inst(op, size, dummy_inst, _arch);
     insns.emplace(offset, inst);
   }
 }

--- a/src/lib/banal/gpu/GPUBlock.cpp
+++ b/src/lib/banal/gpu/GPUBlock.cpp
@@ -20,11 +20,26 @@ Address GPUBlock::last() const {
 
 
 void GPUBlock::getInsns(Insns &insns) const {
+  entryID entry_id = _entry_ids_max_;
+
+  if (_arch == Arch_cuda) {
+    entry_id = cuda_op_general;
+  } else {
 #ifdef DYNINST_SUPPORTS_INTEL_GPU
+    if (_arch == Arch_intelGen9) {
+      entry_id = intel_gpu_op_general;
+    }
+#endif  // DYNINST_SUPPORTS_INTEL_GPU
+  }
+
+  // Don't construct CFG if Dyninst does not support this GPU arch
+  if (entry_id == _entry_ids_max_) {
+    return;
+  }
+
   unsigned char dummy_inst[MAX_INST_SIZE];
 
   for (auto &inst_offset : _inst_offsets) {
-    entryID entry_id = intel_gpu_op_general;
     InstructionAPI::Operation op(entry_id, "", _arch);
 
     auto offset = inst_offset.first;
@@ -33,7 +48,6 @@ void GPUBlock::getInsns(Insns &insns) const {
     InstructionAPI::Instruction inst(op, size, dummy_inst, _arch);
     insns.emplace(offset, inst);
   }
-#endif  // DYNINST_SUPPORTS_INTEL_GPU
 }
 
 }

--- a/src/lib/banal/gpu/GPUBlock.cpp
+++ b/src/lib/banal/gpu/GPUBlock.cpp
@@ -20,32 +20,36 @@ Address GPUBlock::last() const {
 
 
 void GPUBlock::getInsns(Insns &insns) const {
+#ifdef DYNINST_SUPPORTS_INTEL_GPU
   entryID entry_id = _entry_ids_max_;
+  unsigned char dummy_inst[MAX_INST_SIZE];
 
   if (_arch == Arch_cuda) {
     entry_id = cuda_op_general;
-  } else {
-#ifdef DYNINST_SUPPORTS_INTEL_GPU
-    if (_arch == Arch_intelGen9) {
-      entry_id = intel_gpu_op_general;
-    }
-#endif  // DYNINST_SUPPORTS_INTEL_GPU
+  } else if (_arch == Arch_intelGen9) {
+    entry_id = intel_gpu_op_general;
   }
 
   // Don't construct CFG if Dyninst does not support this GPU arch
   if (entry_id == _entry_ids_max_) {
     return;
   }
-
-  unsigned char dummy_inst[MAX_INST_SIZE];
+#endif  // DYNINST_SUPPORTS_INTEL_GPU
 
   for (auto &inst_offset : _inst_offsets) {
+#ifdef DYNINST_SUPPORTS_INTEL_GPU
+    entryID entry_id = _entry_ids_max_;
     InstructionAPI::Operation op(entry_id, "", _arch);
 
     auto offset = inst_offset.first;
     auto size = inst_offset.second;
 
     InstructionAPI::Instruction inst(op, size, dummy_inst, _arch);
+#else
+    // Dyninst 10.2.0 does not have cuda_op_general
+    // Just use the default constructor
+    InstructionAPI::Instruction inst;    
+#endif  // DYNINST_SUPPORTS_INTEL_GPU  
     insns.emplace(offset, inst);
   }
 }

--- a/src/lib/banal/gpu/ReadCudaCFG.cpp
+++ b/src/lib/banal/gpu/ReadCudaCFG.cpp
@@ -213,7 +213,7 @@ parseDotCFG
           block->begin_offset = cuda_arch >= 70 ? 16 : 8;
           max_block_id++;
           while (function_size < symbol_size) {
-            block->insts.push_back(new GPUParse::Inst(function_size + function->address, len));
+            block->insts.push_back(new GPUParse::CudaInst(function_size + function->address, len));
             function_size += len;
           } 
           if (function->blocks.size() > 0) {

--- a/src/lib/banal/gpu/ReadIntelCFG.cpp
+++ b/src/lib/banal/gpu/ReadIntelCFG.cpp
@@ -153,7 +153,7 @@ parseIntelCFG
     block_offset_map[offset] = block;
 
     size = kv.getInstSize(offset);
-    auto *inst = new GPUParse::Inst(offset, size);
+    auto *inst = new GPUParse::IntelInst(offset, size);
     block->insts.push_back(inst);
 
     while (!kv.isInstTarget(offset + size) && (offset + size < text_section_size)) {
@@ -164,7 +164,7 @@ parseIntelCFG
         break;
       }
 
-      inst = new GPUParse::Inst(offset, size);
+      inst = new GPUParse::IntelInst(offset, size);
       block->insts.push_back(inst);
     }
 


### PR DESCRIPTION
Use arch flag to determine the entry id of a GPU instruction; If using dyninst 10.2, intel GPU instruction is not supported