### PR TITLE
Various fixes related to CPU tracing

### DIFF
--- a/src/lib/prof-lean/hpcrun-fmt.h
+++ b/src/lib/prof-lean/hpcrun-fmt.h
@@ -786,11 +786,11 @@ typedef struct sampling_info_s {
 
   // sampling period in nanoseconds.
   // This is used for adding <no activity> to traces where threads are idle
-  // 0 means not a time-based metric or a REALTIME sample, in which case
-  // we do not add <no activity> to trace.
+  // 0 means not a time-based metric, in which case we do not add 
+  // <no activity> to the trace.
   uint64_t sampling_period;
 
-  // 1 if we get a sample for a time based metric
+  // 1 if the sample is for a time-based metric
   // 0 otherwise
   int is_time_based_metric;
 } sampling_info_t;

--- a/src/lib/prof-lean/hpcrun-fmt.h
+++ b/src/lib/prof-lean/hpcrun-fmt.h
@@ -783,6 +783,16 @@ hpcmetricDB_fmt_hdr_fprint(hpcmetricDB_fmt_hdr_t* hdr, FILE* outfs);
 typedef struct sampling_info_s {
   uint64_t  sample_clock;
   void     *sample_data;
+
+  // sampling period in nanoseconds.
+  // This is used for adding <no activity> to traces where threads are idle
+  // 0 means not a time-based metric or a REALTIME sample, in which case
+  // we do not add <no activity> to trace.
+  uint64_t sampling_period;
+
+  // 1 if we get a sample for a time based metric
+  // 0 otherwise
+  int is_time_based_metric;
 } sampling_info_t;
 
 

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -438,10 +438,7 @@ consume_one_trace_item
   }
 
   if (append) {
-    gpu_trace_stream_append(td, no_activity, start - 1);
     gpu_trace_stream_append(td, leaf, start);
-
-    gpu_trace_stream_append(td, leaf, end);
     gpu_trace_stream_append(td, no_activity, end + 1);
 
     PRINT("%p Append trace activity [%lu, %lu]\n", td, start, end);

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -457,6 +457,7 @@ hpcrun_init_internal(bool is_child)
   hpcrun_options__getopts(&opts);
 
   hpcrun_trace_init(); // this must go after thread initialization
+
   hpcrun_trace_open(&(TD_GET(core_profile_trace_data)));
 
   // Decide whether to retain full single recursion, or collapse recursive calls to
@@ -525,6 +526,13 @@ hpcrun_init_internal(bool is_child)
   }
   SAMPLE_SOURCES(gen_event_set, lush_metrics);
 
+  // Check whether tracing is enabled and metrics suitable for tracing are specified
+  if (hpcrun_trace_isactive() && hpcrun_get_trace_metric() == 0) {
+    fprintf(stderr, "Error: Tracing is specified at the command line without a sutable metric for tracing.\n");
+    fprintf(stderr, "\tCPU tracing is only meaningful when a time based metric is given, such as REALTIME, CPUTIME, and CYCLES\n");
+    fprintf(stderr, "\tGPU tracing is always meaningful.\n");
+    monitor_real_exit(1);
+  }
   // set up initial 'epoch'
 
   TMSG(EPOCH,"process init setting up initial epoch/loadmap");

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -572,15 +572,15 @@ hpcrun_init_internal(bool is_child)
   hpcrun_set_safe_to_sync();
 
   if (hpcrun_trace_isactive() && hpcrun_cpu_trace_on()) {
-    // if we enable CPU tracing,
-    // we append a <no activity> at the begnning of the execution.
-    // In this way, if there is a long period during which sampling is disable,
-    // the traces will not be cut short.
-    // We should not add <no activity> when only GPU tracing is enabled.
+    // If tracing on the CPU, insert <no activity> at the beginning of the 
+    // trace.  This ensures that if there is a long interval at the 
+    // beginning of the trace when sampling is disabled, the trace will 
+    // not be artificially short.  Don't add <no activity> to a CPU trace 
+    // line when only tracing on a GPU.
     core_profile_trace_data_t * cptd = &(TD_GET(core_profile_trace_data));
     cct_bundle_t* cct_bundle = &(cptd->epoch->csdata);
-    cct_node_t* idle_node = hpcrun_cct_bundle_get_no_activity_node(cct_bundle);
-    hpcrun_trace_append(cptd, idle_node, 0, INT_MAX, 0);
+    cct_node_t* no_activity = hpcrun_cct_bundle_get_no_activity_node(cct_bundle);
+    hpcrun_trace_append(cptd, no_activity, 0, INT_MAX, 0);
   }
 
   // release the wallclock handler -for this thread-

