### PR TITLE
Spawn Fnbounds as a Grandchild

### DIFF
--- a/src/tool/hpcrun/fnbounds/fnbounds_client.c
+++ b/src/tool/hpcrun/fnbounds/fnbounds_client.c
@@ -396,12 +396,6 @@ shutdown_server(void)
 static int
 hpcfnbounds_grandchild(void* fds_vp)
 {
-  //
-  // child process: disable profiling, dup the log file fd onto
-  // stderr and exec hpcfnbounds in server mode.
-  //
-  hpcrun_set_disabled();
-
   struct {
     int sendfd[2], recvfd[2];
   }* fds = fds_vp;
@@ -463,7 +457,7 @@ hpcfnbounds_child(void* fds_vp) {
                 ? (void*)&fds - 256 : (void*)&fds + 256;
 
   // Do the clone, and pass the result back to our parent through the shared memory space
-  fds->pid = auditor_exports->clone(hpcfnbounds_grandchild, stack, SIGCHLD, fds_vp);
+  fds->pid = auditor_exports->clone(hpcfnbounds_grandchild, stack, SIGCHLD | CLONE_VM, fds_vp);
   return 0;
 }
 

--- a/src/tool/hpcrun/fnbounds/fnbounds_client.c
+++ b/src/tool/hpcrun/fnbounds/fnbounds_client.c
@@ -394,7 +394,7 @@ shutdown_server(void)
 }
 
 static int
-hpcfnbounds_child(void* fds_vp)
+hpcfnbounds_grandchild(void* fds_vp)
 {
   //
   // child process: disable profiling, dup the log file fd onto
@@ -451,15 +451,32 @@ hpcfnbounds_child(void* fds_vp)
   err(1, "hpcrun system server: exec(%s) failed", server);
 }
 
