### PR TITLE
cleanup finalization of CUDA traces

### DIFF
--- a/src/tool/hpcrun/sample-sources/nvidia.c
+++ b/src/tool/hpcrun/sample-sources/nvidia.c
@@ -110,7 +110,6 @@
 
 // finalizers
 static device_finalizer_fn_entry_t device_finalizer_flush;
-static device_finalizer_fn_entry_t device_finalizer_shutdown;
 static device_finalizer_fn_entry_t device_trace_finalizer_shutdown;
 
 
@@ -391,16 +390,6 @@ METHOD_FN(process_event_list, int lush_metrics)
     monitor_real_exit(-1);
   }
 #endif
-
-  // Register hpcrun callbacks
-  device_finalizer_flush.fn = cupti_device_flush;
-  device_finalizer_register(device_finalizer_type_flush,
-			    &device_finalizer_flush);
-
-  device_finalizer_shutdown.fn = cupti_device_shutdown;
-  device_finalizer_register(device_finalizer_type_shutdown,
-			    &device_finalizer_shutdown);
-
   // Get control knobs
   int device_buffer_size;
   if (control_knob_value_get_int("HPCRUN_CUDA_DEVICE_BUFFER_SIZE", &device_buffer_size) != 0)
@@ -441,6 +430,13 @@ METHOD_FN(process_event_list, int lush_metrics)
   cupti_enabled_activities |= CUPTI_KERNEL_INVOCATION;
   cupti_enabled_activities |= CUPTI_DATA_MOTION_EXPLICIT;
   cupti_enabled_activities |= CUPTI_OVERHEAD;
+
+  // Register flush function to turn off cupti activity tracing  and flush traces 
+  // NOTE: this is a registered as a flush callback because is MUST precede 
+  //       GPU trace finalization, which is registered as a shutdown callback
+  device_finalizer_flush.fn = cupti_device_shutdown;
+  device_finalizer_register(device_finalizer_type_flush,
+			    &device_finalizer_flush);
 
   // Register shutdown functions to write trace files
   device_trace_finalizer_shutdown.fn = gpu_trace_fini;


### PR DESCRIPTION
before this commit:

1) a device flush finalizer flushes cupti activity traces.
2) the last registered device shutdown finalizer calls
   gpu_trace_fini
3) the first registered  device shutdown finalizer shuts
   down cuda activity tracing and flushes any remaining
   traces

issues: (3) shuts down and flushes cuda traces after gpu
tracing has been finalized. (1) and (3) both flush

after this commit
1) a device flush finalizer shuts down cuda activity tracing
   and flushes any remaining traces
2) a device shutdown finalizer calls gpu_trace_fini

improvements: cuda activity tracing is disabled before a single
flush. a single flush occurs before gpu_trace_fini, as it must.