### PR TITLE
add initial handshake from fnbounds2 to application

### DIFF
--- a/src/tool/hpcfnbounds/server.cpp
+++ b/src/tool/hpcfnbounds/server.cpp
@@ -419,6 +419,8 @@ system_server(DiscoverFnTy fn_discovery, int fd1, int fd2)
   }
   signal_handler_init();
 
+  write_mesg(SYSERV_READY, 0);
+
   for (;;) {
     int ret = read_mesg(&mesg);
 

--- a/src/tool/hpcfnbounds/syserv-mesg.h
+++ b/src/tool/hpcfnbounds/syserv-mesg.h
@@ -67,7 +67,8 @@ enum {
   SYSERV_QUERY,
   SYSERV_EXIT,
   SYSERV_OK,
-  SYSERV_ERR
+  SYSERV_ERR,
+  SYSERV_READY
 };
 
 struct syserv_mesg {

--- a/src/tool/hpcfnbounds2/server.c
+++ b/src/tool/hpcfnbounds2/server.c
@@ -135,7 +135,7 @@ init_server (DiscoverFnTy fn_discovery, int fd1, int fd2)
   }
   signal_handler_init();
 
-  write_mesg(77, 0);
+  write_mesg(SYSERV_READY, 0);
 
   for (;;) {
     int ret = read_mesg(&mesg);

--- a/src/tool/hpcfnbounds2/syserv-mesg.h
+++ b/src/tool/hpcfnbounds2/syserv-mesg.h
@@ -67,7 +67,8 @@ enum {
   SYSERV_QUERY,
   SYSERV_EXIT,
   SYSERV_OK,
-  SYSERV_ERR
+  SYSERV_ERR,
+  SYSERV_READY
 };
 
 struct syserv_mesg {

--- a/src/tool/hpcrun/fnbounds/fnbounds_client.c
+++ b/src/tool/hpcrun/fnbounds/fnbounds_client.c
@@ -555,9 +555,16 @@ launch_server(void)
 
   TMSG(FNBOUNDS_CLIENT, "syserv launch: success, child shim: %d, server: %d", (int) child_pid, (int) server_pid);
 
-  // Server talks first, but we don't care about the actual message
+  // Fnbounds talks first with a READY message
   struct syserv_mesg mesg;
-  read_mesg(&mesg);
+  if (read_mesg(&mesg) != SUCCESS) {
+    EMSG("FNBOUNDS_CLIENT ERROR: syserv did not give READY message");
+    return -1;
+  }
+  if (mesg.type != SYSERV_READY) {
+    EMSG("FNBOUNDS_CLIENT ERROR: syserv gave bad initial message: expected %d, got %d", SYSERV_READY, mesg.type);
+    return -1;
+  }
 
   // restart sample sources
   if (sampling_is_running) {


### PR DESCRIPTION
we have seen the first message from the application
to fnbounds2 get lost. adding this initial handshake
in the reverse direction avoids that problem.

hat tip to jonathon anderson for diagnosis and patch