### PR TITLE
Returning MONITOR_IGNORE_NEW_THREAD from monitor_thread_pre_create

### DIFF
--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -1163,7 +1163,7 @@ monitor_thread_pre_create(void)
   // N.B.: monitor_thread_pre_create() can be called before
   // monitor_init_thread_support() or even monitor_init_process().
   if (! hpcrun_is_initialized() || hpcrun_get_disabled()) {
-    return NULL;
+    return MONITOR_IGNORE_NEW_THREAD;
   }
 
   struct monitor_thread_info mti;

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -1171,7 +1171,7 @@ monitor_thread_pre_create(void)
   void *thread_pre_create_address = mti.mti_create_return_addr;
 
   if (module_ignore_map_inrange_lookup(thread_pre_create_address)) {
-    return NULL;
+    return MONITOR_IGNORE_NEW_THREAD;
   }
   
   hpcrun_safe_enter();


### PR DESCRIPTION
Patch memory pool create required one more change from Keren:
https://github.com/HPCToolkit/hpctoolkit/pull/473#issuecomment-958084480

Which is returning MONITOR_IGNORE_NEW_THREAD from monitor_thread_pre_create. This feature goes together with libmonitor ignore-from-pre-create branch that needs to be merged.
https://github.com/HPCToolkit/libmonitor/pull/2 