### PR TITLE
overhaul hpcstruct to be parallel by default (#445)

### DIFF
--- a/src/lib/prof-lean/Makefile.am
+++ b/src/lib/prof-lean/Makefile.am
@@ -96,6 +96,7 @@ MYSOURCES = \
 	\
 	binarytree.h binarytree.c \
 	cskiplist.h cskiplist.c \
+	cpuset_hwthreads.h cpuset_hwthreads.c \
 	crypto-hash.h crypto-hash.c \
 	queues.h queues.c \
 	stacks.h stacks.c \

--- a/src/lib/prof-lean/Makefile.in
+++ b/src/lib/prof-lean/Makefile.in
@@ -151,6 +151,7 @@ am__objects_1 = libHPCprof_lean_la-hpcrun-fmt.lo \
 	lush/libHPCprof_lean_la-lush-support.lo \
 	libHPCprof_lean_la-binarytree.lo \
 	libHPCprof_lean_la-cskiplist.lo \
+	libHPCprof_lean_la-cpuset_hwthreads.lo \
 	libHPCprof_lean_la-crypto-hash.lo libHPCprof_lean_la-queues.lo \
 	libHPCprof_lean_la-stacks.lo libHPCprof_lean_la-bistack.lo \
 	libHPCprof_lean_la-bichannel.lo \
@@ -560,6 +561,7 @@ MYSOURCES = \
 	\
 	binarytree.h binarytree.c \
 	cskiplist.h cskiplist.c \
+	cpuset_hwthreads.h cpuset_hwthreads.c \
 	crypto-hash.h crypto-hash.c \
 	queues.h queues.c \
 	stacks.h stacks.c \
@@ -679,6 +681,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-bichannel.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-binarytree.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-bistack.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-cpuset_hwthreads.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-crypto-hash.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-cskiplist.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-elf-helper.Plo@am__quote@
@@ -823,6 +826,13 @@ libHPCprof_lean_la-cskiplist.lo: cskiplist.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='cskiplist.c' object='libHPCprof_lean_la-cskiplist.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libHPCprof_lean_la_CFLAGS) $(CFLAGS) -c -o libHPCprof_lean_la-cskiplist.lo `test -f 'cskiplist.c' || echo '$(srcdir)/'`cskiplist.c
+
+libHPCprof_lean_la-cpuset_hwthreads.lo: cpuset_hwthreads.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libHPCprof_lean_la_CFLAGS) $(CFLAGS) -MT libHPCprof_lean_la-cpuset_hwthreads.lo -MD -MP -MF $(DEPDIR)/libHPCprof_lean_la-cpuset_hwthreads.Tpo -c -o libHPCprof_lean_la-cpuset_hwthreads.lo `test -f 'cpuset_hwthreads.c' || echo '$(srcdir)/'`cpuset_hwthreads.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libHPCprof_lean_la-cpuset_hwthreads.Tpo $(DEPDIR)/libHPCprof_lean_la-cpuset_hwthreads.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='cpuset_hwthreads.c' object='libHPCprof_lean_la-cpuset_hwthreads.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libHPCprof_lean_la_CFLAGS) $(CFLAGS) -c -o libHPCprof_lean_la-cpuset_hwthreads.lo `test -f 'cpuset_hwthreads.c' || echo '$(srcdir)/'`cpuset_hwthreads.c
 
 libHPCprof_lean_la-crypto-hash.lo: crypto-hash.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libHPCprof_lean_la_CFLAGS) $(CFLAGS) -MT libHPCprof_lean_la-crypto-hash.lo -MD -MP -MF $(DEPDIR)/libHPCprof_lean_la-crypto-hash.Tpo -c -o libHPCprof_lean_la-crypto-hash.lo `test -f 'crypto-hash.c' || echo '$(srcdir)/'`crypto-hash.c

--- a/src/lib/prof-lean/cpuset_hwthreads.h
+++ b/src/lib/prof-lean/cpuset_hwthreads.h
@@ -1,4 +1,4 @@
-// -*-Mode: C++;-*-
+// -*-Mode: C++;-*- // technically C99
 
 // * BeginRiceCopyright *****************************************************
 //
