### PR TITLE
roctracer support for fixing finalization

### DIFF
--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -578,6 +578,17 @@ roctracer_init
 }
 
 void
+roctracer_flush
+(
+ void* args,
+ int how
+)
+{
+  HPCRUN_ROCTRACER_CALL(roctracer_flush_activity_expl, (NULL));
+}
+
+
+void
 roctracer_fini
 (
  void* args,
@@ -590,7 +601,8 @@ roctracer_fini
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_activity, (ACTIVITY_DOMAIN_HSA_OPS));
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_callback, (ACTIVITY_DOMAIN_KFD_API));
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_callback, (ACTIVITY_DOMAIN_ROCTX));
-  HPCRUN_ROCTRACER_CALL(roctracer_flush_activity_expl, (NULL));
+
+  roctracer_flush(args, how);
 
   gpu_application_thread_process_activities();
 }

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -585,6 +585,8 @@ roctracer_flush
 )
 {
   HPCRUN_ROCTRACER_CALL(roctracer_flush_activity_expl, (NULL));
+
+  gpu_application_thread_process_activities();
 }
 
 
@@ -603,7 +605,5 @@ roctracer_fini
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_callback, (ACTIVITY_DOMAIN_ROCTX));
 
   roctracer_flush(args, how);
-
-  gpu_application_thread_process_activities();
 }
 

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.h
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.h
@@ -58,6 +58,14 @@ roctracer_init
 
 
 void
+roctracer_flush
+(
+ void *args,
+ int how
+);
+
+
+void
 roctracer_fini
 (
  void *args,

--- a/src/tool/hpcrun/sample-sources/amd.c
+++ b/src/tool/hpcrun/sample-sources/amd.c
@@ -73,6 +73,7 @@
 #define AMD_ROCM "gpu=amd"
 
 static device_finalizer_fn_entry_t device_finalizer_flush;
+static device_finalizer_fn_entry_t device_finalizer_shutdown;
 static device_finalizer_fn_entry_t device_trace_finalizer_shutdown;
 
 
@@ -171,12 +172,13 @@ METHOD_FN(finalize_event_list)
 #endif
   roctracer_init();
 
-  // Register flush function to turn off roctracer and flush traces 
-  // NOTE: this is a registered as a flush callback because is MUST precede 
-  //       GPU trace finalization, which is registered as a shutdown callback
-  device_finalizer_flush.fn = roctracer_fini;
+  device_finalizer_flush.fn = roctracer_flush;
   device_finalizer_register(device_finalizer_type_flush, 
                             &device_finalizer_flush);
+
+  device_finalizer_shutdown.fn = roctracer_fini;
+  device_finalizer_register(device_finalizer_type_shutdown, 
+                            &device_finalizer_shutdown);
 
   // initialize gpu tracing 
   gpu_trace_init();


### PR DESCRIPTION
- thread device finalizer flushes trace
- process device finalizer shuts down rocm measurement, flushes trace, then calls gpu_trace_fini