--- a/src/tool/hpcrun/sample-sources/amd.c
+++ b/src/tool/hpcrun/sample-sources/amd.c
@@ -55,6 +55,7 @@
 #include <hpcrun/sample_sources_registered.h>
 #include <hpcrun/sample_event.h>
 #include <hpcrun/thread_data.h>
+#include <hpcrun/trace.h>
 
 #include <utilities/tokenize.h>
 #include <messages/messages.h>
@@ -148,7 +149,7 @@ METHOD_FN(process_event_list, int lush_metrics)
 {
     int nevents = (self->evl).nevents;
     gpu_metrics_default_enable();
-    hpcrun_set_trace_metric();
+    hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
     TMSG(CUDA,"nevents = %d", nevents);
 }
 

--- a/src/tool/hpcrun/sample-sources/amd.c
+++ b/src/tool/hpcrun/sample-sources/amd.c
@@ -149,7 +149,7 @@ METHOD_FN(process_event_list, int lush_metrics)
 {
     int nevents = (self->evl).nevents;
     gpu_metrics_default_enable();
-    hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
+    hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_FLAG);
     TMSG(CUDA,"nevents = %d", nevents);
 }
 

--- a/src/tool/hpcrun/sample-sources/amd.c
+++ b/src/tool/hpcrun/sample-sources/amd.c
@@ -148,6 +148,7 @@ METHOD_FN(process_event_list, int lush_metrics)
 {
     int nevents = (self->evl).nevents;
     gpu_metrics_default_enable();
+    hpcrun_set_trace_metric();
     TMSG(CUDA,"nevents = %d", nevents);
 }
 

--- a/src/tool/hpcrun/sample-sources/common.h
+++ b/src/tool/hpcrun/sample-sources/common.h
@@ -52,6 +52,11 @@
 #define HPCRUN_PAPI_ERROR_UNAVAIL  1
 #define HPCRUN_PAPI_ERROR_VERSION  2
 
+// HPCRUN_CPU_FREQUENCY is used to add <no activity>
+// to CPU traces where we do not any sample for a long period.
+// The exact CPU frequency does not really matter.
+#define HPCRUN_CPU_FREQUENCY 2000000000
+
 void  METHOD_FN(hpcrun_ss_add_event, const char* ev);
 void  METHOD_FN(hpcrun_ss_store_event, int event_id, long thresh);
 void  METHOD_FN(hpcrun_ss_store_metric_id, int event_id, int metric_id);

--- a/src/tool/hpcrun/sample-sources/cuda.c
+++ b/src/tool/hpcrun/sample-sources/cuda.c
@@ -298,7 +298,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   int i, ret;
   int num_lush_metrics = 0;
 