@@ -44,71 +44,33 @@
 //
 // ******************************************************* EndRiceCopyright *
 
-// This file defines the external API that Struct.cpp provides for
-// tool/hpcstruct/main.cpp.
 
-//***************************************************************************
+#ifndef cpuset_hwthreads_h
+#define cpuset_hwthreads_h
 
-#ifndef BAnal_Struct_hpp
-#define BAnal_Struct_hpp
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
-#include <ostream>
-#include <string>
+//******************************************************************************
+// public operations
+//******************************************************************************
 
-namespace BAnal {
-namespace Struct {
+//------------------------------------------------------------------------------
+//   Function cpuset_hwthreads
+//   Purpose:
+//     return the number of hardware threads available to this process
+//     return 1 if no other value can be computed
+//------------------------------------------------------------------------------
+unsigned int 
+cpuset_hwthreads
+(
+  void
+);
 
-// Parameters on how to run makeStructure().
-class Options {
-public:
-  unsigned int jobs;
 
-  unsigned int jobs_struct;
-  unsigned int jobs_parse;
-  unsigned int jobs_symtab;
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif
 
-  bool show_time;
-
-  bool analyze_cpu_binaries;
-
-  bool analyze_gpu_binaries;
-  bool compute_gpu_cfg;
-
-  unsigned long parallel_analysis_threshold;
-
-  void set
-  (
-   unsigned int _jobs,
-   unsigned int _jobs_struct,
-   unsigned int _jobs_parse,
-   unsigned int _jobs_symtab,
-   bool _show_time,
-   bool _analyze_cpu_binaries,
-   bool _analyze_gpu_binaries,
-   bool _compute_gpu_cfg,
-   unsigned long _parallel_analysis_threshold
-  ) {
-   jobs = _jobs;
-   jobs_struct = _jobs_struct;
-   jobs_parse  = _jobs_parse;
-   jobs_symtab = _jobs_symtab;
-   show_time = _show_time;
-   analyze_cpu_binaries = _analyze_cpu_binaries;
-   analyze_gpu_binaries = _analyze_gpu_binaries;
-   compute_gpu_cfg = _compute_gpu_cfg;
-   parallel_analysis_threshold = _parallel_analysis_threshold;
-  };
-};
-
-void
-makeStructure(std::string filename,
-	      std::ostream * outFile,
-	      std::ostream * gapsFile,
-	      std::string gaps_filenm,
-	      std::string search_path,
-	      Struct::Options & opts);
-
-} // namespace Struct
-} // namespace BAnal
-
-#endif // BAnal_Struct_hpp
+#endif

--- a/src/tool/hpcstruct/main.cpp
+++ b/src/tool/hpcstruct/main.cpp
@@ -79,6 +79,7 @@ using std::endl;
 
 #include <lib/banal/Struct.hpp>
 #include <lib/prof-lean/hpcio.h>
+#include <lib/prof-lean/cpuset_hwthreads.h>
 #include <lib/support/diagnostics.h>
 #include <lib/support/realpath.h>
 #include <lib/support/FileUtil.hpp>
@@ -149,6 +150,10 @@ doMeasurementsDir(string measurements_dir, BAnal::Struct::Options & opts)
   string hpcproftt_path = string(HPCTOOLKIT_INSTALL_PREFIX) 
     + "/libexec/hpctoolkit/hpcproftt";
 
+  string struct_path = string(HPCTOOLKIT_INSTALL_PREFIX) 
+    + "/bin/hpcstruct";
+
+
   //
   // Write Makefile and launch analysis.
   //
@@ -164,15 +169,29 @@ doMeasurementsDir(string measurements_dir, BAnal::Struct::Options & opts)
     exit(1);
   }
 
