### PR TITLE
hpcrun: Add a "head note" for probably unprofilable events

### DIFF
--- a/src/tool/hpcrun/sample-sources/perf/perfmon-util.c
+++ b/src/tool/hpcrun/sample-sources/perf/perfmon-util.c
@@ -269,6 +269,8 @@ show_info(char *event )
 
   pname = event_has_pname(event);
 
+  printf("(*) Denotes the counter may not be profilable.\n\n");
+
   /*
    * scan all supported events, incl. those
    * from undetected PMU models
@@ -293,8 +295,6 @@ show_info(char *event )
       }
     }
   }
-  if (profilable != EVENT_IS_PROFILABLE) 
-    printf("(*) The counter may not be profilable.\n\n");
   
   return match;
 }
@@ -445,6 +445,7 @@ pfmu_showEventList()
 {
   static char *argv_all =  ".*";
 
+#if 0
   int total_supported_events = 0;
   int total_available_events = 0;
   int i, ret;
@@ -459,7 +460,6 @@ pfmu_showEventList()
       "uncore",
       "OS generic",
   };
-
   printf("Detected PMU models:\n");
   
   pfm_for_all_pmus(i) {
@@ -487,7 +487,7 @@ pfmu_showEventList()
   printf("Total events: %d available, %d supported\n", total_available_events, total_supported_events);
 
   display_line_single(stdout);
-
+#endif
   show_info(argv_all);
 
   return 0;


### PR DESCRIPTION
Instead of having a footnote to warn of probably unprofilable events, it's better to show the note in the beginning.
This fix will show this message in the beginning of perf sample source when using -L flag:

(*) Denotes the counter may not be profilable.
...

Minor update:
- remove warning
- remove unnecessary info from libpfm4 about the number of events for each perf module. Users don't care.