### PR TITLE
Avoid hanging at exit when using CLONE_VM on Glibc <2.24

### DIFF
--- a/src/tool/hpcrun/fnbounds/fnbounds_client.c
+++ b/src/tool/hpcrun/fnbounds/fnbounds_client.c
@@ -545,7 +545,7 @@ launch_server(void)
   my_pid = getpid();
   client_status = SYSERV_ACTIVE;
 
-  TMSG(FNBOUNDS_CLIENT, "syserv launch: success, child shim: %d, server: ???", (int) child_pid;
+  TMSG(FNBOUNDS_CLIENT, "syserv launch: success, child shim: %d, server: ???", (int) child_pid);
 
   // Fnbounds talks first with a READY message
   struct syserv_mesg mesg;


### PR DESCRIPTION
Fixes #455, ping @jmellorcrummey and @mwkrentel. IMO 2.24 is old enough we could get away with just dropping support, if not though this PR provides a hacky fix.

There is a bug in older Glibc (https://sourceware.org/bugzilla/show_bug.cgi?id=18862) where using `CLONE_VM` instead of `CLONE_THREAD` causes the Glibc wrapper to reset its internal pthread state in the parent process. This wreaks havoc with all things pthread, but most noticably it stops the `pthread_kill` in libmonitor's shootdown from functioning (and libmonitor doesn't pay attention enough to the returned error codes).

As a sort of hack, it turns out the reset happens after the body passed to `clone`, so killing the child via a signal instead of returning dodges the issue. At least, it seems to work on 2.17.

This also adds an auditor-export for `sigaction` (to reset the signal disposition for a faster signal-death). In the fake-auditor case there isn't a "default" function to use since `sigaction` is wrapped by libmonitor, which in turn doesn't provide a `monitor_real_sigaction`. Caveat emptor.