### PR TITLE
finalize level0 traces

### DIFF
--- a/src/tool/hpcrun/sample-sources/level0.c
+++ b/src/tool/hpcrun/sample-sources/level0.c
@@ -114,6 +114,7 @@
 #define LEVEL0 "gpu=level0"
 
 static device_finalizer_fn_entry_t device_finalizer_shutdown;
+static device_finalizer_fn_entry_t device_finalizer_trace;
 
 //******************************************************************************
 // interface operations
@@ -206,6 +207,9 @@ METHOD_FN(finalize_event_list)
 
   device_finalizer_shutdown.fn = level0_fini;
   device_finalizer_register(device_finalizer_type_shutdown, &device_finalizer_shutdown);
+
+  device_finalizer_trace.fn = gpu_trace_fini;
+  device_finalizer_register(device_finalizer_type_shutdown, &device_finalizer_trace);
 }
 
 


### PR DESCRIPTION
finalize level0 traces by calling gpu_trace_fini as last device finalizer when shutting down the process.