-  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_FLAG);
   char* evlist = METHOD_CALL(self, get_event_str);
   for (event = start_tok(evlist); more_tok(); event = next_tok()) {
     char name[1024];

--- a/src/tool/hpcrun/sample-sources/cuda.c
+++ b/src/tool/hpcrun/sample-sources/cuda.c
@@ -298,6 +298,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   int i, ret;
   int num_lush_metrics = 0;
 
+  hpcrun_set_trace_metric();
   char* evlist = METHOD_CALL(self, get_event_str);
   for (event = start_tok(evlist); more_tok(); event = next_tok()) {
     char name[1024];

--- a/src/tool/hpcrun/sample-sources/cuda.c
+++ b/src/tool/hpcrun/sample-sources/cuda.c
@@ -298,7 +298,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   int i, ret;
   int num_lush_metrics = 0;
 
-  hpcrun_set_trace_metric();
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
   char* evlist = METHOD_CALL(self, get_event_str);
   for (event = start_tok(evlist); more_tok(); event = next_tok()) {
     char name[1024];

--- a/src/tool/hpcrun/sample-sources/itimer.c
+++ b/src/tool/hpcrun/sample-sources/itimer.c
@@ -98,6 +98,7 @@
 #include <hpcrun/sample_sources_registered.h>
 #include <hpcrun/thread_data.h>
 #include <hpcrun/ompt/ompt-region.h>
+#include <hpcrun/trace.h>
 
 #include <lush/lush-backtrace.h>
 #include <messages/messages.h>
@@ -465,7 +466,7 @@ METHOD_FN(process_event_list, int lush_metrics)
 
   TMSG(ITIMER_CTL, "process event list, lush_metrics = %d", lush_metrics);
 
-  hpcrun_set_trace_metric();
+  hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_MASK);
 
   // fetch the event string for the sample source
   char* evlist = METHOD_CALL(self, get_event_str);
@@ -673,11 +674,9 @@ itimer_signal_handler(int sig, siginfo_t* siginfo, void* context)
   // get the current time for the appropriate clock
   uint64_t cur_time_us = 0;
   int ret;
-  uint64_t sample_interval = 0;
 
   if (use_cputime) {
     ret = time_getTimeCPU(&cur_time_us);
-    sample_interval = period * 1000;
   } else {
     ret = time_getTimeReal(&cur_time_us);
   }
@@ -697,7 +696,7 @@ itimer_signal_handler(int sig, siginfo_t* siginfo, void* context)
   sampling_info_t info = {
     .sample_clock = 0,
     .sample_data = NULL,
-    .sampling_period = sample_interval,
+    .sampling_period = period * 1000,
     .is_time_based_metric = 1
   };
 

--- a/src/tool/hpcrun/sample-sources/itimer.c
+++ b/src/tool/hpcrun/sample-sources/itimer.c
@@ -466,7 +466,7 @@ METHOD_FN(process_event_list, int lush_metrics)
 
   TMSG(ITIMER_CTL, "process event list, lush_metrics = %d", lush_metrics);
 
-  hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_MASK);
+  hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_FLAG);
 
   // fetch the event string for the sample source
   char* evlist = METHOD_CALL(self, get_event_str);

--- a/src/tool/hpcrun/sample-sources/itimer.c
+++ b/src/tool/hpcrun/sample-sources/itimer.c
@@ -465,6 +465,8 @@ METHOD_FN(process_event_list, int lush_metrics)
 
   TMSG(ITIMER_CTL, "process event list, lush_metrics = %d", lush_metrics);
 
+  hpcrun_set_trace_metric();
+
   // fetch the event string for the sample source
   char* evlist = METHOD_CALL(self, get_event_str);
   char* event = start_tok(evlist);

--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -185,7 +185,7 @@ static void
 METHOD_FN(process_event_list, int lush_metrics)
 {
   int nevents = (self->evl).nevents;
-  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_FLAG);
   gpu_metrics_default_enable();
   TMSG(CUDA,"nevents = %d", nevents);
 }

--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -97,6 +97,7 @@
 #include <hpcrun/sample_sources_registered.h>
 #include <hpcrun/sample_event.h>
 #include <hpcrun/thread_data.h>
+#include <hpcrun/trace.h>
 
 #include <utilities/tokenize.h>
 #include <messages/messages.h>
@@ -184,7 +185,7 @@ static void
 METHOD_FN(process_event_list, int lush_metrics)
 {
   int nevents = (self->evl).nevents;
-  hpcrun_set_trace_metric();
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
   gpu_metrics_default_enable();
   TMSG(CUDA,"nevents = %d", nevents);
 }

--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -184,6 +184,7 @@ static void
 METHOD_FN(process_event_list, int lush_metrics)
 {
   int nevents = (self->evl).nevents;
+  hpcrun_set_trace_metric();
   gpu_metrics_default_enable();
   TMSG(CUDA,"nevents = %d", nevents);
 }

--- a/src/tool/hpcrun/sample-sources/nvidia.c
+++ b/src/tool/hpcrun/sample-sources/nvidia.c
@@ -91,6 +91,7 @@
 #include <hpcrun/sample_sources_registered.h>
 #include <hpcrun/utilities/tokenize.h>
 #include <hpcrun/thread_data.h>
+#include <hpcrun/trace.h>
 
 
 
@@ -345,7 +346,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   int nevents = (self->evl).nevents;
 
   TMSG(CUDA,"nevents = %d", nevents);
-  hpcrun_set_trace_metric();
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
 
   // Fetch the event string for the sample source
   // only one event is allowed

--- a/src/tool/hpcrun/sample-sources/nvidia.c
+++ b/src/tool/hpcrun/sample-sources/nvidia.c
@@ -346,7 +346,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   int nevents = (self->evl).nevents;
 
   TMSG(CUDA,"nevents = %d", nevents);
