### PR TITLE
adjust loadmap to note which load modules need analysis

### DIFF
--- a/src/lib/prof-lean/hpcrun-fmt.h
+++ b/src/lib/prof-lean/hpcrun-fmt.h
@@ -452,6 +452,8 @@ hpcrun_fmt_metric_set_format(metric_desc_t *metric_desc, char *format);
 // loadmap
 //***************************************************************************
 
+#define LOADMAP_ENTRY_ANALYZE 1
+
 typedef struct loadmap_entry_t {
 
   uint16_t id; // HPCRUN_FMT_LMId_NULL is the NULL value

--- a/src/lib/prof/CallPath-Profile.cpp
+++ b/src/lib/prof/CallPath-Profile.cpp
@@ -1178,7 +1178,8 @@ Profile::fmt_epoch_fread(Profile* &prof, FILE* infs, uint rFlags,
         
 	// make sure we eliminate the <vmlinux> and <vdso> load modules
 	// These modules have prefix '<' and hopefully it doesn't change
-	if (x->name != NULL && x->name[0] != '<')
+	if ((x->name != NULL && x->name[0] != '<') && 
+            (x->flags & LOADMAP_ENTRY_ANALYZE))
           fprintf(outfs, "%s\n", x->name );
       }
       // hack: case for hpcproftt with --lm option

--- a/src/tool/hpcrun/loadmap.h
+++ b/src/tool/hpcrun/loadmap.h
@@ -62,6 +62,7 @@
 #include <lib/prof-lean/hpcio.h>
 #include <lib/prof-lean/hpcfmt.h>
 #include <lib/prof-lean/hpcrun-fmt.h>
+#include <lib/prof-lean/stdatomic.h>
 
 #include "fnbounds_file_header.h"
 
@@ -132,7 +133,7 @@ typedef struct load_module_t
   struct dl_phdr_info phdr_info;
   struct load_module_t* next;
   struct load_module_t* prev;
-
+  atomic_int flags;
 } load_module_t;
 
 
@@ -142,6 +143,13 @@ hpcrun_loadModule_new(const char* name);
 // used only to add a load module for the kernel 
 uint16_t 
 hpcrun_loadModule_add(const char* name);
+
+void
+hpcrun_loadModule_flags_set(load_module_t *lm, int flag);
+
+int
+hpcrun_loadModule_flags_get(load_module_t *lm);
+
 
 //***************************************************************************
 // 

--- a/src/tool/hpcrun/write_data.c
+++ b/src/tool/hpcrun/write_data.c
@@ -289,8 +289,7 @@ write_epochs(FILE* fs, core_profile_trace_data_t * cptd, epoch_t* epoch)
       loadmap_entry_t lm_entry;
       lm_entry.id = lm_src->id;
       lm_entry.name = lm_src->name;
-      lm_entry.flags = 0;
-      
+      lm_entry.flags = hpcrun_loadModule_flags_get(lm_src);
       hpcrun_fmt_loadmapEntry_fwrite(&lm_entry, fs);
     }
 


### PR DESCRIPTION
binaries are often loaded into an address space that do
not end up on a call path; such binaries don't need binary
analysis. mark load modules that we queried with
hpcrun_loadModule_findByAddr as needing binary analysis.