### PR TITLE
STREAMS_PER_TRACING_THREAD default set to 256 and gpu_trace_cct_no_activity optimization

### DIFF
--- a/src/tool/hpcrun/control-knob.c
+++ b/src/tool/hpcrun/control-knob.c
@@ -49,7 +49,7 @@ control_knob_register(char *name, char *value, control_knob_type type)
 
 static void
 control_knob_default_register(){
-  control_knob_register("STREAMS_PER_TRACING_THREAD", "4", ck_int);
+  control_knob_register("STREAMS_PER_TRACING_THREAD", "256", ck_int);
   control_knob_register("MAX_COMPLETION_CALLBACK_THREADS", "1000", ck_int);
 }
 

--- a/src/tool/hpcrun/gpu/gpu-trace-channel.c
+++ b/src/tool/hpcrun/gpu/gpu-trace-channel.c
@@ -225,6 +225,7 @@ gpu_trace_channel_consume
   // reverse them so that they are in FIFO order
   channel_reverse(channel, bichannel_direction_forward);
 
+  cct_node_t *no_activity = gpu_trace_cct_no_activity(channel->td);
   // consume all elements enqueued before this function was called
   for (;;) {
     gpu_trace_item_t *ti = channel_pop(channel, bichannel_direction_forward);
@@ -236,7 +237,7 @@ gpu_trace_channel_consume
            ti->start,
            ti->end,
            ti->call_path_leaf);
-    gpu_trace_item_consume(consume_one_trace_item, channel->td, ti);
+    gpu_trace_item_consume(consume_one_trace_item, channel->td, ti, no_activity);
     gpu_trace_item_free(channel, ti);
   }
 }

--- a/src/tool/hpcrun/gpu/gpu-trace-item.c
+++ b/src/tool/hpcrun/gpu/gpu-trace-item.c
@@ -96,10 +96,11 @@ gpu_trace_item_consume
 (
  gpu_trace_item_consume_fn_t trace_item_consume,
  thread_data_t *td,
- gpu_trace_item_t *ti
+ gpu_trace_item_t *ti,
+ cct_node_t *no_activity
 )
 {
-  trace_item_consume(td, ti->call_path_leaf, ti->start, ti->end);
+  trace_item_consume(td, ti->call_path_leaf, ti->start, ti->end, no_activity);
 }
 
 

--- a/src/tool/hpcrun/gpu/gpu-trace-item.h
+++ b/src/tool/hpcrun/gpu/gpu-trace-item.h
@@ -90,7 +90,8 @@ typedef void (*gpu_trace_item_consume_fn_t)
  thread_data_t *td,
  cct_node_t *call_path_leaf,
  uint64_t start_time,
- uint64_t end_time
+ uint64_t end_time,
+ cct_node_t *no_activity
 );
 
 
@@ -115,7 +116,8 @@ gpu_trace_item_consume
 (
  gpu_trace_item_consume_fn_t trace_item_consume,
  thread_data_t *td,
- gpu_trace_item_t *ti
+ gpu_trace_item_t *ti,
+ cct_node_t *no_activity
 );
 
 

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -172,19 +172,6 @@ gpu_trace_cct_root
 
 
 static cct_node_t *
-gpu_trace_cct_no_activity
-(
- thread_data_t* td
-)
-{
-  cct_node_t *no_activity =
-    hpcrun_cct_bundle_get_no_activity_node(&(td->core_profile_trace_data.epoch->csdata));
-
-  return no_activity;
-}
-
-
-static cct_node_t *
 gpu_trace_cct_insert_context
 (
  thread_data_t* td,
@@ -261,6 +248,19 @@ gpu_trace_stream_id
   int id = 500 + atomic_fetch_add(&num_streams, 1);
 
   return id;
+}
+
+
+cct_node_t *
+gpu_trace_cct_no_activity
+(
+ thread_data_t* td
+)
+{
+  cct_node_t *no_activity =
+    hpcrun_cct_bundle_get_no_activity_node(&(td->core_profile_trace_data.epoch->csdata));
+
+  return no_activity;
 }
 
 
@@ -402,13 +402,12 @@ consume_one_trace_item
  thread_data_t* td,
  cct_node_t *call_path,
  uint64_t start_time,
- uint64_t end_time
+ uint64_t end_time,
+ cct_node_t *no_activity
 )
 {
 
   cct_node_t *leaf = gpu_trace_cct_insert_context(td, call_path);
-
-  cct_node_t *no_activity = gpu_trace_cct_no_activity(td);
 
   uint64_t start = gpu_trace_time(start_time);
   uint64_t end   = gpu_trace_time(end_time);

--- a/src/tool/hpcrun/gpu/gpu-trace.h
+++ b/src/tool/hpcrun/gpu/gpu-trace.h
@@ -137,7 +137,15 @@ consume_one_trace_item
 thread_data_t* td,
 cct_node_t *call_path,
 uint64_t start_time,
-uint64_t end_time
+uint64_t end_time,
+cct_node_t *no_activity
+);
+
+
+cct_node_t *
+gpu_trace_cct_no_activity
+(
+ thread_data_t* td
 );
 
 


### PR DESCRIPTION
Based on the latest experiment we(John and I) conclude that one tracing thread is capable of dealing with 256 GPU streams.

Based on Oracle PE, we put gpu_trace_cct_no_activity out of the trace-consuming loop and get some performance.