### PR TITLE
Fixup OSUtil_hostid for thread-safety and unsigned return

### DIFF
--- a/src/lib/support-lean/OSUtil.h
+++ b/src/lib/support-lean/OSUtil.h
@@ -68,7 +68,7 @@
 //***************************************************************************
 
 #include <stddef.h>
-
+#include <inttypes.h>
 
 
 //***************************************************************************
@@ -83,7 +83,7 @@
 // macros
 //***************************************************************************
 
-#define HOSTID_FORMAT "%08lx"
+#define HOSTID_FORMAT "%08" PRIx32
 
 
 
@@ -101,7 +101,7 @@ OSUtil_pid();
 const char*
 OSUtil_jobid();
 
-long
+uint32_t
 OSUtil_hostid();
 
 // set the buffer into the customized kernel name


### PR DESCRIPTION
Doesn't fix any known issues, but may prevent very hard-to-debug issues in the future.

There was a comment in this region that claimed some versions of RHEL 6.x had issues with gethostid() triggering a SIGFPE, the previous implementation would catch and gracefully absorb the signal. There is no clean and contained way to do this in thread-safe manner, so this version doesn't do so (and thus is much simpler).

---

Targeting `master` since this patch is not specific to anything in `develop`.

Ping @mwkrentel as the author of the previous version of this function (and the RHEL 6.x comment).