### PR TITLE
Patch memory pool create

### DIFF
--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -471,7 +471,7 @@ roctracer_buffer_completion_callback
  void* arg
 )
 {
-  hpcrun_thread_init_mem_pool_once();
+  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
   roctracer_buffer_completion_notify();
   roctracer_record_t* record = (roctracer_record_t*)(begin);
   roctracer_record_t* end_record = (roctracer_record_t*)(end);

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -471,6 +471,7 @@ roctracer_buffer_completion_callback
  void* arg
 )
 {
+  hpcrun_thread_init_mem_pool_once();
   roctracer_buffer_completion_notify();
   roctracer_record_t* record = (roctracer_record_t*)(begin);
   roctracer_record_t* end_record = (roctracer_record_t*)(end);

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -342,6 +342,8 @@ gpu_trace_record
 {
   gpu_trace_channel_set_t *channel_set = (gpu_trace_channel_set_t *) args;
 
+  hpcrun_thread_init_mem_pool_once();
+
   while (!atomic_load(&stop_trace_flag)) {
     //getting data from a trace channel
     gpu_trace_channel_set_process(channel_set);

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -342,7 +342,7 @@ gpu_trace_record
 {
   gpu_trace_channel_set_t *channel_set = (gpu_trace_channel_set_t *) args;
 
-  hpcrun_thread_init_mem_pool_once();
+  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
 
   while (!atomic_load(&stop_trace_flag)) {
     //getting data from a trace channel

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -1335,7 +1335,7 @@ cupti_buffer_completion_callback
  size_t validSize
 )
 {
-  hpcrun_thread_init_mem_pool_once();
+  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
 
   // handle notifications
   cupti_buffer_completion_notify();

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -1335,6 +1335,8 @@ cupti_buffer_completion_callback
  size_t validSize
 )
 {
+  hpcrun_thread_init_mem_pool_once();
+
   // handle notifications
   cupti_buffer_completion_notify();
 

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -780,20 +780,7 @@ hpcrun_thread_init(int id, local_thread_data_t* local_thread_data, bool has_trac
   bool demand_new_thread = false;
   cct_ctxt_t* thr_ctxt = local_thread_data ? local_thread_data->thr_ctxt : NULL;
 
-  hpcrun_mmap_init();
-
-  // ----------------------------------------
-  // call thread manager to get a thread data. If there is unused thread data,
-  //  we can recycle it, otherwise we need to allocate a new one.
-  // If we allocate a new one, we need to initialize the data and trace file.
-  // ----------------------------------------
-
-  thread_data_t* td = NULL;
-  hpcrun_threadMgr_data_get_safe(id, thr_ctxt, &td, has_trace, demand_new_thread);
-  hpcrun_set_thread_data(td);
-
-  td->inside_hpcrun = 1;  // safe enter, disable signals
-
+  hpcrun_thread_init_mem_pool(id, thr_ctxt, has_trace, demand_new_thread);
   
   if (ENABLED(THREAD_CTXT)) {
     if (thr_ctxt) {

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -780,7 +780,7 @@ hpcrun_thread_init(int id, local_thread_data_t* local_thread_data, bool has_trac
   bool demand_new_thread = false;
   cct_ctxt_t* thr_ctxt = local_thread_data ? local_thread_data->thr_ctxt : NULL;
 
-  hpcrun_thread_init_mem_pool(id, thr_ctxt, has_trace, demand_new_thread);
+  hpcrun_thread_init_mem_pool_once(id, thr_ctxt, has_trace, demand_new_thread);
   
   if (ENABLED(THREAD_CTXT)) {
     if (thr_ctxt) {

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -782,6 +782,9 @@ hpcrun_thread_init(int id, local_thread_data_t* local_thread_data, bool has_trac
 
   hpcrun_thread_init_mem_pool_once(id, thr_ctxt, has_trace, demand_new_thread);
   
+  hpcrun_get_thread_data()->inside_hpcrun = 1;
+  
+  
   if (ENABLED(THREAD_CTXT)) {
     if (thr_ctxt) {
       hpcrun_walk_path(thr_ctxt->context, logit, (cct_op_arg_t) (intptr_t) id);

--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -65,11 +65,13 @@
 
 #include "thread_data.h"
 #include "trace.h"
+#include "threadmgr.h"
 
 #include <lush/lush-pthread.h>
 #include <messages/messages.h>
 #include <trampoline/common/trampoline.h>
 #include <memory/mmap.h>
+
 
 //***************************************************************************
 
@@ -235,7 +237,7 @@ hpcrun_threaded_data
 
 
 void
-hpcrun_thread_init_mem_pool
+hpcrun_thread_init_mem_pool_once
 (
   int id, 
   cct_ctxt_t *thr_ctxt,
@@ -244,27 +246,12 @@ hpcrun_thread_init_mem_pool
 )
 { 
   thread_data_t* td = NULL;
-  
-  hpcrun_mmap_init();
-  hpcrun_threadMgr_data_get_safe(id, thr_ctxt, &td, has_trace, demand_new_thread);
-  hpcrun_set_thread_data(td);
-  td->inside_hpcrun = 1;  // safe enter, disable signals
-}
-
-
-void
-hpcrun_thread_init_mem_pool_once
-(
-)
-{ 
-  // Should be called every time hpcrun tooling thread is created
-  int id = 0;
-  cct_ctxt_t *thr_ctxt = NULL;
-  bool has_trace = false;
-  bool demand_new_thread = true;
 
   if (mem_pool_initialized == false){
-    hpcrun_thread_init_mem_pool(id, thr_ctxt, has_trace, demand_new_thread);
+    hpcrun_mmap_init();
+    hpcrun_threadMgr_data_get_safe(id, thr_ctxt, &td, has_trace, demand_new_thread);
+    hpcrun_set_thread_data(td);
+
     mem_pool_initialized = true;
   }
 }

--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -90,10 +90,14 @@ __thread int monitor_tid = -1;
 static thread_data_t _local_td;
 static pthread_key_t _hpcrun_key;
 static int use_getspecific = 0;
+static __thread bool mem_pool_initialized = false;
 
 
 void
-hpcrun_init_pthread_key(void)
+hpcrun_init_pthread_key
+(
+  void
+)
 {
   TMSG(THREAD_SPECIFIC,"creating _hpcrun_key");
   int bad = pthread_key_create(&_hpcrun_key, NULL);
@@ -105,7 +109,10 @@ hpcrun_init_pthread_key(void)
 
 
 void
-hpcrun_set_thread0_data(void)
+hpcrun_set_thread0_data
+(
+  void
+)
 {
   TMSG(THREAD_SPECIFIC,"set thread0 data");
   hpcrun_set_thread_data(&_local_td);
@@ -113,7 +120,10 @@ hpcrun_set_thread0_data(void)
 
 
 void
-hpcrun_set_thread_data(thread_data_t *td)
+hpcrun_set_thread_data
+(
+  thread_data_t *td
+)
 {
   TMSG(THREAD_SPECIFIC,"setting td");
   pthread_setspecific(_hpcrun_key, (void *) td);
@@ -123,21 +133,30 @@ hpcrun_set_thread_data(thread_data_t *td)
 //***************************************************************************
 
 static thread_data_t*
-hpcrun_get_thread_data_local(void)
+hpcrun_get_thread_data_local
+(
+  void
+)
 {
   return &_local_td;
 }
 
 
 static bool
-hpcrun_get_thread_data_local_avail(void)
+hpcrun_get_thread_data_local_avail
+(
+  void
+)
 {
   return true;
 }
 
 
 thread_data_t*
-hpcrun_safe_get_td(void)
+hpcrun_safe_get_td
+(
+  void
+)
 {
   if (use_getspecific) {
     return (thread_data_t *) pthread_getspecific(_hpcrun_key);
@@ -147,8 +166,12 @@ hpcrun_safe_get_td(void)
   }
 }
 
+
 static thread_data_t*
-hpcrun_get_thread_data_specific(void)
+hpcrun_get_thread_data_specific
+(
+  void
+)
 {
   thread_data_t *ret = (thread_data_t *) pthread_getspecific(_hpcrun_key);
   if (!ret){
@@ -157,12 +180,17 @@ hpcrun_get_thread_data_specific(void)
   return ret;
 }
 
+
 static bool
-hpcrun_get_thread_data_specific_avail(void)
+hpcrun_get_thread_data_specific_avail
+(
+  void
+)
 {
   thread_data_t *ret = (thread_data_t *) pthread_getspecific(_hpcrun_key);
   return !(ret == NULL);
 }
+
 
 
 thread_data_t* (*hpcrun_get_thread_data)(void) = &hpcrun_get_thread_data_local;
@@ -184,7 +212,10 @@ hpcrun_get_thread_data()
 
 
 void
-hpcrun_unthreaded_data(void)
+hpcrun_unthreaded_data
+(
+  void
+)
 {
   hpcrun_get_thread_data = &hpcrun_get_thread_data_local;
   hpcrun_td_avail        = &hpcrun_get_thread_data_local_avail;
@@ -192,7 +223,10 @@ hpcrun_unthreaded_data(void)
 
 
 void
-hpcrun_threaded_data(void)
+hpcrun_threaded_data
+(
+  void
+)
 {
   assert(hpcrun_get_thread_data == &hpcrun_get_thread_data_local);
   hpcrun_get_thread_data = &hpcrun_get_thread_data_specific;
@@ -200,19 +234,65 @@ hpcrun_threaded_data(void)
 }
 
 
+void
+hpcrun_thread_init_mem_pool
+(
+  int id, 
+  cct_ctxt_t *thr_ctxt,
+  bool has_trace, 
+  bool demand_new_thread
+)
+{ 
+  thread_data_t* td = NULL;
+  
+  hpcrun_mmap_init();
+  hpcrun_threadMgr_data_get_safe(id, thr_ctxt, &td, has_trace, demand_new_thread);
+  hpcrun_set_thread_data(td);
+  td->inside_hpcrun = 1;  // safe enter, disable signals
+}
+
+
+void
+hpcrun_thread_init_mem_pool_once
+(
+)
+{ 
+  // Should be called every time hpcrun tooling thread is created
+  int id = 0;
+  cct_ctxt_t *thr_ctxt = NULL;
+  bool has_trace = false;
+  bool demand_new_thread = true;
+
+  if (mem_pool_initialized == false){
+    hpcrun_thread_init_mem_pool(id, thr_ctxt, has_trace, demand_new_thread);
+    mem_pool_initialized = true;
+  }
+}
+
+
+
 //***************************************************************************
 // 
 //***************************************************************************
 
 thread_data_t*
-hpcrun_allocate_thread_data(int id)
+hpcrun_allocate_thread_data
+(
+  int id
+)
 {
   TMSG(THREAD_SPECIFIC,"malloc thread data for thread %d", id);
   return hpcrun_mmap_anon(sizeof(thread_data_t));
 }
 
+
 static inline void
-core_profile_trace_data_init(core_profile_trace_data_t * cptd, int id, cct_ctxt_t* thr_ctxt) 
+core_profile_trace_data_init
+(
+  core_profile_trace_data_t * cptd, 
+  int id, 
+  cct_ctxt_t* thr_ctxt
+) 
 {
   // ----------------------------------------
   // id
@@ -266,8 +346,15 @@ static inline void gpu_data_init(gpu_data_t * gpu_data)
 }
 #endif
 
+
 void
-hpcrun_thread_data_init(int id, cct_ctxt_t* thr_ctxt, int is_child, size_t n_sources)
+hpcrun_thread_data_init
+(
+  int id, 
+  cct_ctxt_t* thr_ctxt, 
+  int is_child, 
+  size_t n_sources
+)
 {
   hpcrun_meminfo_t memstore;
   thread_data_t* td = hpcrun_get_thread_data();
@@ -415,7 +502,10 @@ hpcrun_thread_data_init(int id, cct_ctxt_t* thr_ctxt, int is_child, size_t n_sou
 //***************************************************************************
 
 void
-hpcrun_cached_bt_adjust_size(size_t n)
+hpcrun_cached_bt_adjust_size
+(
+  size_t n
+)
 {
   thread_data_t *td = hpcrun_get_thread_data();
   if ((td->cached_bt_buf_frame_end - td->cached_bt_buf_beg) >= n) {
@@ -433,7 +523,10 @@ hpcrun_cached_bt_adjust_size(size_t n)
 
 
 frame_t*
-hpcrun_expand_btbuf(void)
+hpcrun_expand_btbuf
+(
+  void
+)
 {
   thread_data_t* td = hpcrun_get_thread_data();
   frame_t* unwind = td->btbuf_cur;
@@ -469,7 +562,10 @@ hpcrun_expand_btbuf(void)
 
 
 void
-hpcrun_ensure_btbuf_avail(void)
+hpcrun_ensure_btbuf_avail
+(
+  void
+)
 {
   thread_data_t* td = hpcrun_get_thread_data();
   if (td->btbuf_cur == td->btbuf_end) {

--- a/src/tool/hpcrun/thread_data.h
+++ b/src/tool/hpcrun/thread_data.h
@@ -336,20 +336,13 @@ hpcrun_threaded_data
 );
 
 
-void
-hpcrun_thread_init_mem_pool
+void 
+hpcrun_thread_init_mem_pool_once
 (
   int id, 
   cct_ctxt_t *thr_ctxt,
   bool has_trace, 
   bool demand_new_thread
-);
-
-
-void 
-hpcrun_thread_init_mem_pool_once
-(
-  void
 );
 
 

--- a/src/tool/hpcrun/thread_data.h
+++ b/src/tool/hpcrun/thread_data.h
@@ -293,9 +293,25 @@ typedef struct thread_data_t {
 static const size_t HPCRUN_TraceBufferSz = HPCIO_RWBufferSz;
 
 
-void hpcrun_init_pthread_key(void);
-void hpcrun_set_thread0_data(void);
-void hpcrun_set_thread_data(thread_data_t *td);
+void 
+hpcrun_init_pthread_key
+(
+  void
+);
+
+
+void 
+hpcrun_set_thread0_data
+(
+  void
+);
+
+
+void 
+hpcrun_set_thread_data
+(
+  thread_data_t *td
+);
 
 
 #define TD_GET(field) hpcrun_get_thread_data()->field
@@ -303,23 +319,85 @@ void hpcrun_set_thread_data(thread_data_t *td);
 extern thread_data_t* (*hpcrun_get_thread_data)(void);
 extern bool           (*hpcrun_td_avail)(void);
 extern thread_data_t* hpcrun_safe_get_td(void);
-
-void hpcrun_unthreaded_data(void);
-void hpcrun_threaded_data(void);
-
-
 extern thread_data_t* hpcrun_allocate_thread_data(int id);
 
+
+void 
+hpcrun_unthreaded_data
+(
+  void
+);
+
+
+void 
+hpcrun_threaded_data
+(
+  void
+);
+
+
 void
-hpcrun_thread_data_init(int id, cct_ctxt_t* thr_ctxt, int is_child, size_t n_sources);
+hpcrun_thread_init_mem_pool
+(
+  int id, 
+  cct_ctxt_t *thr_ctxt,
+  bool has_trace, 
+  bool demand_new_thread
+);
 
 
-void     hpcrun_cached_bt_adjust_size(size_t n);
-frame_t* hpcrun_expand_btbuf(void);
-void     hpcrun_ensure_btbuf_avail(void);
+void 
+hpcrun_thread_init_mem_pool_once
+(
+  void
+);
 
-void           hpcrun_thread_data_reuse_init(cct_ctxt_t* thr_ctxt);
-void           hpcrun_cached_bt_adjust_size(size_t n);
+
+void
+hpcrun_thread_data_init
+(
+  int id, 
+  cct_ctxt_t* thr_ctxt, 
+  int is_child, 
+  size_t n_sources
+);
+
+
+void     
+hpcrun_cached_bt_adjust_size
+(
+  size_t n
+);
+
+
+frame_t* 
+hpcrun_expand_btbuf
+(
+  void
+);
+
+
+void
+hpcrun_ensure_btbuf_avail
+(
+  void
+);
+
+
+void
+hpcrun_thread_data_reuse_init
+(
+  cct_ctxt_t* thr_ctxt
+);
+
+
+void
+hpcrun_cached_bt_adjust_size
+(
+  size_t n
+);
+
+
 
 // utilities to match previous api
 #define hpcrun_get_thread_epoch()  TD_GET(core_profile_trace_data.epoch)


### PR DESCRIPTION
This patch introduces **hpcrun_thread_init_mem_pool_once** at the beginning of each thread created from the monitoring tool (hpcrun or vendor-api) to process tracing/profiling data. This is necessary because these threads need to have initialized thread-data structure, since they create channels and other things with td data structure.

I added this function at the beginning of **cupti/rocm_buffer_completion_callback** and **gpu_trace_record**. I can see that there are pthread_create calls for:
- stream_data_collecting,
- finalize_all_thread_data,
- gpu_operation_record 

Should I put **hpcrun_thread_init_mem_pool_once** for them too?
Let me know if this patch solves the problem with cuda versions, we talked on the meeting.