-  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_FLAG);
 
   // Fetch the event string for the sample source
   // only one event is allowed

--- a/src/tool/hpcrun/sample-sources/nvidia.c
+++ b/src/tool/hpcrun/sample-sources/nvidia.c
@@ -345,6 +345,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   int nevents = (self->evl).nevents;
 
   TMSG(CUDA,"nevents = %d", nevents);
+  hpcrun_set_trace_metric();
 
   // Fetch the event string for the sample source
   // only one event is allowed

--- a/src/tool/hpcrun/sample-sources/opencl.c
+++ b/src/tool/hpcrun/sample-sources/opencl.c
@@ -55,6 +55,7 @@
 #include <hpcrun/gpu/gpu-trace.h>
 #include <hpcrun/gpu/opencl/opencl-api.h>
 #include <hpcrun/thread_data.h>
+#include <hpcrun/trace.h>
 
 #include <messages/messages.h>
 
@@ -154,7 +155,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   TMSG(OPENCL,"nevents = %d", nevents);
   gpu_metrics_default_enable();
   gpu_metrics_KINFO_enable();
-  hpcrun_set_trace_metric();
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
 
   char* evlist = METHOD_CALL(self, get_event_str);
   char* event = start_tok(evlist);

--- a/src/tool/hpcrun/sample-sources/opencl.c
+++ b/src/tool/hpcrun/sample-sources/opencl.c
@@ -154,6 +154,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   TMSG(OPENCL,"nevents = %d", nevents);
   gpu_metrics_default_enable();
   gpu_metrics_KINFO_enable();
+  hpcrun_set_trace_metric();
 
   char* evlist = METHOD_CALL(self, get_event_str);
   char* event = start_tok(evlist);

--- a/src/tool/hpcrun/sample-sources/opencl.c
+++ b/src/tool/hpcrun/sample-sources/opencl.c
@@ -155,7 +155,7 @@ METHOD_FN(process_event_list, int lush_metrics)
   TMSG(OPENCL,"nevents = %d", nevents);
   gpu_metrics_default_enable();
   gpu_metrics_KINFO_enable();
-  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_MASK);
+  hpcrun_set_trace_metric(HPCRUN_GPU_TRACE_FLAG);
 
   char* evlist = METHOD_CALL(self, get_event_str);
   char* event = start_tok(evlist);

--- a/src/tool/hpcrun/sample-sources/papi-c.c
+++ b/src/tool/hpcrun/sample-sources/papi-c.c
@@ -571,7 +571,7 @@ METHOD_FN(process_event_list, int lush_metrics)
     METHOD_CALL(self, store_metric_id, i, metric_id);
     if (isCycles) {
       hpcrun_cycles_metric_id = metric_id;
-      hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_MASK);
+      hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_FLAG);
     }
 
     // FIXME:LUSH: need a more flexible metric interface

--- a/src/tool/hpcrun/sample-sources/papi-c.c
+++ b/src/tool/hpcrun/sample-sources/papi-c.c
@@ -135,6 +135,9 @@ static bool disable_papi_cuda = false;
 
 static kind_info_t *papi_kind;
 
