### PR TITLE
Hpcrun static

### DIFF
--- a/src/tool/hpcrun/fnbounds/fnbounds_static.c
+++ b/src/tool/hpcrun/fnbounds/fnbounds_static.c
@@ -102,6 +102,7 @@ fnbounds_init(const char *executable_name)
     hpcrun_dso_make(executable_name, (void*)hpcrun_nm_addrs, 
 		    &fh, lm_beg_fn, lm_end_fn, lm_size);
   fnbounds_executable_dso = hpcrun_loadmap_map(dso);
+  hpcrun_loadModule_flags_set(fnbounds_executable_dso, LOADMAP_ENTRY_ANALYZE);
 
   return 0;
 }

--- a/src/tool/hpcrun/sample-sources/ss-list.h
+++ b/src/tool/hpcrun/sample-sources/ss-list.h
@@ -93,7 +93,9 @@ SAMPLE_SOURCE_DECL_MACRO(nvidia_gpu)
 #endif
 
 #ifdef HPCRUN_SS_AMD
+#ifndef HPCRUN_STATIC_LINK
 SAMPLE_SOURCE_DECL_MACRO(amd_gpu)
+#endif
 #endif
 
 #ifdef HPCRUN_SS_LEVEL0


### PR DESCRIPTION
- have hpcrun mark a static binary for binary analysis by hpcstruct
- don't require AMD GPU sample source for static binaries (the code is not even built)