+static int
+hpcfnbounds_child(void* fds_vp) {
+  struct {
+    int sendfd[2], recvfd[2];
+    pid_t pid;
+  }* fds = fds_vp;
+
+  // We should be roughly able to figure out which direction the stack grows.
+  void* stack = (void*)&fds < (void*)&server_stack[SERVER_STACK_SIZE * 1024]
+                ? (void*)&fds - 256 : (void*)&fds + 256;
+
+  // Do the clone, and pass the result back to our parent through the shared memory space
+  fds->pid = auditor_exports->clone(hpcfnbounds_grandchild, stack, SIGCHLD, fds_vp);
+  return 0;
+}
+
 // Returns: 0 on success, else -1 on failure.
 static int
 launch_server(void)
 {
   struct {
     int sendfd[2], recvfd[2];
+    pid_t pid;
   } fds;
   bool sampling_is_running;
-  pid_t pid;
+  pid_t child_pid;
 
   // already running
   if (client_status == SYSERV_ACTIVE && my_pid == getpid()) {
@@ -484,14 +501,50 @@ launch_server(void)
   }
 
   // For safety, we don't assume the direction of stack growth
-  pid = auditor_exports->clone(hpcfnbounds_child,
-    &server_stack[SERVER_STACK_SIZE * 1024], SIGCHLD, &fds);
+  child_pid = auditor_exports->clone(hpcfnbounds_child,
+    &server_stack[SERVER_STACK_SIZE * 1024], SIGCHLD | CLONE_VM, &fds);
 
-  if (pid < 0) {
+  if (child_pid < 0) {
     //
     // clone failed
     //
     EMSG("FNBOUNDS_CLIENT ERROR: syserv launch failed: clone failed");
+    return -1;
+  }
+
+  // Wait for the child to successfully clone the grandchild
+  int status;
+  if (auditor_exports->waitpid(child_pid, &status, 0) < 0) {
+    //
+    // waitpid failed
+    //
+    EMSG("FNBOUNDS_CLIENT ERROR: syserv launch failed: waitpid failed");
+    return -1;
+  }
+  if(!WIFEXITED(status)) {
+    //
+    // child died mysteriously
+    //
+    if(WIFSIGNALED(status))
+      EMSG("FNBOUNDS_CLIENT ERROR: syserv launch failed: child shim died by signal %d", WTERMSIG(status));
+    else
+      EMSG("FNBOUNDS_CLIENT ERROR: syserv launch failed: child shim died mysteriously");
+    return -1;
+  }
+  if(WEXITSTATUS(status) != 0) {
+    //
+    // child failed for some other reason
+    //
+    EMSG("FNBOUNDS_CLIENT ERROR: syserv launch failed: child exited mysteriously");
+    return -1;
+  }
+
+  // Check the result the child passed back to us
+  if(fds.pid < 0) {
+    //
+    // gradchild clone failed
+    //
+    EMSG("FNBOUNDS_CLIENT ERROR: syserv launch failed: grandchild clone failed");
     return -1;
   }
 
@@ -503,10 +556,10 @@ launch_server(void)
   fdout = fds.sendfd[1];
   fdin = fds.recvfd[0];
   my_pid = getpid();
-  server_pid = pid;
+  server_pid = fds.pid;
   client_status = SYSERV_ACTIVE;
 
-  TMSG(FNBOUNDS_CLIENT, "syserv launch: success, server: %d", (int) server_pid);
+  TMSG(FNBOUNDS_CLIENT, "syserv launch: success, child shim: %d, server: %d", (int) child_pid, (int) server_pid);
 
   // restart sample sources
   if (sampling_is_running) {


### PR DESCRIPTION
An attempt to fix the `wait()` issue reported by @martyitz, and an alternative approach to fixing the large memory space slowdowns reported and partially resolved by @Lucindaaaa in #420.

Background: The Fnbounds server process is spawned as a child of the application process through a direct call to `clone()`. After the merge of #420, the Fnbounds server stays around by default throughout the entire application execution. @martyitz discovered that this causes issues with applications using `wait()` since the Fnbounds server is now (from the application's perspective) a rogue mystery child process that doesn't seem to die.

There are two commits here, the first attempts to fix the `wait()` issue by spawning the Fnbounds process as a grandchild, removing its "child" status and thus making it invisible to `wait()` (and suitable cases in its variants). In short, the application spawns a child "shim" which then spawns the grandchild, which will become the Fnbounds process. This child "shim" is fully synchronous with the application thread and shares its address space via `CLONE_VM` to ease passing back the grandchild PID (but its not a thread, its an actual separate process. Linux is weird and fun.)

(**CLARIFICATION:** Although the flag is called `CLONE_VM` it tells `clone()` to **not** clone the virtual memory space, overriding the default where it does. It should probably have been called `CLONE_SHARE_VM` or `CLONE_KEEP_VM` or similar. Blame the Linux kernel devs for that one.)

The `strace` man page gives a few more ideas for extensions to this approach:
```
       -DD
       --daemonize=pgroup
       --daemonize=pgrp
                   Run  tracer process as tracee's grandchild in a separate process group.  In addition
                   to reduction of the visible effect of strace, it also avoids killing of strace  with
                   kill(2) issued to the whole process group.

       -DDD
       --daemonize=session
                   Run  tracer  process  as tracee's grandchild in a separate session ("true daemonisa‐
                   tion").  In addition to reduction of the visible effect of strace,  it  also  avoids
                   killing of strace upon session termination.
```
I don't know whether these might prevent MPI process cleanup in certain cases (e.g. `MPI_Abort`).

The second commit attempts to prevent slowdowns caused by very large memory spaces using `CLONE_VM` when cloning the grandchild to skip the potentially slow cloning of the page tables. The `exec()` splits (or rather eradicates) the caller's memory space, so the Fnbounds application is still completely detached from the application address space.

Because the address space is shared for a small window prior to the exec, there may be data races if the Fnbounds server is spawned multiple times in parallel with no intervening `waitpid()`. At a glance it looks fine, the entire process management is under a lock, it looks like `shutdown_server()` is called at every opportunity and the potentially racy window is fairly small.

---

[waittest.c](https://github.com/HPCToolkit/hpctoolkit/files/7074544/waittest.txt) tests the `wait()` issue, when it fails `hpcrun` will hang until killed and the resulting database will be missing one of the three calls to `spinsleep` from `main`. After the first commit it no longer hangs and all three calls are visible in the database.

[bigmemtest.c](https://github.com/HPCToolkit/hpctoolkit/files/7074546/bigmemtest.txt) tests the large memory space slowdown, when it fails the time for respawning Fnbounds with lots of memory allocated is significantly higher than without:
```
Timing a quick dlopen to respawn fnbounds (use --fnbounds-eager-shutdown)...
Time taken: 0.000890
Time taken: 0.002425
Time taken: 0.001934
Mapping and locking 21474836480 bytes of memory...
Timing a quick dlopen to respawn fnbounds (use --fnbounds-eager-shutdown)...
Time taken: 0.245688
Time taken: 0.245437
Time taken: 0.247188
```
After the second commit the time difference is basically non-existent:
```
Timing a quick dlopen to respawn fnbounds (use --fnbounds-eager-shutdown)...
Time taken: 0.000982
Time taken: 0.001722
Time taken: 0.001663
Mapping and locking 21474836480 bytes of memory...
Timing a quick dlopen to respawn fnbounds (use --fnbounds-eager-shutdown)...
Time taken: 0.002010
Time taken: 0.001530
Time taken: 0.001499
```