### PR TITLE
fine tune strategy of applying hpcstruct to whole measurement directories

### DIFF
--- a/src/lib/prof/NameMappings.cpp
+++ b/src/lib/prof/NameMappings.cpp
@@ -67,7 +67,27 @@ const int  TYPE_TOPDOWN_PLACEHOLDER  = 4;  // special place holder for top-down 
 class NameMapCompare {
 public:
   bool operator()(const char *n1,  const char *n2) const {
-    return strcmp(n1,n2) < 0;
+    // consider n1 and n2 equivalent (returning false) if
+    // n1 and n2 are the same or if the first character
+    // where they differ is a blank
+    int l1 = strlen(n1);
+    int l2 = strlen(n2);
+    int min_len;
+    if (l1 < l2) {
+      min_len = l1;
+    } else {
+      min_len = l2;
+    }
+
+    int result = strncmp(n1, n2, min_len);
+
+    if (result != 0 || l1 == l2) return result < 0;
+
+    if (l1 == min_len) {
+      return n2[min_len] == ' ' ? false : true;
+    }
+
+    return false;
   }
 };
 

--- a/src/tool/hpcstruct/pmake.txt
+++ b/src/tool/hpcstruct/pmake.txt
@@ -1,10 +1,4 @@
 
-#-------------------------------------------------------------------------------
-# set up subdirectory paths
-#-------------------------------------------------------------------------------
-GPUBIN_DIR  = $(MEAS_DIR)/gpubins
-STRUCTS_DIR = $(MEAS_DIR)/structs
-
 #*******************************************************************************
 # a helper template makefile used by hpcstruct at runtime
 #
@@ -17,6 +11,12 @@ STRUCTS_DIR = $(MEAS_DIR)/structs
 # this avoids the need for hpcstruct to know how to find a copy of this
 # makefile at runtime in an hpctoolkit installation.
 #*******************************************************************************
+
+#-------------------------------------------------------------------------------
+# set up subdirectory paths
+#-------------------------------------------------------------------------------
+GPUBIN_DIR  = $(MEAS_DIR)/gpubins
+STRUCTS_DIR = $(MEAS_DIR)/structs
 
 #*******************************************************************************
 #*******************************************************************************
@@ -64,10 +64,15 @@ H := $(wildcard $(MEAS_DIR)/*.hpcrun)
 L := $(patsubst $(MEAS_DIR)/%.hpcrun,$(LM_DIR)/%.lm,$(H))
 
 #-------------------------------------------------------------------------------
+# omit structure files for any CPU files containing the following strings
+#-------------------------------------------------------------------------------
+OMIT_PATTERN='[gpubin|libhpcrun|libxed|libmonitor]'
+
+#-------------------------------------------------------------------------------
 # create $(LM_DIR)/all.lm: a list of all load modules involved in the execution
 #-------------------------------------------------------------------------------
 $(LM_DIR)/all.lm: $(L)
-	cat $(L) | sort -u | grep -v gpubin > $(LM_DIR)/all.lm
+	cat $(L) | sort -u | grep -v $(OMIT_PATTERN) > $(LM_DIR)/all.lm
 
 #-------------------------------------------------------------------------------
 # create cpubins directory containing links to all CPU binaries

--- a/src/tool/hpcstruct/pmake.txt
+++ b/src/tool/hpcstruct/pmake.txt
@@ -64,15 +64,10 @@ H := $(wildcard $(MEAS_DIR)/*.hpcrun)
 L := $(patsubst $(MEAS_DIR)/%.hpcrun,$(LM_DIR)/%.lm,$(H))
 
 #-------------------------------------------------------------------------------
-# omit structure files for any CPU files containing the following strings
-#-------------------------------------------------------------------------------
-OMIT_PATTERN='[gpubin|libhpcrun|libxed|libmonitor]'
-
-#-------------------------------------------------------------------------------
 # create $(LM_DIR)/all.lm: a list of all load modules involved in the execution
 #-------------------------------------------------------------------------------
 $(LM_DIR)/all.lm: $(L)
-	cat $(L) | sort -u | grep -v $(OMIT_PATTERN) > $(LM_DIR)/all.lm
+	cat $(L) | sort -u | grep -v gpubin | grep -v libhpcrun | grep -v libmonitor | grep -v libxed | grep -v libpfm | grep -v libcuda | grep -v libcupti > $(LM_DIR)/all.lm
 
 #-------------------------------------------------------------------------------
 # create cpubins directory containing links to all CPU binaries


### PR DESCRIPTION
- fix placeholders that are not matched because function names in stripped binaries (libmonitor and libhpcrun) get their load module added to them
- skip hpcstruct analysis of libhpcrun, libmonitor, libpfm, libcuda, libcupti, libxed ...