### PR TITLE
Fix hpcviewer.e4 bug #108 (partial call path in flat view)00

### DIFF
--- a/src/lib/prof/NameMappings.cpp
+++ b/src/lib/prof/NameMappings.cpp
@@ -151,7 +151,7 @@ static NameMapping renamingTable[] = {
   { "gpu_op_trace",        GPU_KERNEL        ,  TYPE_ELIDED         },
 
   { "hpcrun_no_activity",  NO_ACTIVITY       ,  TYPE_ELIDED         },
-  { PARTIAL_CALLPATH,      PARTIAL_CALLPATH  ,  TYPE_PLACEHOLDER    }
+  { PARTIAL_CALLPATH,      PARTIAL_CALLPATH  ,  TYPE_TOPDOWN_PLACEHOLDER }
 };
 
 


### PR DESCRIPTION
The cause of the bug is because hpcprof generated the 'f' attribute of <Partial call paths> to "1" (folder node) instead of "4" (top down folder).
By setting the value to "4" fixes this problem.