+static int hpcrun_cycles_metric_id = -1;
+static uint64_t hpcrun_cycles_cmd_period = 0;
+
 
 /******************************************************************************
  * private operations 
@@ -476,12 +479,13 @@ METHOD_FN(process_event_list, int lush_metrics)
     TMSG(PAPI,"checking event spec = %s",event);
     // FIXME: restore checking will require deciding if the event is synchronous or not
 #ifdef USE_PAPI_CHECKING
-    if (! hpcrun_extract_ev_thresh(event, sizeof(name), name, &thresh, DEFAULT_THRESHOLD)) {
+    int period_type = hpcrun_extract_ev_thresh(event, sizeof(name), name, &thresh, DEFAULT_THRESHOLD);
+    if (!period_type) {
       AMSG("WARNING: %s using default threshold %ld, "
 	   "better to use an explicit threshold.", name, DEFAULT_THRESHOLD);
     }
 #else
-    hpcrun_extract_ev_thresh(event, sizeof(name), name, &thresh, DEFAULT_THRESHOLD);
+    int period_type = hpcrun_extract_ev_thresh(event, sizeof(name), name, &thresh, DEFAULT_THRESHOLD);
 #endif // USE_PAPI_CHECKING
     ret = PAPI_event_name_to_code(name, &evcode);
     if (ret != PAPI_OK) {
@@ -499,6 +503,17 @@ METHOD_FN(process_event_list, int lush_metrics)
       num_lush_metrics++;
     }
 
+    if (strncmp(event, "PAPI_TOT_CYC", 12) == 0) {
+      if (period_type == THRESH_FREQ) {
+        // frequency is specified in samples per second
+        hpcrun_cycles_cmd_period = (uint64_t) (1000000000.0 / thresh);
+      } else {
+        // default is period.
+        // period is specified in the number of cycles per sample
+        hpcrun_cycles_cmd_period = (uint64_t) (1000000000.0 * thresh / HPCRUN_CPU_FREQUENCY);
+      }
+    }
+
     TMSG(PAPI,"event %s -> event code = %x, thresh = %ld", event, evcode, thresh);
     METHOD_CALL(self, store_event, evcode, thresh);
   }
@@ -514,10 +529,12 @@ METHOD_FN(process_event_list, int lush_metrics)
     PAPI_event_code_to_name(self->evl.events[i].event, buffer);
     TMSG(PAPI, "metric for event %d = %s", i, buffer);
 
+    int isCycles = 0;
     // blame shifting needs to know if there is a cycles metric
     if (strcmp(buffer, "PAPI_TOT_CYC") == 0) {
       prop = metric_property_cycles;
       blame_shift_source_register(bs_type_cycles);
+      isCycles = 1;
     }
 
     // allow derived events (proxy sampling), as long as some event
@@ -551,6 +568,9 @@ METHOD_FN(process_event_list, int lush_metrics)
 					    MetricFlags_ValFmt_Int,
 					    threshold, prop);
     METHOD_CALL(self, store_metric_id, i, metric_id);
+    if (isCycles) {
+      hpcrun_cycles_metric_id = metric_id;
+    }
 
     // FIXME:LUSH: need a more flexible metric interface
     if (num_lush_metrics > 0 && strcmp(buffer, "PAPI_TOT_CYC") == 0) {
@@ -915,9 +935,17 @@ papi_event_handler(int event_set, void *pc, long long ovec,
       metricIncrement = 1;
     }
 
+    int time_based_metric = (hpcrun_cycles_metric_id == metric_id) ? 1 : 0;
+
+    sampling_info_t info = {
+      .sample_clock = 0,
+      .sample_data = NULL,
+      .sampling_period = hpcrun_cycles_cmd_period,
+      .is_time_based_metric = time_based_metric
+    };
     sample_val_t sv = hpcrun_sample_callpath(context, metric_id, 
 			(hpcrun_metricVal_t) {.i=metricIncrement},
-			0/*skipInner*/, 0/*isSync*/, NULL);
+			0/*skipInner*/, 0/*isSync*/, &info);
 
     blame_shift_apply(metric_id, sv.sample_node, 1 /*metricIncr*/);
   }

--- a/src/tool/hpcrun/sample-sources/papi-c.c
+++ b/src/tool/hpcrun/sample-sources/papi-c.c
@@ -570,6 +570,7 @@ METHOD_FN(process_event_list, int lush_metrics)
     METHOD_CALL(self, store_metric_id, i, metric_id);
     if (isCycles) {
       hpcrun_cycles_metric_id = metric_id;
+      hpcrun_set_trace_metric();
     }
 
     // FIXME:LUSH: need a more flexible metric interface

--- a/src/tool/hpcrun/sample-sources/papi-c.c
+++ b/src/tool/hpcrun/sample-sources/papi-c.c
@@ -91,6 +91,7 @@
 #include <hpcrun/sample_event.h>
 #include <hpcrun/thread_data.h>
 #include <hpcrun/threadmgr.h>
+#include <hpcrun/trace.h>
 
 #include <sample-sources/blame-shift/blame-shift.h>
 #include <utilities/tokenize.h>
