### PR TITLE
Fixed issues of uninitialized gpu_trace_finished and control_knob.c circular list

### DIFF
--- a/src/tool/hpcrun/control-knob.c
+++ b/src/tool/hpcrun/control-knob.c
@@ -40,7 +40,6 @@ control_knob_register(char *name, char *value, control_knob_type type)
     iter->name = strdup(name);
     iter->type = type;
     iter->value = strdup(value);
-
     iter->next = control_knobs;
     control_knobs = iter;
   }else{

--- a/src/tool/hpcrun/control-knob.c
+++ b/src/tool/hpcrun/control-knob.c
@@ -39,10 +39,14 @@ control_knob_register(char *name, char *value, control_knob_type type)
     iter = (control_knob_t*) malloc(sizeof(control_knob_t));
     iter->name = strdup(name);
     iter->type = type;
+    iter->value = strdup(value);
+
+    iter->next = control_knobs;
+    control_knobs = iter;
+  }else{
+    iter->value = strdup(value);
   }
-  iter->value = strdup(value);
-  iter->next = control_knobs;
-  control_knobs = iter;
+  
 }
 
 

--- a/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
@@ -71,7 +71,7 @@ typedef void *(*pthread_start_routine_t)(void *);
 //******************************************************************************
 
 static _Atomic(bool) stop_operation_flag;
-static _Atomic(bool) gpu_trace_finished;
+static _Atomic(bool) gpu_trace_finished = ATOMIC_VAR_INIT(true);
 
 static atomic_uint operation_channels_count;
 static __thread uint32_t my_operation_channel_id = -1;


### PR DESCRIPTION
The bug was created when we want to register a control knob that is already registered. Instead of just changing the value, I was mistakenly setting next pointers, which should be done only when adding a control knob the first time in the list.