+  unsigned int pthreads;
+  unsigned int jobs;
+
+  if (opts.jobs == 0) { // not specified
+    unsigned int hwthreads = cpuset_hwthreads();
+    jobs = std::max(hwthreads/2, 1U);
+    pthreads = std::min(jobs, 16U);
+  } else {
+    jobs = opts.jobs;
+    pthreads = jobs;
+  }
+    
   string gpucfg = opts.compute_gpu_cfg ? "yes" : "no";
 
-  makefile << "MEAS_DIR =  "   << measurements_dir << "\n"
-	   << "GPUBIN_CFG = "  << gpucfg << "\n"
-	   << "CPU_ANALYZE = " << opts.analyze_cpu_binaries << "\n"
-	   << "GPU_ANALYZE = " << opts.analyze_gpu_binaries << "\n"
-	   << "PAR_SIZE = "    << opts.parallel_analysis_threshold << "\n"
-	   << "JOBS = "        << opts.jobs << "\n\n"
-	   << "PROFTT = "      << hpcproftt_path << "\n\n"
+  makefile << "MEAS_DIR =  "    << measurements_dir << "\n"
+	   << "GPUBIN_CFG = "   << gpucfg << "\n"
+	   << "CPU_ANALYZE = "  << opts.analyze_cpu_binaries << "\n"
+	   << "GPU_ANALYZE = "  << opts.analyze_gpu_binaries << "\n"
+	   << "PAR_SIZE = "     << opts.parallel_analysis_threshold << "\n"
+	   << "JOBS = "         << jobs << "\n"
+	   << "PTHREADS = "     << pthreads << "\n"
+	   << "PROFTT = "       << hpcproftt_path << "\n"
+	   << "STRUCT= "        << struct_path << "\n"
 	   << analysis_makefile << endl;
   makefile.close();
 
@@ -180,7 +199,7 @@ doMeasurementsDir(string measurements_dir, BAnal::Struct::Options & opts)
       + " --no-print-directory all";
 
   if (system(make_cmd.c_str()) != 0) {
-    DIAG_EMsg("Make hpcstruct files for GPU binaries failed.");
+    DIAG_EMsg("Make hpcstruct files for measurement directory failed.");
     exit(1);
   }
 }
