### PR TITLE
fix hpcstruct handling of parallelism for large binaries

### DIFF
--- a/src/tool/hpcstruct/pmake.txt
+++ b/src/tool/hpcstruct/pmake.txt
@@ -111,11 +111,12 @@ $(STRUCTS_DIR)/%.hpcstruct: $(CPUBIN_DIR)/%
 	@cpubin_name=`basename -s x $<`
 	struct_name=$@
 	warn_name=$(STRUCTS_DIR)/$$cpubin_name.warnings
-	if test `du -b $< | tail -1 | awk '{ print $$1 }'` -gt $(CPAR_SIZE) ; then
+	nbytes=`du -b -L $< | tail -1 | awk '{ print $$1 }'`
+	if test $$nbytes -gt $(CPAR_SIZE) ; then
 		if test $(THREADS) -gt 1 ; then
-			echo msg: begin parallel analysis of $$cpubin_name \\(using $(THREADS) threads\\)
+			echo msg: begin parallel analysis of $$cpubin_name \\(size = $$nbytes, using $(THREADS) threads\\)
 		else
-			echo msg: begin concurrent analysis of $$cpubin_name \\(using 1 of $(JOBS) threads\\)
+			echo msg: begin concurrent analysis of $$cpubin_name \\(size = $$nbytes, using 1 of $(JOBS) threads\\)
 		fi
 		$(STRUCT) -j $(THREADS) -o $$struct_name $< > $$warn_name 2>&1
 		if test -s $$warn_name ; then
@@ -144,11 +145,12 @@ $(STRUCTS_DIR)/%.hpcstruct: $(GPUBIN_DIR)/%
 	@gpubin_name=`basename -s x $<`
 	struct_name=$@
 	warn_name=$(STRUCTS_DIR)/$$gpubin_name.warnings
-	if test `du -b $< | tail -1 | awk '{ print $$1 }'` -gt $(GPAR_SIZE) ; then
+	nbytes=`du -b -L $< | tail -1 | awk '{ print $$1 }'`
+	if test $$nbytes -gt $(GPAR_SIZE) ; then
 		if test $(THREADS) -gt 1 ; then
-			echo msg: begin parallel analysis of $$gpubin_name \\(using $(THREADS) threads\\)
+			echo msg: begin parallel analysis of $$gpubin_name \\(size = $$nbytes, using $(THREADS) threads\\)
 		else
-			echo msg: begin concurrent analysis of $$gpubin_name \\(using 1 of $(JOBS) threads\\)
+			echo msg: begin concurrent analysis of $$gpubin_name \\(size = $$nbytes, using 1 of $(JOBS) threads\\)
 		fi
 		$(STRUCT) -j $(THREADS) --gpucfg $(GPUBIN_CFG) -o $$struct_name $< > $$warn_name 2>&1
 		if test -s $$warn_name ; then


### PR DESCRIPTION
1. testing without large binaries led to no parallelism
   for large binaries. check size of linked file rather
   than link (which affects links in cpubins directory).
2. include file size in hpcstruct output so a user can
   see the size of a file that is slow to analyze and
   adjust accordingly.