### PR TITLE
Add the E4S metadata

### DIFF
--- a/.e4s/e4s.yaml
+++ b/.e4s/e4s.yaml
@@ -1,0 +1,5 @@
+- e4s_product: hpctoolkit
+  docs:  [README.md, README.ReleaseNotes, README.License]
+  Area: "Development tools"
+  Description: "Performance analysis tools."
+  MemberProduct: True


### PR DESCRIPTION
The E4S metadata is part of E4S policy. My understanding is that it requires a yaml file in `.e4s` directory.
The content of the yaml is an adaptation from https://github.com/E4S-Project/E4S-Documenter/blob/master/data/hpctoolkit/e4s.yaml where the `MemberProduct` field is set to `True` (instead of `False`).

The metadata is not well documented and strangely, even E4S team doesn't know what this field means.