### PR TITLE
fix cupti thread and process finalizer order

### DIFF
--- a/src/tool/hpcrun/device-finalizers.c
+++ b/src/tool/hpcrun/device-finalizers.c
@@ -6,9 +6,13 @@ static device_finalizer_fn_entry_t *kinds[2] = {0, 0};
 void
 device_finalizer_register(device_finalizer_type_t type, device_finalizer_fn_entry_t *entry)
 {
-   device_finalizer_fn_entry_t* device_fn = kinds[type];
-   entry->next = device_fn;
-   kinds[type] = entry;
+   device_finalizer_fn_entry_t** device_fn = &kinds[type];
+
+   // append finalizer at end of list.
+   while (*device_fn != 0) {
+     device_fn = &((*device_fn)->next);
+   }
+   *device_fn = entry;
 }
 
 

--- a/src/tool/hpcrun/device-finalizers.h
+++ b/src/tool/hpcrun/device-finalizers.h
@@ -17,7 +17,10 @@ typedef struct device_finalizer_fn_entry_t {
 } device_finalizer_fn_entry_t;
 
 
+// note finalizers in the order they are registered
 extern void device_finalizer_register(device_finalizer_type_t type, device_finalizer_fn_entry_t* entry);
+
+// apply finalizers in the order they are registered
 extern void device_finalizer_apply(device_finalizer_type_t type, int how);
 
 #endif


### PR DESCRIPTION
- ensure that device finalizers are called in the order that they are registered
- register cupti_device_flush as a device_flush finalizer
- regster cupti_device_shutdown and then gpu_trace_fini as device_shutdown finalizers