@@ -216,7 +235,6 @@ static int
 realmain(int argc, char* argv[])
 {
   Args args(argc, argv);
-  BAnal::Struct::Options opts;
 
   RealPathMgr::singleton().searchPaths(args.searchPathStr);
   RealPathMgr::singleton().realpath(args.in_filenm);
@@ -225,47 +243,39 @@ realmain(int argc, char* argv[])
   // Parameters on how to run hpcstruct
   // ------------------------------------------------------------
 
+  unsigned int jobs_struct;
+  unsigned int jobs_parse;
+  unsigned int jobs_symtab;
+
 #ifdef ENABLE_OPENMP
   //
   // Translate the args jobs to the struct opts jobs.  The specific
   // overrides the general: for example, -j sets all three phases,
   // --jobs-parse overrides just that one phase.
   //
-  int jobs = (args.jobs >= 1) ? args.jobs : 1;
 
-  opts.jobs = jobs;
-  opts.jobs_struct = jobs;
-  opts.jobs_parse = jobs;
-  opts.jobs_symtab = jobs;
-
-  if (args.jobs_struct >= 1) {
-    opts.jobs_struct = args.jobs_struct;
-  }
-  if (args.jobs_parse >= 1) {
-    opts.jobs_parse = args.jobs_parse;
-  }
-  if (args.jobs_symtab >= 1) {
-    opts.jobs_symtab = args.jobs_symtab;
-  }
+  jobs_struct = (args.jobs_struct >= 1) ? args.jobs_struct : args.jobs;
+  jobs_parse  = (args.jobs_parse >= 1)  ? args.jobs_parse  : args.jobs;
 
 #ifndef ENABLE_OPENMP_SYMTAB
-  opts.jobs_symtab = 1;
+  jobs_symtab = 1;
+#else
+  jobs_symtab = (args.jobs_symtab >= 1) ? args.jobs_symtab : args.jobs;
 #endif
 
   omp_set_num_threads(1);
 
 #else
-  opts.jobs = 1;
-  opts.jobs_struct = 1;
-  opts.jobs_parse = 1;
-  opts.jobs_symtab = 1;
+  jobs_struct = 1;
+  jobs_parse = 1;
+  jobs_symtab = 1;
 #endif
 
-  opts.show_time = args.show_time;
-  opts.compute_gpu_cfg = args.compute_gpu_cfg;
-  opts.analyze_cpu_binaries = args.analyze_cpu_binaries;
-  opts.analyze_gpu_binaries = args.analyze_gpu_binaries;
-  opts.parallel_analysis_threshold = args.parallel_analysis_threshold;
+  BAnal::Struct::Options opts;
+
+  opts.set(args.jobs, jobs_struct, jobs_parse, jobs_symtab, args.show_time,
+	   args.analyze_cpu_binaries, args.analyze_gpu_binaries,
+	   args.compute_gpu_cfg, args.parallel_analysis_threshold);
 
   // ------------------------------------------------------------
   // If in_filenm is a directory, then analyze separately
@@ -273,6 +283,10 @@ realmain(int argc, char* argv[])
   struct stat sb;
 
   if (stat(args.in_filenm.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode)) {
+    if (!args.out_filenm.empty()) {
+      DIAG_EMsg("Outfile file may not be specified when analyziing a measurement directory.");
+      exit(1);
+    }
     doMeasurementsDir(args.in_filenm, opts);
     return 0;
   }

--- a/src/tool/hpcstruct/pmake.txt
+++ b/src/tool/hpcstruct/pmake.txt
@@ -66,14 +66,8 @@ L := $(patsubst $(MEAS_DIR)/%.hpcrun,$(LM_DIR)/%.lm,$(H))
 #-------------------------------------------------------------------------------
 # create $(LM_DIR)/all.lm: a list of all load modules involved in the execution
 #-------------------------------------------------------------------------------
-ifneq ($(L),)
 $(LM_DIR)/all.lm: $(L)
 	cat $(L) | sort -u | grep -v gpubin | grep -v libhpcrun | grep -v libmonitor | grep -v libxed | grep -v libpfm | grep -v libcuda | grep -v libcupti > $(LM_DIR)/all.lm
-else
-$(LM_DIR)/all.lm: $(L)
-	-@mkdir $(LM_DIR) >&- 2>&-
-	touch $(LM_DIR)/all.lm 
-endif
 
 #-------------------------------------------------------------------------------
 # create cpubins directory containing links to all CPU binaries
@@ -123,7 +117,7 @@ $(STRUCTS_DIR)/%.hpcstruct: $(CPUBIN_DIR)/%
 		else
 			echo msg: begin concurrent analysis of $$cpubin_name \\(using 1 of $(JOBS) threads\\)
 		fi
-		hpcstruct -j $(THREADS) -o $$struct_name $< > $$warn_name 2>&1
+		$(STRUCT) -j $(THREADS) -o $$struct_name $< > $$warn_name 2>&1
 		if test -s $$warn_name ; then
 			echo WARNING: incomplete analysis of $$cpubin_name';' see $$warn_name for details
 			if test ! -s $$struct_name ; then
@@ -156,7 +150,7 @@ $(STRUCTS_DIR)/%.hpcstruct: $(GPUBIN_DIR)/%
 		else
 			echo msg: begin concurrent analysis of $$gpubin_name \\(using 1 of $(JOBS) threads\\)
 		fi
-		hpcstruct -j $(THREADS) --gpucfg $(GPUBIN_CFG) -o $$struct_name $< > $$warn_name 2>&1
+		$(STRUCT) -j $(THREADS) --gpucfg $(GPUBIN_CFG) -o $$struct_name $< > $$warn_name 2>&1
 		if test -s $$warn_name ; then
 			echo WARNING: incomplete analysis of $$gpubin_name';' see $$warn_name for details
 			if test ! -s $$struct_name ; then
@@ -173,11 +167,23 @@ $(STRUCTS_DIR)/%.hpcstruct: $(GPUBIN_DIR)/%
 	fi
 
 #-------------------------------------------------------------------------------
-# analyze all gpubins to create structure files
+# analyze files to create structure files
 #-------------------------------------------------------------------------------
+DOMAKE=1
+
+ifeq ($(CPU_ANALYZE),1)
+ifeq ($(L),)
+all:
+	echo ERROR: directory $(MEAS_DIR) does not contain any hpcrun measurement files
+DOMAKE=0
+endif
+endif
+
+ifeq ($(DOMAKE),1)
 all: $(CPUBIN_DIR)
-	$(MAKE) -j 1 JOBS=1 THREADS=$(JOBS)  GPAR_SIZE=$(PAR_SIZE) CPAR_SIZE=$(PAR_SIZE) analyze
+	$(MAKE) -j 1 JOBS=1 THREADS=$(PTHREADS)  GPAR_SIZE=$(PAR_SIZE) CPAR_SIZE=$(PAR_SIZE) analyze
 	$(MAKE) -j $(JOBS) JOBS=$(JOBS) THREADS=1  GPAR_SIZE=0 CPAR_SIZE=0 analyze
+endif
 
 analyze: $(GS) $(CS) 
 

--- a/src/tool/hpcstruct/usage.txt
+++ b/src/tool/hpcstruct/usage.txt
@@ -1,66 +1,70 @@
-Given an application binary, a shared library, or an hpctoolkit
-measurement directory collected for a GPU-accelerated program that run
-on NVIDIA GPUs, hpcstruct recovers the program structure of its object
-code.  Program structure is a mapping of a program's static source-level
-structure to its object code.  By default, hpcstruct writes its results
-to the file 'basename(<binary>).hpcstruct'.  This file is typically
-passed to HPCToolkit's correlation tool hpcprof.
+Description:
+  hpcstruct recovers the program structure for all CPU and GPU
+  binaries referenced by a directory containing HPCToolkit performance
+  measurements. If needed, one can apply hpcstruct to recover program
+  structure for an individual CPU or GPU binary.
 
-hpcstruct is designed for highly optimized binaries created from
-compiled languages such as C, C++, Fortran, and CUDA source code. Because
-hpcstruct's algorithms exploit a binary's debugging information, for best
-results, binary should be compiled with standard debugging information.
-See the documentation for more information.
+  Program structure is a mapping from addresses of machine instructions
+  in a binary to source code contexts; this mapping is used to attribute
+  measured performance metrics back to source code. A strength of
+  hpcstruct is its ability to attribute metrics to inlined functions
+  and loops; such mappings are especially useful for understanding the
+  performance of programs generated using template-based programming
+  models.
+
+  hpcstruct is designed for analysis of optimized binaries created from
+  C, C++, Fortran, CUDA, HIP, and DPC++ source code. Because hpcstruct's
+  algorithms exploit the line map and debug information recorded in an
+  application binary during compilation, for best results, we recommend that
+  binaries be compiled with standard debug information or at a minimum,
+  line map information. Typically, this is accomplished by pasing a '-g'
+  option to each compiler along with any optimization flags. See the
+  HPCToolkit manual for more information.
+
+  To accelerate analysis of a measurement directory, which contains
+  references to an application as well as any shared libraries
+  and/or GPU binaries it uses, hpcstruct employs multiple threads by
+  default. Multiple small binaries are analyzed concurrently, using one
+  thread per binary.  By default, this analysis will use half of the
+  threads in the CPU set for the process. Binaries larger than a certain
+  threshold (see the --psize option and its default) are analyzed using
+  multiple threads. By default, large binaries will be analyzed using
+  min(half of the threads in the CPU set for the process, 16) threads.
 
 Options: General
-  -v [<n>], --verbose [<n>]
-                       Verbose: generate progress messages to stderr at
-                       verbosity level <n>. {1}
   -V, --version        Print version information.
-  -h, --help           Print this help.
-  --debug=[<n>]        Debug: use debug level <n>. {1}
-  --debug-proc <glob>  Debug structure recovery for procedures matching
-                       the procedure glob <glob>
-  -j <num>, --jobs <num>  Use <num> openmp threads (jobs), default 1.
-  --jobs-parse <num>   Use <num> openmp threads for ParseAPI::parse(),
-                       default is same value for --jobs.
-  --jobs-symtab <num>  Use <num> openmp threads for Symtab methods.
-  --time               Display stats on time and space usage.
+  -h, --help           Print this help message.
 
-Options: Structure recovery
-  -I <path>, --include <path>
-                       Use <path> when resolving source file names. For a
-                       recursive search, append a '*' after the last slash,
-                       e.g., '/mypath/*' (quote or escape to protect from
-                       the shell.) May pass multiple times.
+Options: Override parallelism defaults
+  -j <num>, --jobs <num> Use <num> threads for for concurrent analysis of
+                       small binaries. Use <num> threads for parallel
+		       analysis of binaries of greater than <psize>.
+  --psize <psize>      Size (bytes) of a binary that will cause hpcstruct
+                       to use threads to analyze a binary in parallel.
+                       Binaries with fewer than <psize> bytes will be analyzed
+                       concurrently, {100000000}
 
-  -R '<old-path>=<new-path>', --replace-path '<old-path>=<new-path>'
-                       Substitute instances of <old-path> with <new-path>;
-                       apply to all paths (profile's load map, source code)
-                       for which <old-path> is a prefix.  Use '\\' to escape
-                       instances of '=' within a path. May pass multiple
-                       times.
-  --use-binutils       Use binutils as the default binary instruction decoder
-                       On x86 default is Intel XED library.
-  --show-gaps          Experimental feature to show unclaimed vma ranges (gaps)
-                       in the control-flow graph.
+Options: Override structure recovery defaults
+  --cpu <yes/no>       Analyze CPU binaries referenced by a measurements
+                       directory. {yes} 
+  --gpu <yes/no>       Analyze GPU binaries referenced by a measurements
+                       directory. {yes} 
+  --gpucfg <yes/no>    Compute loop nesting structure for GPU machine code.
+                       Loop nesting structure is only useful with
+                       instruction-level measurements collected using PC
+                       sampling or instrumentation. {no} 
 
-Options: Demangling
-  --demangle-library <path to demangling library>
-                       Specify the pathname for a dynamically-linked
-                       library whose demangler function should 
-                       be used for demangling. By default, the demangler used
-                       is __cxa_demangle in the C++ Standard Library linked into
-                       hpcstruct.
-
-  --demangle-function <name of the demangler>
-                       By default, the demangler used is __cxa_demangle, a function
-                       provided by the C++ Standard Library. This option enables
-                       one to specify an alternate demangler, e.g., cplus_demangle
-                       provided by the BFD library.
-
-Options: Output:
+Options: Specify output file when analyzing a single binary
   -o <file>, --output <file>
                        Write hpcstruct file to <file>.
                        Use '--output=-' to write output to stdout.
-  --compact            Generate compact output, eliminating extra white space
+                       Note: this option may only be used when analyzing
+		       a single binary.
+
+Options: Developers only
+  --jobs-struct <num>  Use <num> threads for the MakeStructure() phase only.
+  --jobs-parse  <num>  Use <num> threads for the ParseAPI::parse() phase only.
+  --jobs-symtab <num>  Use <num> threads for the Symtab phase (if possible).
+  --show-gaps          Feature to show unclaimed vma ranges (gaps)
+                       in the control-flow graph.
+  --time               Display stats on hpcstruct's time and space usage.


### PR DESCRIPTION
* overhaul hpcstruct to be parallel by default
- add parallelism by default:
    default concurrency: cpuset size /2
    default parallelism: min(16, cpuset size/2)
- have job control throttle parallelism
- error message when output file for directory
- rewrite usage message
- migrage usage message to usage.txt
- add path to hpcstruct to makefile
- bulletproof parallel makefile for exceptional cases
    no measurement files

* update hpcstruct help message

* fix typo