### PR TITLE
Support Structfiles for multiple load modules

### DIFF
--- a/src/lib/profile/finalizers/struct.hpp
+++ b/src/lib/profile/finalizers/struct.hpp
@@ -49,12 +49,18 @@
 
 #include "../finalizer.hpp"
 
+#include <vector>
+
 namespace hpctoolkit::finalizers {
+
+namespace detail {
+class StructFileParser;
+}
 
 // When a struct file is around, this draws data from it to Classify a Module.
 class StructFile final : public ProfileFinalizer {
 public:
-  StructFile(const stdshim::filesystem::path& p);
+  StructFile(stdshim::filesystem::path path);
   ~StructFile();
 
   ExtensionClass provides() const noexcept override {
@@ -63,13 +69,15 @@ public:
   ExtensionClass requires() const noexcept override { return {}; }
   void module(const Module&, Classification&) noexcept override;
 
-  const stdshim::filesystem::path& forPath() const noexcept { return modpath; }
+  std::vector<stdshim::filesystem::path> forPaths() const;
 
 private:
-  bool parse(const Module&, Classification&);
-
   stdshim::filesystem::path path;
-  stdshim::filesystem::path modpath;
+
+  // Structfiles can have data on multiple load modules (LM tags), this maps
+  // each binary path with the properly initialized Parser for that tag.
+  std::unordered_map<stdshim::filesystem::path,
+                     std::unique_ptr<finalizers::detail::StructFileParser>> lms;
 };
 
 }

--- a/src/tool/hpcprof2/args.cpp
+++ b/src/tool/hpcprof2/args.cpp
@@ -230,8 +230,8 @@ ProfArgs::ProfArgs(int argc, char* const argv[])
         std::cerr << "Invalid structure file '" << optarg << "'!\n";
         std::exit(2);
       }
-      const auto& p = c->forPath();
-      structheads[p.filename()].emplace_back(p.parent_path());
+      for(const auto& p : c->forPaths())
+        structheads[p.filename()].emplace_back(p.parent_path());
       structs.emplace_back(std::move(c), path);
       break;
     }


### PR DESCRIPTION
Although allowed by the Structfile specification, Prof2 has not supported
multiple LM tags within the same Structfile. Since there are cases where
these kinds of Structfiles will be generated (in some GPU-related cases),
this commit adds the missing support.

Fixes https://github.com/HPCToolkit/hpctoolkit/issues/434

---

@aarontcopal2 Can you test this on one of the cases you had troubles with? It works fine on my synthetic case but I'd like it to pass a tougher case before merging.