### PR TITLE
Fix the need of -t to enable GPU CFG construction

### DIFF
--- a/src/tool/hpcprof/main.cpp
+++ b/src/tool/hpcprof/main.cpp
@@ -154,10 +154,6 @@ realmain(int argc, char* const* argv)
     exit(-1);
   }
 
-  if (nArgs.paths->size() == 1 && !args.hpcprof_isMetricArg) {
-    args.prof_metrics = Analysis::Args::MetricFlg_Thread;
-  }
-
   if (Analysis::Args::MetricFlg_isThread(args.prof_metrics)
       && nArgs.paths->size() > 16
       && !args.hpcprof_forceMetrics) {


### PR DESCRIPTION
With the help of @Jokeren , this fixes the bug that PC sampling requiring -t. I tested this PR with quicksilver on ufront. I compared the a few calling contexts with/without -t and the they look the same. The database with pc sampling without -t still have GPU call frames.

I am not certain about the side effect of this change related to CPU profiling.