### PR TITLE
Fix a couple of POSIX shell compatibility bugs in the hpcstruct Makefile

### DIFF
--- a/src/tool/hpcstruct/pmake.txt
+++ b/src/tool/hpcstruct/pmake.txt
@@ -71,7 +71,7 @@ $(LM_DIR)/all.lm: $(L)
 	cat $(L) | sort -u | grep -v gpubin | grep -v libhpcrun | grep -v libmonitor | grep -v libxed | grep -v libpfm | grep -v libcuda | grep -v libcupti > $(LM_DIR)/all.lm
 else
 $(LM_DIR)/all.lm: $(L)
-	-@mkdir $(LM_DIR) >& /dev/null
+	-@mkdir $(LM_DIR) >&- 2>&-
 	touch $(LM_DIR)/all.lm 
 endif
 
@@ -79,8 +79,8 @@ endif
 # create cpubins directory containing links to all CPU binaries
 #-------------------------------------------------------------------------------
 $(CPUBIN_DIR): $(LM_DIR)/all.lm
-	-@mkdir $(CPUBIN_DIR) >& /dev/null 
-	-@pushd $(CPUBIN_DIR) >& /dev/null; for i in `cat $(LM_DIR)/all.lm`; do ln -s $$i; done >& /dev/null 
+	-@mkdir $(CPUBIN_DIR) >&- 2>&-
+	-@cd $(CPUBIN_DIR) >&- 2>&-; for i in `cat $(LM_DIR)/all.lm`; do ln -s $$i; done >&- 2>&-
 
 #-------------------------------------------------------------------------------
 # $(CB): cpubin files
@@ -185,7 +185,7 @@ analyze: $(GS) $(CS)
 # rule for listing load modules in hpcrun files
 #-------------------------------------------------------------------------------
 $(LM_DIR)/%.lm: $(MEAS_DIR)/%.hpcrun
-	-@mkdir $(LM_DIR) >& /dev/null
+	-@mkdir $(LM_DIR) >&- 2>&-
 	$(PROFTT) -l $< > $@
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The new version of the Struct Makefile (for processing an entire measurements directory) do not work out-of-the-box on my Debian rig, since in Debian `/bin/sh` is not bash but a minimal POSIX shell called [dash](https://manpages.debian.org/unstable/dash/dash.1.en.html).

This patch removes the reliance on two bash-isms that aren't present in all POSIX-compliant shells:
 - In bash, `&> file` or `>& file` can be used to redirect both standard output and error to the same file, being equivalent to `> file 2>&1`. The Makefile only uses this to redirect to `/dev/null`, so the constructs are replaced with `>&- 2>&-` which closes standard output and error for the same effect.
 - Bash supports a `pushd` builtin to manipulate the "directory stack," a mechanism for saving working directories over the course of a session. The Makefile makes absolutely no use of the directory stack, so the (single) use of `pushd` is replaced with the equivalent `cd`.