@@ -570,7 +571,7 @@ METHOD_FN(process_event_list, int lush_metrics)
     METHOD_CALL(self, store_metric_id, i, metric_id);
     if (isCycles) {
       hpcrun_cycles_metric_id = metric_id;
-      hpcrun_set_trace_metric();
+      hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_MASK);
     }
 
     // FIXME:LUSH: need a more flexible metric interface

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -212,6 +212,9 @@ static struct event_threshold_s default_threshold = {DEFAULT_THRESHOLD, FREQUENC
 
 static kind_info_t *lnux_kind;
 
+static int hpcrun_cycles_metric_id = -1;
+static uint64_t hpcrun_cycles_cmd_period = 0;
+
 //******************************************************************************
 // private operations 
 //******************************************************************************
@@ -551,8 +554,13 @@ record_sample(event_thread_t *current, perf_mmap_data_t *mmap_data,
   // ----------------------------------------------------------------------------
   // update the cct and add callchain if necessary
   // ----------------------------------------------------------------------------
-  sampling_info_t info = {.sample_clock = 0, .sample_data = mmap_data};
-
+  int time_based_metric = (hpcrun_cycles_metric_id == current->event->hpcrun_metric_id) ? 1 : 0;
+  sampling_info_t info = {
+    .sample_clock = 0,
+    .sample_data = mmap_data,
+    .sampling_period = hpcrun_cycles_cmd_period,
+    .is_time_based_metric = time_based_metric
+  };
   *sv = hpcrun_sample_callpath(context, current->event->hpcrun_metric_id,
         (hpcrun_metricVal_t) {.r=counter},
         0/*skipInner*/, 0/*isSync*/, &info);
@@ -873,9 +881,12 @@ METHOD_FN(process_event_list, int lush_metrics)
     //  this assumption is not true, but it's quite closed
     // ------------------------------------------------------------
 
+    //TODO: what about CYCLES_NOT_IN_HALT?
+    int isCycles = 0;
     if (strcasestr(name, "CYCLES") != NULL) {
       prop = metric_property_cycles;
       blame_shift_source_register(bs_type_cycles);
+      isCycles = 1;
     } else {
       prop = metric_property_none;
     }
@@ -898,6 +909,18 @@ METHOD_FN(process_event_list, int lush_metrics)
     // set the metric for this perf event
     event_desc[i].hpcrun_metric_id = hpcrun_set_new_metric_desc_and_period(lnux_kind, name_dup,
             desc, MetricFlags_ValFmt_Real, metric_period, prop);
+
+    if (isCycles) {
+      hpcrun_cycles_metric_id = event_desc[i].hpcrun_metric_id;
+      if (is_period) {
+        // period is specified in the number of cycles per sample
+        hpcrun_cycles_cmd_period = (uint64_t) (1000000000.0 * threshold / HPCRUN_CPU_FREQUENCY);
+      } else {
+        // default is frequency
+        // frequency is specified in samples per second
+        hpcrun_cycles_cmd_period = (uint64_t) (1000000000.0 / threshold);
+      }
+    }
    
     METHOD_CALL(self, store_event, event_attr->config, metric_period);
     free(name);

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -911,6 +911,7 @@ METHOD_FN(process_event_list, int lush_metrics)
             desc, MetricFlags_ValFmt_Real, metric_period, prop);
 
     if (isCycles) {
+      hpcrun_set_trace_metric();
       hpcrun_cycles_metric_id = event_desc[i].hpcrun_metric_id;
       if (is_period) {
         // period is specified in the number of cycles per sample

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -103,6 +103,7 @@
 #include <hpcrun/sample-sources/blame-shift/blame-shift.h>
 #include <hpcrun/utilities/tokenize.h>
 #include <hpcrun/utilities/arch/context-pc.h>
+#include <hpcrun/trace.h>
 
 #include <evlist.h>
 #include <limits.h>   // PATH_MAX
@@ -911,7 +912,7 @@ METHOD_FN(process_event_list, int lush_metrics)
             desc, MetricFlags_ValFmt_Real, metric_period, prop);
 
     if (isCycles) {
-      hpcrun_set_trace_metric();
+      hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_MASK);
       hpcrun_cycles_metric_id = event_desc[i].hpcrun_metric_id;
       if (is_period) {
         // period is specified in the number of cycles per sample

--- a/src/tool/hpcrun/sample-sources/perf/linux_perf.c
+++ b/src/tool/hpcrun/sample-sources/perf/linux_perf.c
@@ -912,7 +912,7 @@ METHOD_FN(process_event_list, int lush_metrics)
             desc, MetricFlags_ValFmt_Real, metric_period, prop);
 
     if (isCycles) {
-      hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_MASK);
+      hpcrun_set_trace_metric(HPCRUN_CPU_TRACE_FLAG);
       hpcrun_cycles_metric_id = event_desc[i].hpcrun_metric_id;
       if (is_period) {
         // period is specified in the number of cycles per sample

--- a/src/tool/hpcrun/sample_event.c
+++ b/src/tool/hpcrun/sample_event.c
@@ -166,6 +166,12 @@ hpcrun_sample_callpath(void* context, int metricId,
 		       hpcrun_metricVal_t metricIncr,
 		       int skipInner, int isSync, sampling_info_t *data)
 {
+  uint64_t sampling_period = 0;
+  int is_time_based_metric = 0;
+  if (data != NULL) {
+    sampling_period = data->sampling_period;
+    is_time_based_metric = data->is_time_based_metric;
+  }
 
   sample_val_t ret;
   hpcrun_sample_val_init(&ret);
@@ -273,7 +279,7 @@ hpcrun_sample_callpath(void* context, int metricId,
 
   bool trace_ok = ! td->deadlock_drop;
   TMSG(TRACE1, "trace ok (!deadlock drop) = %d", trace_ok);
-  if (trace_ok && hpcrun_trace_isactive() && !isSync) {
+  if (trace_ok && hpcrun_trace_isactive() && !isSync && is_time_based_metric > 0) {
     TMSG(TRACE, "Sample event encountered");
 
     cct_addr_t frm;
@@ -287,7 +293,7 @@ hpcrun_sample_callpath(void* context, int metricId,
     ret.trace_node = func_proxy;
 
     TMSG(TRACE, "Changed persistent id to indicate mutation of func_proxy node");
-    hpcrun_trace_append(&td->core_profile_trace_data, func_proxy, metricId, td->prev_dLCA);
+    hpcrun_trace_append(&td->core_profile_trace_data, func_proxy, metricId, td->prev_dLCA, sampling_period);
     TMSG(TRACE, "Appended func_proxy node to trace");
   }
 

--- a/src/tool/hpcrun/threadmgr.c
+++ b/src/tool/hpcrun/threadmgr.c
@@ -379,7 +379,7 @@ hpcrun_threadMgr_data_put( epoch_t *epoch, thread_data_t *data, int no_separator
     cct_node_t *node  = hpcrun_cct_bundle_get_no_activity_node(&epoch->csdata);
     if (node) {
       hpcrun_trace_append(&(data->core_profile_trace_data), node, 0, 
-			  HPCTRACE_FMT_DLCA_NULL);
+			  HPCTRACE_FMT_DLCA_NULL, 0);
     }
   }
 

--- a/src/tool/hpcrun/trace.c
+++ b/src/tool/hpcrun/trace.c
@@ -107,6 +107,7 @@ static inline void hpcrun_trace_append_with_time_real(core_profile_trace_data_t 
 //*********************************************************************
 
 static int tracing = 0;
+static int trace_suitable_metric = 0;
 
 //*********************************************************************
 // interface operations
@@ -305,4 +306,20 @@ hpcrun_trace_file_validate(int valid, char *op)
     EMSG("unable to %s trace file\n", op);
     monitor_real_abort();
   }
+}
+
+void
+hpcrun_set_trace_metric
+(
+)
+{
+  trace_suitable_metric = 1;
+}
+
+int
+hpcrun_get_trace_metric
+(
+)
+{
+  return trace_suitable_metric;
 }

--- a/src/tool/hpcrun/trace.c
+++ b/src/tool/hpcrun/trace.c
@@ -330,7 +330,7 @@ hpcrun_cpu_trace_on
 (
 )
 {
-  return (trace_suitable_metric & HPCRUN_CPU_TRACE_MASK) ? 1 : 0;
+  return (trace_suitable_metric & HPCRUN_CPU_TRACE_FLAG) ? 1 : 0;
 }
 
 int
@@ -338,5 +338,5 @@ hpcrun_gpu_trace_on
 (
 )
 {
-  return (trace_suitable_metric & HPCRUN_GPU_TRACE_MASK) ? 1 : 0;
+  return (trace_suitable_metric & HPCRUN_GPU_TRACE_FLAG) ? 1 : 0;
 }

--- a/src/tool/hpcrun/trace.c
+++ b/src/tool/hpcrun/trace.c
@@ -311,15 +311,32 @@ hpcrun_trace_file_validate(int valid, char *op)
 void
 hpcrun_set_trace_metric
 (
+  hpcrun_trace_type_masks_t m
 )
 {
-  trace_suitable_metric = 1;
+  trace_suitable_metric |= m;
 }
 
 int
-hpcrun_get_trace_metric
+hpcrun_has_trace_metric
 (
 )
 {
-  return trace_suitable_metric;
+  return (trace_suitable_metric > 0) ? 1 : 0;
+}
+
+int
+hpcrun_cpu_trace_on
+(
+)
+{
+  return (trace_suitable_metric & HPCRUN_CPU_TRACE_MASK) ? 1 : 0;
+}
+
+int
+hpcrun_gpu_trace_on
+(
+)
+{
+  return (trace_suitable_metric & HPCRUN_GPU_TRACE_MASK) ? 1 : 0;
 }

--- a/src/tool/hpcrun/trace.h
+++ b/src/tool/hpcrun/trace.h
@@ -55,7 +55,7 @@ void trace_other_close(void *thread_data);
 
 void hpcrun_trace_init();
 void hpcrun_trace_open(core_profile_trace_data_t * cptd);
-void hpcrun_trace_append(core_profile_trace_data_t *cptd, cct_node_t* node, uint metric_id, uint32_t dLCA);
+void hpcrun_trace_append(core_profile_trace_data_t *cptd, cct_node_t* node, uint metric_id, uint32_t dLCA, uint64_t sampling_period);
 void hpcrun_trace_append_with_time(core_profile_trace_data_t *st, unsigned int call_path_id, uint metric_id, uint64_t nanotime);
 void hpcrun_trace_close(core_profile_trace_data_t * cptd);
 

--- a/src/tool/hpcrun/trace.h
+++ b/src/tool/hpcrun/trace.h
@@ -63,6 +63,14 @@ void hpcrun_trace_append_stream(core_profile_trace_data_t *cptd, cct_node_t *nod
 
 int hpcrun_trace_isactive();
 
+// When a sample source finds that a metric suitable for tracing
+// is specified, we call this function to indicate we can do tracing
+void hpcrun_set_trace_metric();
+
+// After processing all command line events, we call this function
+// to check whether a metric suitable for tracing exists
+int hpcrun_get_trace_metric();
+
 #endif // hpcrun_trace_h
 
 

--- a/src/tool/hpcrun/trace.h
+++ b/src/tool/hpcrun/trace.h
@@ -53,8 +53,8 @@
 #include <include/uint.h>
 
 typedef enum hpcrun_trace_type_masks {
-    HPCRUN_CPU_TRACE_MASK = 1,
-    HPCRUN_GPU_TRACE_MASK = 2
+    HPCRUN_CPU_TRACE_FLAG = 1,
+    HPCRUN_GPU_TRACE_FLAG = 2
 } hpcrun_trace_type_masks_t;
 
 void trace_other_close(void *thread_data);

--- a/src/tool/hpcrun/trace.h
+++ b/src/tool/hpcrun/trace.h
@@ -51,6 +51,12 @@
 #include "core_profile_trace_data.h"
 
 #include <include/uint.h>
+
+typedef enum hpcrun_trace_type_masks {
+    HPCRUN_CPU_TRACE_MASK = 1,
+    HPCRUN_GPU_TRACE_MASK = 2
+} hpcrun_trace_type_masks_t;
+
 void trace_other_close(void *thread_data);
 
 void hpcrun_trace_init();
@@ -65,11 +71,14 @@ int hpcrun_trace_isactive();
 
 // When a sample source finds that a metric suitable for tracing
 // is specified, we call this function to indicate we can do tracing
-void hpcrun_set_trace_metric();
+void hpcrun_set_trace_metric(hpcrun_trace_type_masks_t);
 
 // After processing all command line events, we call this function
 // to check whether a metric suitable for tracing exists
-int hpcrun_get_trace_metric();
+int hpcrun_has_trace_metric();
+
+int hpcrun_cpu_trace_on();
+int hpcrun_gpu_trace_on();
 
 #endif // hpcrun_trace_h
 


### PR DESCRIPTION
1. Add <no activity> to CPU traces when there is a long gap without any sample
2. Only do cpu tracing when a time based metric is specified, such as cycles, cputime, and realtime.
3. Print an error message when -t is specified but no suitable tracing metric is given
4. fix itimer event's handling of sampling frequency
5. Cut GPU traces size by half