### PR TITLE
Add cache for hpcstruct

### DIFF
--- a/src/lib/prof-lean/Makefile.am
+++ b/src/lib/prof-lean/Makefile.am
@@ -109,7 +109,7 @@ MYSOURCES = \
 	vdso.h vdso.c \
 	randomizer.h randomizer.c \
 	splay-uint64.h splay-uint64.c \
-	elf-helper.h elf-helper.c
+	elf-helper.h elf-helper.c elf-hash.h elf-hash.c
 
 MYCFLAGS = @HOST_CFLAGS@ $(HPC_IFLAGS) $(MBEDTLS_IFLAGS)  -I$(LIBELF_INC)
 

--- a/src/lib/prof-lean/Makefile.in
+++ b/src/lib/prof-lean/Makefile.in
@@ -160,7 +160,8 @@ am__objects_1 = libHPCprof_lean_la-hpcrun-fmt.lo \
 	libHPCprof_lean_la-procmaps.lo libHPCprof_lean_la-vdso.lo \
 	libHPCprof_lean_la-randomizer.lo \
 	libHPCprof_lean_la-splay-uint64.lo \
-	libHPCprof_lean_la-elf-helper.lo
+	libHPCprof_lean_la-elf-helper.lo \
+	libHPCprof_lean_la-elf-hash.lo
 am_libHPCprof_lean_la_OBJECTS = $(am__objects_1)
 libHPCprof_lean_la_OBJECTS = $(am_libHPCprof_lean_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -574,7 +575,7 @@ MYSOURCES = \
 	vdso.h vdso.c \
 	randomizer.h randomizer.c \
 	splay-uint64.h splay-uint64.c \
-	elf-helper.h elf-helper.c
+	elf-helper.h elf-helper.c elf-hash.h elf-hash.c
 
 MYCFLAGS = @HOST_CFLAGS@ $(HPC_IFLAGS) $(MBEDTLS_IFLAGS)  -I$(LIBELF_INC)
 @IS_HOST_AR_FALSE@MYAR = $(AR) cru
@@ -684,6 +685,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-cpuset_hwthreads.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-crypto-hash.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-cskiplist.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-elf-hash.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-elf-helper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-generic_pair.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libHPCprof_lean_la-hpcfmt.Plo@am__quote@
@@ -917,6 +919,13 @@ libHPCprof_lean_la-elf-helper.lo: elf-helper.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='elf-helper.c' object='libHPCprof_lean_la-elf-helper.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libHPCprof_lean_la_CFLAGS) $(CFLAGS) -c -o libHPCprof_lean_la-elf-helper.lo `test -f 'elf-helper.c' || echo '$(srcdir)/'`elf-helper.c
+
+libHPCprof_lean_la-elf-hash.lo: elf-hash.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libHPCprof_lean_la_CFLAGS) $(CFLAGS) -MT libHPCprof_lean_la-elf-hash.lo -MD -MP -MF $(DEPDIR)/libHPCprof_lean_la-elf-hash.Tpo -c -o libHPCprof_lean_la-elf-hash.lo `test -f 'elf-hash.c' || echo '$(srcdir)/'`elf-hash.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libHPCprof_lean_la-elf-hash.Tpo $(DEPDIR)/libHPCprof_lean_la-elf-hash.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='elf-hash.c' object='libHPCprof_lean_la-elf-hash.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libHPCprof_lean_la_CFLAGS) $(CFLAGS) -c -o libHPCprof_lean_la-elf-hash.lo `test -f 'elf-hash.c' || echo '$(srcdir)/'`elf-hash.c
 
 mostlyclean-libtool:
 	-rm -f *.lo

--- a/src/lib/prof-lean/elf-hash.c
+++ b/src/lib/prof-lean/elf-hash.c
@@ -1,0 +1,195 @@
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2021, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+
+//***************************************************************************
+//
+// File: elf-hash.c
+//
+// Purpose:
+//   compute a useful hash of an ELF file
+//   
+//***************************************************************************
+
+
+//******************************************************************************
+// system includes
+//******************************************************************************
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+
+
+//******************************************************************************
+// local includes
+//******************************************************************************
+
+#include "elf-hash.h"
+#include "crypto-hash.h"
+
+
+
+//******************************************************************************
+// macros
+//******************************************************************************
+
+#define FILE_MAX_HASH_LENGTH (1 << 16) // 64K
+
+
+
+//******************************************************************************
+// internal functions
+//******************************************************************************
+
+static int
+elf_hash_compute
+(
+ const char *filename,
+ unsigned char *hash,
+ unsigned int hash_length
+)
+{
+  struct stat statbuf;
+  int status = -1;
+
+  if (stat(filename, &statbuf) != -1) {
+    int fd = open(filename, O_RDONLY | O_CLOEXEC);
+    if (fd != -1) {
+      // for speed, hash at most FILE_MAX_HASH_LENGTH data
+      size_t flen = statbuf.st_size; 
+      if (flen > FILE_MAX_HASH_LENGTH) {
+	flen = FILE_MAX_HASH_LENGTH;
+      }
+
+      void * ANYWHERE = 0;
+      off_t NO_OFFSET = 0;
+      void *data = mmap(ANYWHERE, flen, PROT_READ, MAP_SHARED, fd, NO_OFFSET);
+      if (data) {
+	status = crypto_hash_compute((const unsigned char*) data, flen, hash,
+				     hash_length);
+	munmap(data, flen);
+      }
+      close(fd);
+    }
+  } 
+
+  return status;
+}
+
+
+static unsigned int
+elf_hash_length
+(
+ void
+)
+{
+  return crypto_hash_length();
+}
+
+
+
+//******************************************************************************
+// interface functions
+//******************************************************************************
+
+char *
+elf_hash
+(
+ const char *filename
+)
+{
+  char *hash_string = 0;
+
+  unsigned int hash_length = elf_hash_length();
+  unsigned char *hash = (unsigned char *) malloc(hash_length);
+
+  if (hash) {
+    memset(hash, 0, hash_length);
+    if (elf_hash_compute(filename, hash, hash_length) == 0) {
+      unsigned int hash_string_length = 1 + (hash_length << 1);
+      hash_string = (char *) malloc(hash_string_length);
+      *(hash_string + hash_string_length) = 0; // terminate the string
+      if (hash_string &&
+	  crypto_hash_to_hexstring(hash, hash_string,
+				   hash_string_length) != 0) {
+	free(hash_string);
+	hash_string = 0;
+      }
+    }
+
+    free(hash);
+  }
+
+  return hash_string;
+}
+
+
+
+//******************************************************************************
+// unit test
+//******************************************************************************
+
+#ifdef UNIT_TEST
+
+#include <stdio.h>
+
+int
+main
+(
+ int argc,
+ char **argv
+)
+{
+  char *h = elf_hash("/bin/ls");
+  if (h) {
+    printf("hash string: %s\n", h); 
+    free(h);
+    return 0;
+  }
+  return -1;
+}
+
+#endif

--- a/src/lib/prof-lean/elf-hash.h
+++ b/src/lib/prof-lean/elf-hash.h
@@ -1,9 +1,4 @@
-// -*-Mode: C++;-*-
-
 // * BeginRiceCopyright *****************************************************
-//
-// $HeadURL$
-// $Id$
 //
 // --------------------------------------------------------------------------
 // Part of HPCToolkit (hpctoolkit.org)
@@ -12,7 +7,7 @@
 // HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
 // --------------------------------------------------------------------------
 //
-// Copyright ((c)) 2002-2022, Rice University
+// Copyright ((c)) 2002-2021, Rice University
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -44,102 +39,53 @@
 //
 // ******************************************************* EndRiceCopyright *
 
+
 //***************************************************************************
 //
-// File:
-//   $HeadURL$
+// File: elf-helper.h
 //
 // Purpose:
-//   [The purpose of this file]
-//
-// Description:
-//   [The set of functions, macros, etc. defined in the file]
-//
+//   interface to query ELF binary information and hide the details about 
+//   extended number
+//   
 //***************************************************************************
 
-#ifndef Args_hpp
-#define Args_hpp
+#ifndef ELF_HASH_H
+#define ELF_HASH_H
 
-//************************* System Include Files ****************************
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#include <iostream>
-#include <string>
 
-//*************************** User Include Files ****************************
 
-#include <include/uint.h>
-#include <lib/support/CmdLineParser.hpp>
+//-----------------------------------------------------------------------------
+// function: 
+//   elf_hash
+//
+// arguments:
+//   filename:        
+//     name of the ELF file to hash
+//   hash:        
+//     pointer to a vector of bytes of length >= elf_hash_length()
+//
+//   hash_length:        
+//     length of hash
+//
+// return value:
+//   success: hash string
+//   failure: NULL
+//-----------------------------------------------------------------------------
+char *
+elf_hash
+(
+ const char *filename
+);
 
-//*************************** Forward Declarations **************************
 
-//***************************************************************************
+#ifdef __cplusplus
+};
+#endif
 
-class Args {
-public: 
-  Args(); 
-  Args(int argc, const char* const argv[]);
-  ~Args(); 
 
-  // Parse the command line
-  void
-  parse(int argc, const char* const argv[]);
-
-  // Version and Usage information
-  void
-  printVersion(std::ostream& os) const;
-
-  void
-  printUsage(std::ostream& os) const;
-  
-  // Error
-  void
-  printError(std::ostream& os, const char* msg) const;
-
-  void
-  printError(std::ostream& os, const std::string& msg) const;
-
-  // Dump
-  void
-  dump(std::ostream& os = std::cerr) const;
-
-  void
-  ddump() const;
-
-public:
-  // Parsed Data: Command
-  const std::string& getCmd() const;
-
-  int jobs;
-  int jobs_struct;
-  int jobs_parse;
-  int jobs_symtab;
-  bool show_time;
-  long parallel_analysis_threshold; 
-  bool analyze_cpu_binaries ;     // default: true
-  bool analyze_gpu_binaries ;     // default: true
-  bool compute_gpu_cfg;
-
-  // Parsed Data: optional arguments
-  std::string searchPathStr;          // default: "."
-  std::string dbgProcGlob;
-
-  bool prettyPrintOutput;         // default: true
-  bool useBinutils;		  // default: false
-  bool show_gaps;                 // default: false
-  bool nocache;                   // default: false
-
-  // Parsed Data: arguments
-  std::string in_filenm;
-  std::string out_filenm;
-  std::string cache_directory;
-
-private:
-  void
-  Ctor();
-
-private:
-  static CmdLineParser::OptArgDesc optArgs[];
-  CmdLineParser parser;
-}; 
-
-#endif // Args_hpp 
+#endif

--- a/src/lib/support/FileUtil.cpp
+++ b/src/lib/support/FileUtil.cpp
@@ -352,8 +352,10 @@ mkdir(const char* dir)
 
     int ret = ::mkdir(x.c_str(), mode);
     if (ret != 0) {
-      DIAG_Throw("[FileUtil::mkdir] '" << pathStr << "': Could not mkdir '"
-		 << x << "' (" << strerror(errno) << ")");
+      if (errno != EEXIST) {
+	DIAG_Throw(pathStr << "': Could not mkdir '"
+		   << x << "' (" << strerror(errno) << ")");
+      }
     }
   }
 

--- a/src/tool/hpcstruct/Args.cpp
+++ b/src/tool/hpcstruct/Args.cpp
@@ -114,6 +114,8 @@ CmdLineParser::OptArgDesc Args::optArgs[] = {
   {  0 ,  "jobs-symtab",  CLP::ARG_REQ,  CLP::DUPOPT_CLOB,  NULL,  NULL },
   {  0 ,  "psize",        CLP::ARG_REQ,  CLP::DUPOPT_CLOB,  NULL,  NULL },
   {  0 ,  "time",         CLP::ARG_NONE, CLP::DUPOPT_CLOB,  NULL,  NULL },
+  { 'c',  "cache",        CLP::ARG_REQ,  CLP::DUPOPT_CLOB,  NULL,  NULL },
+  {  0 ,  "nocache",      CLP::ARG_NONE, CLP::DUPOPT_CLOB,  NULL,  NULL },
 
   // Structure recovery options
   {  0 ,  "gpucfg",       CLP::ARG_REQ,  CLP::DUPOPT_CLOB,  NULL,  NULL },
@@ -291,6 +293,15 @@ Args::parse(int argc, const char* const argv[])
     if (parser.isOpt("psize")) {
       const string & arg = parser.getOptArg("psize");
       parallel_analysis_threshold = CmdLineParser::toLong(arg);
+    }
+
+    if (parser.isOpt("cache")) {
+      const string & arg = parser.getOptArg("cache");
+      cache_directory = arg.c_str();
+    }
+
+    if (parser.isOpt("nocache")) {
+      nocache =  true;
     }
 
     if (parser.isOpt("gpucfg")) {

--- a/src/tool/hpcstruct/Makefile.am
+++ b/src/tool/hpcstruct/Makefile.am
@@ -82,7 +82,7 @@ IGC_LDFLGS = @OPT_IGC_LDFLAGS@
 IGC_IFLAGS = @OPT_IGC_IFLAGS@
 endif
 
-MYSOURCES = main.cpp Args.cpp cache.cpp
+MYSOURCES = main.cpp Args.cpp Structure-Cache.cpp
 
 MYCXXFLAGS = \
 	@HOST_CXXFLAGS@  \

--- a/src/tool/hpcstruct/Makefile.am
+++ b/src/tool/hpcstruct/Makefile.am
@@ -82,7 +82,7 @@ IGC_LDFLGS = @OPT_IGC_LDFLAGS@
 IGC_IFLAGS = @OPT_IGC_IFLAGS@
 endif
 
-MYSOURCES = main.cpp Args.cpp
+MYSOURCES = main.cpp Args.cpp cache.cpp
 
 MYCXXFLAGS = \
 	@HOST_CXXFLAGS@  \

--- a/src/tool/hpcstruct/Makefile.in
+++ b/src/tool/hpcstruct/Makefile.in
@@ -159,7 +159,7 @@ dotgraph_bin_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(dotgraph_bin_CXXFLAGS) \
 	$(CXXFLAGS) $(dotgraph_bin_LDFLAGS) $(LDFLAGS) -o $@
 am__objects_1 = hpcstruct_bin-main.$(OBJEXT) \
-	hpcstruct_bin-Args.$(OBJEXT)
+	hpcstruct_bin-Args.$(OBJEXT) hpcstruct_bin-cache.$(OBJEXT)
 am_hpcstruct_bin_OBJECTS = $(am__objects_1)
 hpcstruct_bin_OBJECTS = $(am_hpcstruct_bin_OBJECTS)
 hpcstruct_bin_DEPENDENCIES = $(am__DEPENDENCIES_3)
@@ -563,7 +563,7 @@ SYMTABAPI_LIB = @SYMTABAPI_LIB@
 SYMTABAPI_LIB_LIST = @SYMTABAPI_LIB_LIST@
 @OPT_ENABLE_IGC_TRUE@IGC_LDFLGS = @OPT_IGC_LDFLAGS@
 @OPT_ENABLE_IGC_TRUE@IGC_IFLAGS = @OPT_IGC_IFLAGS@
-MYSOURCES = main.cpp Args.cpp
+MYSOURCES = main.cpp Args.cpp cache.cpp
 MYCXXFLAGS = @HOST_CXXFLAGS@ $(HPC_IFLAGS) @BINUTILS_IFLAGS@ \
 	$(BOOST_IFLAGS) $(DYNINST_IFLAGS) -I$(LIBELF_INC) \
 	$(IGC_IFLAGS) $(TBB_IFLAGS) $(am__append_1)
@@ -799,6 +799,7 @@ distclean-compile:
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/dotgraph_bin-DotGraph.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hpcstruct_bin-Args.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hpcstruct_bin-cache.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hpcstruct_bin-main.Po@am__quote@
 
 .cpp.o:
@@ -863,6 +864,20 @@ hpcstruct_bin-Args.obj: Args.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='Args.cpp' object='hpcstruct_bin-Args.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-Args.obj `if test -f 'Args.cpp'; then $(CYGPATH_W) 'Args.cpp'; else $(CYGPATH_W) '$(srcdir)/Args.cpp'; fi`
+
+hpcstruct_bin-cache.o: cache.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -MT hpcstruct_bin-cache.o -MD -MP -MF $(DEPDIR)/hpcstruct_bin-cache.Tpo -c -o hpcstruct_bin-cache.o `test -f 'cache.cpp' || echo '$(srcdir)/'`cache.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/hpcstruct_bin-cache.Tpo $(DEPDIR)/hpcstruct_bin-cache.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='cache.cpp' object='hpcstruct_bin-cache.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-cache.o `test -f 'cache.cpp' || echo '$(srcdir)/'`cache.cpp
+
+hpcstruct_bin-cache.obj: cache.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -MT hpcstruct_bin-cache.obj -MD -MP -MF $(DEPDIR)/hpcstruct_bin-cache.Tpo -c -o hpcstruct_bin-cache.obj `if test -f 'cache.cpp'; then $(CYGPATH_W) 'cache.cpp'; else $(CYGPATH_W) '$(srcdir)/cache.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/hpcstruct_bin-cache.Tpo $(DEPDIR)/hpcstruct_bin-cache.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='cache.cpp' object='hpcstruct_bin-cache.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-cache.obj `if test -f 'cache.cpp'; then $(CYGPATH_W) 'cache.cpp'; else $(CYGPATH_W) '$(srcdir)/cache.cpp'; fi`
 
 mostlyclean-libtool:
 	-rm -f *.lo

--- a/src/tool/hpcstruct/Makefile.in
+++ b/src/tool/hpcstruct/Makefile.in
@@ -159,7 +159,8 @@ dotgraph_bin_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(dotgraph_bin_CXXFLAGS) \
 	$(CXXFLAGS) $(dotgraph_bin_LDFLAGS) $(LDFLAGS) -o $@
 am__objects_1 = hpcstruct_bin-main.$(OBJEXT) \
-	hpcstruct_bin-Args.$(OBJEXT) hpcstruct_bin-cache.$(OBJEXT)
+	hpcstruct_bin-Args.$(OBJEXT) \
+	hpcstruct_bin-Structure-Cache.$(OBJEXT)
 am_hpcstruct_bin_OBJECTS = $(am__objects_1)
 hpcstruct_bin_OBJECTS = $(am_hpcstruct_bin_OBJECTS)
 hpcstruct_bin_DEPENDENCIES = $(am__DEPENDENCIES_3)
@@ -563,7 +564,7 @@ SYMTABAPI_LIB = @SYMTABAPI_LIB@
 SYMTABAPI_LIB_LIST = @SYMTABAPI_LIB_LIST@
 @OPT_ENABLE_IGC_TRUE@IGC_LDFLGS = @OPT_IGC_LDFLAGS@
 @OPT_ENABLE_IGC_TRUE@IGC_IFLAGS = @OPT_IGC_IFLAGS@
-MYSOURCES = main.cpp Args.cpp cache.cpp
+MYSOURCES = main.cpp Args.cpp Structure-Cache.cpp
 MYCXXFLAGS = @HOST_CXXFLAGS@ $(HPC_IFLAGS) @BINUTILS_IFLAGS@ \
 	$(BOOST_IFLAGS) $(DYNINST_IFLAGS) -I$(LIBELF_INC) \
 	$(IGC_IFLAGS) $(TBB_IFLAGS) $(am__append_1)
@@ -799,7 +800,7 @@ distclean-compile:
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/dotgraph_bin-DotGraph.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hpcstruct_bin-Args.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hpcstruct_bin-cache.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hpcstruct_bin-Structure-Cache.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hpcstruct_bin-main.Po@am__quote@
 
 .cpp.o:
@@ -865,19 +866,19 @@ hpcstruct_bin-Args.obj: Args.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-Args.obj `if test -f 'Args.cpp'; then $(CYGPATH_W) 'Args.cpp'; else $(CYGPATH_W) '$(srcdir)/Args.cpp'; fi`
 
-hpcstruct_bin-cache.o: cache.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -MT hpcstruct_bin-cache.o -MD -MP -MF $(DEPDIR)/hpcstruct_bin-cache.Tpo -c -o hpcstruct_bin-cache.o `test -f 'cache.cpp' || echo '$(srcdir)/'`cache.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/hpcstruct_bin-cache.Tpo $(DEPDIR)/hpcstruct_bin-cache.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='cache.cpp' object='hpcstruct_bin-cache.o' libtool=no @AMDEPBACKSLASH@
+hpcstruct_bin-Structure-Cache.o: Structure-Cache.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -MT hpcstruct_bin-Structure-Cache.o -MD -MP -MF $(DEPDIR)/hpcstruct_bin-Structure-Cache.Tpo -c -o hpcstruct_bin-Structure-Cache.o `test -f 'Structure-Cache.cpp' || echo '$(srcdir)/'`Structure-Cache.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/hpcstruct_bin-Structure-Cache.Tpo $(DEPDIR)/hpcstruct_bin-Structure-Cache.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='Structure-Cache.cpp' object='hpcstruct_bin-Structure-Cache.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-cache.o `test -f 'cache.cpp' || echo '$(srcdir)/'`cache.cpp
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-Structure-Cache.o `test -f 'Structure-Cache.cpp' || echo '$(srcdir)/'`Structure-Cache.cpp
 
-hpcstruct_bin-cache.obj: cache.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -MT hpcstruct_bin-cache.obj -MD -MP -MF $(DEPDIR)/hpcstruct_bin-cache.Tpo -c -o hpcstruct_bin-cache.obj `if test -f 'cache.cpp'; then $(CYGPATH_W) 'cache.cpp'; else $(CYGPATH_W) '$(srcdir)/cache.cpp'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/hpcstruct_bin-cache.Tpo $(DEPDIR)/hpcstruct_bin-cache.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='cache.cpp' object='hpcstruct_bin-cache.obj' libtool=no @AMDEPBACKSLASH@
+hpcstruct_bin-Structure-Cache.obj: Structure-Cache.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -MT hpcstruct_bin-Structure-Cache.obj -MD -MP -MF $(DEPDIR)/hpcstruct_bin-Structure-Cache.Tpo -c -o hpcstruct_bin-Structure-Cache.obj `if test -f 'Structure-Cache.cpp'; then $(CYGPATH_W) 'Structure-Cache.cpp'; else $(CYGPATH_W) '$(srcdir)/Structure-Cache.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/hpcstruct_bin-Structure-Cache.Tpo $(DEPDIR)/hpcstruct_bin-Structure-Cache.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='Structure-Cache.cpp' object='hpcstruct_bin-Structure-Cache.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-cache.obj `if test -f 'cache.cpp'; then $(CYGPATH_W) 'cache.cpp'; else $(CYGPATH_W) '$(srcdir)/cache.cpp'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(hpcstruct_bin_CXXFLAGS) $(CXXFLAGS) -c -o hpcstruct_bin-Structure-Cache.obj `if test -f 'Structure-Cache.cpp'; then $(CYGPATH_W) 'Structure-Cache.cpp'; else $(CYGPATH_W) '$(srcdir)/Structure-Cache.cpp'; fi`
 
 mostlyclean-libtool:
 	-rm -f *.lo

--- a/src/tool/hpcstruct/Structure-Cache.cpp
+++ b/src/tool/hpcstruct/Structure-Cache.cpp
@@ -47,7 +47,7 @@
 //***************************************************************************
 //
 // File:
-//   cache.cpp
+//   Structure-Cache.cpp
 //
 // Purpose:
 //   functions that support management of a cache for hpcstruct files
@@ -75,7 +75,8 @@
 #include <lib/support/diagnostics.h>
 #include <lib/support/Exception.hpp>
 #include <lib/support/FileUtil.hpp>
-#include "cache.hpp"
+
+#include "Structure-Cache.hpp"
 
 
 
@@ -222,15 +223,38 @@ hpcstruct_cache_hash
 
 
 char *
-hpcstruct_cache_entry
+hpcstruct_cache_flat_directory
 (
  const char *cache_dir,
- const char *binary_abspath,
- const char *hash, // hash for elf file
- const char *kind
+ const char *hash // hash for elf file
 )
 {
   std::string path = cache_dir;
+
+  path += "/FLAT";
+
+  mkpath(path.c_str(), "Failed to create entry in hpcstruct cache directory");
+
+  // compute the full path to the new cache directory
+  path = path + '/' + hash;
+
+  // return the full path for the new cache entry
+  return strdup(path.c_str());
+}
+
+
+char *
+hpcstruct_cache_path_directory
+(
+ const char *cache_dir,
+ const char *binary_abspath,
+ const char *hash // hash for elf file
+)
+{
+  std::string path = cache_dir;
+
+  path += "/PATH";
+
   path += binary_abspath;
 
   // FIXME: catch error
@@ -244,6 +268,36 @@ hpcstruct_cache_entry
 
   // ensure the new cache directory exists
   mkpath(path.c_str(), "Failed to create hpcstruct cache entry");
+
+  // return the full path for the new cache entry
+  return strdup(path.c_str());
+}
+
+
+char *
+hpcstruct_cache_path_link
+(
+ const char *binary_abspath,
+ const char *hash // hash for elf file
+)
+{
+  std::string path = "../PATH";
+
+  path += binary_abspath;
+  path = path + '/' + hash;
+
+  return strdup(path.c_str());
+}
+
+
+char *
+hpcstruct_cache_entry
+(
+ const char *directory,
+ const char *kind
+)
+{
+  std::string path = directory;
 
   // compute the full path for the new cache entry
   path = path + '/' + kind;
@@ -274,8 +328,8 @@ hpcstruct_cache_directory
     // no cache directory specified,
     if (warn) {
       DIAG_MsgIf_GENERIC
-	("ADVICE: ", warn, "Use a structure cache to accelerate analysis of "
-	 "CPU binaries; see the documentation for how.");
+	("ADVICE: ", warn, "See the usage message for how to use "
+	 "a structure cache to accelerate analysis of CPU and GPU binaries");
       warn = false;
     }
     return 0;
@@ -289,7 +343,6 @@ hpcstruct_cache_directory
 
   return strdup(abspath);
 }
-
 
 
 void

--- a/src/tool/hpcstruct/Structure-Cache.hpp
+++ b/src/tool/hpcstruct/Structure-Cache.hpp
@@ -63,12 +63,35 @@
 //***************************************************************************
 
 char *
-hpcstruct_cache_entry
+hpcstruct_cache_path_directory
 (
  const char *cache_dir,
  const char *binary_abspath,
- const char *hash,
+ const char *hash // hash for elf file
+);
+
+
+char *
+hpcstruct_cache_path_link
+(
+ const char *binary_abspath,
+ const char *hash // hash for elf file
+);
+
+
+char *
+hpcstruct_cache_entry
+(
+ const char *directory,
  const char *kind
+);
+
+
+char *
+hpcstruct_cache_flat_directory
+(
+ const char *cache_dir,
+ const char *hash // hash for elf file
 );
 
 

--- a/src/tool/hpcstruct/cache.cpp
+++ b/src/tool/hpcstruct/cache.cpp
@@ -1,0 +1,308 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// $HeadURL$
+// $Id$
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2022, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+//***************************************************************************
+//
+// File:
+//   cache.cpp
+//
+// Purpose:
+//   functions that support management of a cache for hpcstruct files
+//
+//***************************************************************************
+
+//***************************************************************************
+// global includes
+//***************************************************************************
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <linux/limits.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+
+//***************************************************************************
+// local includes
+//***************************************************************************
+
+#include <lib/prof-lean/elf-hash.h>
+#include <lib/support/diagnostics.h>
+#include <lib/support/Exception.hpp>
+#include <lib/support/FileUtil.hpp>
+#include "cache.hpp"
+
+
+
+//***************************************************************************
+// macros
+//***************************************************************************
+
+#define STRUCT_CACHE_DEFAULT "structs-cache"
+#define STRUCT_CACHE_ENV "HPCTOOLKIT_HPCSTRUCT_CACHE"
+
+
+//***************************************************************************
+// local operations
+//***************************************************************************
+
+// return value
+//   1: success
+//   0: failure
+static int
+path_accessible
+(
+ const char *path,
+ int access_flags
+)
+{
+  int status = 0;
+
+  int fd = open(path, access_flags | O_CLOEXEC);
+  if (fd != -1) {
+    status = 1; // found!
+    close(fd); // cleanup
+  }
+
+  return status;
+}
+
+
+static void
+mkpath
+(
+ const char *path,
+ const char *errortype
+)
+{
+  try {
+    FileUtil::mkdir(path);
+  } catch (Diagnostics::FatalException &e) {
+    std::cerr << "ERROR: " << errortype << " - " << e.what() << std::endl;
+    throw e;
+  }
+}
+
+
+// determine if there already exists a different hash entry for a file path
+// 1: cleanup needed
+// 0: no cleanup needed
+static int
+hpcstruct_cache_needs_cleanup
+(
+ std::string path,
+ const char *hash
+)
+{
+  DIR *dir = opendir(path.c_str());
+  for (;;) {
+    struct dirent *d = readdir(dir);
+    if (d == 0) break;
+
+    // ignore "." and ".."
+    if ((strcmp(d->d_name, ".") == 0) ||
+	(strcmp(d->d_name, "..") == 0)) continue;
+
+    if (strcmp(hash, d->d_name) == 0) { // hash present; nothing to do
+      continue;
+    } else {
+      // something else present: cleanup needed
+      closedir(dir);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+
+static int
+hpcstruct_cache_cleanup
+(
+ std::string path,
+ const char *hash
+)
+{
+  int cleanup = hpcstruct_cache_needs_cleanup(path, hash);
+  if (cleanup) {
+    std::string command("rm -rf ");
+    command += path;
+    system(command.c_str());
+    mkpath(path.c_str(), "Failed to clean up hpcstruct cache directory");
+  }
+
+  return 0;
+}
+
+bool no_cache(const char *cache_dir)
+{
+  return cache_dir == 0 || *cache_dir == 0;
+}
+
+
+
+//***************************************************************************
+// interface operations
+//***************************************************************************
+
+bool
+hpcstruct_cache_find
+(
+ const char *cached_entry
+)
+{
+  return path_accessible(cached_entry, O_RDONLY);
+}
+
+
+
+bool
+hpcstruct_cache_writable
+(
+ const char *cache_dir
+)
+{
+  return access(cache_dir, O_RDWR) == 0;
+}
+
+
+char *
+hpcstruct_cache_entry
+(
+ const char *cache_dir,
+ const char *binary_abspath,
+ const char *kind
+)
+{
+  std::string path = cache_dir;
+  path += binary_abspath;
+
+  // FIXME: catch error
+  mkpath(path.c_str(), "Failed to create entry in hpcstruct cache directory");
+
+  // compute hash for elf file
+  char *eh  = elf_hash(binary_abspath);
+
+  // discard any prior entries for path with a different hash 
+  hpcstruct_cache_cleanup(path.c_str(), eh);
+
+  // compute the full path to the new cache directory
+  path = path + '/' + eh;
+  free(eh);
+
+  // ensure the new cache directory exists
+  mkpath(path.c_str(), "Failed to create hpcstruct cache entry");
+
+  // compute the full path for the new cache entry
+  path = path + '/' + kind;
+
+  // return the full path for the new cache entry
+  return strdup(path.c_str());
+}
+
+
+char *
+hpcstruct_cache_directory
+(
+ const char *cache_dir,
+ const char *kind
+) 
+{
+  static bool warn = true;
+  char abspath[PATH_MAX];
+
+  if (no_cache(cache_dir)) {
+    // cache directory is not explicit: consider environment variable value
+    cache_dir = getenv(STRUCT_CACHE_ENV);
+    if (no_cache(cache_dir)) cache_dir = 0;
+  }
+  // invariant: if cache_dir was NULL or empty, it is now NULL
+
+  if (cache_dir == 0) {
+    // no cache directory specified,
+    if (warn) {
+      DIAG_MsgIf_GENERIC
+	("ADVICE: ", warn, "Use a structure cache to accelerate analysis of "
+	 "CPU binaries; see the documentation for how.");
+      warn = false;
+    }
+    return 0;
+  } else {
+    realpath(cache_dir, abspath);
+  }
+
+  strcat(abspath, kind);
+    
+  mkpath(abspath, "Failed to create hpcstruct cache directory");
+
+  return strdup(abspath);
+}
+
+
+
+void
+hpcstruct_reify_path
+(
+ const char *path
+)
+{
+  mkpath(path, "Failed to create hpcstruct output directory");
+}
+
+
+void
+hpcstruct_reify_path_parent
+(
+ const char *path
+)
+{
+  std::string outpath = path;
+  size_t pos = outpath.find_last_of("/");
+  if (pos != std::string::npos) {
+    hpcstruct_reify_path(outpath.substr(0, pos).c_str());
+  }
+}

--- a/src/tool/hpcstruct/cache.cpp
+++ b/src/tool/hpcstruct/cache.cpp
@@ -211,10 +211,22 @@ hpcstruct_cache_writable
 
 
 char *
+hpcstruct_cache_hash
+(
+ const char *binary_abspath
+)
+{
+  char *eh  = elf_hash(binary_abspath);
+  return eh;
+}
+
+
+char *
 hpcstruct_cache_entry
 (
  const char *cache_dir,
  const char *binary_abspath,
+ const char *hash, // hash for elf file
  const char *kind
 )
 {
@@ -224,15 +236,11 @@ hpcstruct_cache_entry
   // FIXME: catch error
   mkpath(path.c_str(), "Failed to create entry in hpcstruct cache directory");
 
-  // compute hash for elf file
-  char *eh  = elf_hash(binary_abspath);
-
   // discard any prior entries for path with a different hash 
-  hpcstruct_cache_cleanup(path.c_str(), eh);
+  hpcstruct_cache_cleanup(path.c_str(), hash);
 
   // compute the full path to the new cache directory
-  path = path + '/' + eh;
-  free(eh);
+  path = path + '/' + hash;
 
   // ensure the new cache directory exists
   mkpath(path.c_str(), "Failed to create hpcstruct cache entry");

--- a/src/tool/hpcstruct/cache.hpp
+++ b/src/tool/hpcstruct/cache.hpp
@@ -67,6 +67,7 @@ hpcstruct_cache_entry
 (
  const char *cache_dir,
  const char *binary_abspath,
+ const char *hash,
  const char *kind
 );
 
@@ -83,6 +84,13 @@ bool
 hpcstruct_cache_find
 (
  const char *cached_entry
+);
+
+
+char *
+hpcstruct_cache_hash
+(
+ const char *binary_abspath
 );
 
 

--- a/src/tool/hpcstruct/cache.hpp
+++ b/src/tool/hpcstruct/cache.hpp
@@ -1,4 +1,4 @@
-// -*-Mode: C++;-*-
+// -*-Mode: C++;-*- // technically C99
 
 // * BeginRiceCopyright *****************************************************
 //
@@ -12,7 +12,7 @@
 // HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
 // --------------------------------------------------------------------------
 //
-// Copyright ((c)) 2002-2022, Rice University
+// Copyright ((c)) 2002-2021, Rice University
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -47,99 +47,64 @@
 //***************************************************************************
 //
 // File:
-//   $HeadURL$
+//   cache.c
 //
 // Purpose:
-//   [The purpose of this file]
-//
-// Description:
-//   [The set of functions, macros, etc. defined in the file]
+//   functions that support management of a cache for hpcstruct files
 //
 //***************************************************************************
 
-#ifndef Args_hpp
-#define Args_hpp
+#ifndef hpcstruct_cache_hpp
+#define hpcstruct_cache_hpp
 
-//************************* System Include Files ****************************
-
-#include <iostream>
-#include <string>
-
-//*************************** User Include Files ****************************
-
-#include <include/uint.h>
-#include <lib/support/CmdLineParser.hpp>
-
-//*************************** Forward Declarations **************************
 
 //***************************************************************************
+// interface operations
+//***************************************************************************
 
-class Args {
-public: 
-  Args(); 
-  Args(int argc, const char* const argv[]);
-  ~Args(); 
+char *
+hpcstruct_cache_entry
+(
+ const char *cache_dir,
+ const char *binary_abspath,
+ const char *kind
+);
 
-  // Parse the command line
-  void
-  parse(int argc, const char* const argv[]);
 
-  // Version and Usage information
-  void
-  printVersion(std::ostream& os) const;
+char *
+hpcstruct_cache_directory
+(
+ const char *cache_dir,
+ const char *kind
+); 
 
-  void
-  printUsage(std::ostream& os) const;
-  
-  // Error
-  void
-  printError(std::ostream& os, const char* msg) const;
 
-  void
-  printError(std::ostream& os, const std::string& msg) const;
+bool
+hpcstruct_cache_find
+(
+ const char *cached_entry
+);
 
-  // Dump
-  void
-  dump(std::ostream& os = std::cerr) const;
 
-  void
-  ddump() const;
+bool
+hpcstruct_cache_writable
+(
+ const char *cache_dir
+);
 
-public:
-  // Parsed Data: Command
-  const std::string& getCmd() const;
 
-  int jobs;
-  int jobs_struct;
-  int jobs_parse;
-  int jobs_symtab;
-  bool show_time;
-  long parallel_analysis_threshold; 
-  bool analyze_cpu_binaries ;     // default: true
-  bool analyze_gpu_binaries ;     // default: true
-  bool compute_gpu_cfg;
+void
+hpcstruct_reify_path
+(
+ const char *path
+);
 
-  // Parsed Data: optional arguments
-  std::string searchPathStr;          // default: "."
-  std::string dbgProcGlob;
 
-  bool prettyPrintOutput;         // default: true
-  bool useBinutils;		  // default: false
-  bool show_gaps;                 // default: false
-  bool nocache;                   // default: false
+void
+hpcstruct_reify_path_parent
+(
+ const char *path
+);
 
-  // Parsed Data: arguments
-  std::string in_filenm;
-  std::string out_filenm;
-  std::string cache_directory;
 
-private:
-  void
-  Ctor();
-
-private:
-  static CmdLineParser::OptArgDesc optArgs[];
-  CmdLineParser parser;
-}; 
-
-#endif // Args_hpp 
+#endif

--- a/src/tool/hpcstruct/main.cpp
+++ b/src/tool/hpcstruct/main.cpp
@@ -265,11 +265,11 @@ public:
   FileOutputStream() : stream(0), buffer(0), use_cache(false),
 		       is_cached(false) {};
   void init(const char *cache_directory, const char *binary_abspath,
-	    const char *kind, const char *result) {
+	    const char *hash, const char *kind, const char *result) {
     name = strdup(result);
     if (cache_directory && cache_directory[0] != 0) {
       use_cache = true;
-      stream_name = hpcstruct_cache_entry(cache_directory, binary_abspath, kind);
+      stream_name = hpcstruct_cache_entry(cache_directory, binary_abspath, hash, kind);
     } else {
       stream_name = name;
     }
@@ -344,13 +344,15 @@ singleApplicationBinary
   FileOutputStream gaps;
   FileOutputStream hpcstruct;
 
-  hpcstruct.init(cache_directory.c_str(), binary_abspath.c_str(), "hpcstruct",
+  char *hash = hpcstruct_cache_hash(binary_abspath.c_str()); 
+  
+  hpcstruct.init(cache_directory.c_str(), binary_abspath.c_str(), hash, "hpcstruct",
 		 hpcstruct_path.c_str());
 
   if (args.show_gaps) {
     std::string gaps_path =
       std::string(hpcstruct_path) + std::string(".gaps");
-    gaps.init(cache_directory.c_str(), binary_abspath.c_str(), "gaps",
+    gaps.init(cache_directory.c_str(), binary_abspath.c_str(), hash, "gaps",
 	      gaps_path.c_str());
   }
 

--- a/src/tool/hpcstruct/pmake.txt
+++ b/src/tool/hpcstruct/pmake.txt
@@ -47,6 +47,16 @@ endif
 #*******************************************************************************
 
 #*******************************************************************************
+# use a measurement cache, if available
+#*******************************************************************************
+ifneq ($(CACHE),"")
+CACHE_ARGS = -c $(CACHE)
+else
+CACHE_ARGS = --nocache
+endif
+
+
+#*******************************************************************************
 # enable analysis of CPU binaries
 #*******************************************************************************
 ifeq ($(CPU_ANALYZE),1)
@@ -118,7 +128,7 @@ $(STRUCTS_DIR)/%.hpcstruct: $(CPUBIN_DIR)/%
 		else
 			echo msg: begin concurrent analysis of $$cpubin_name \\(size = $$nbytes, using 1 of $(JOBS) threads\\)
 		fi
-		$(STRUCT) -j $(THREADS) -o $$struct_name $< > $$warn_name 2>&1
+		$(STRUCT) $(CACHE_ARGS) -j $(THREADS) -o $$struct_name $< > $$warn_name 2>&1
 		if test -s $$warn_name ; then
 			echo WARNING: incomplete analysis of $$cpubin_name';' see $$warn_name for details
 			if test ! -s $$struct_name ; then
@@ -152,7 +162,7 @@ $(STRUCTS_DIR)/%.hpcstruct: $(GPUBIN_DIR)/%
 		else
 			echo msg: begin concurrent analysis of $$gpubin_name \\(size = $$nbytes, using 1 of $(JOBS) threads\\)
 		fi
-		$(STRUCT) -j $(THREADS) --gpucfg $(GPUBIN_CFG) -o $$struct_name $< > $$warn_name 2>&1
+		$(STRUCT) $(CACHE_ARGS) -j $(THREADS) --gpucfg $(GPUBIN_CFG) -o $$struct_name $< > $$warn_name 2>&1
 		if test -s $$warn_name ; then
 			echo WARNING: incomplete analysis of $$gpubin_name';' see $$warn_name for details
 			if test ! -s $$struct_name ; then

--- a/src/tool/hpcstruct/usage.txt
+++ b/src/tool/hpcstruct/usage.txt
@@ -35,6 +35,16 @@ Options: General
   -V, --version        Print version information.
   -h, --help           Print this help message.
 
+Options: Control caching of structure files
+  -c <dir>, --cache <dir> Specify that structure files for CPU and GPU
+                       binaries should be cached and reused in
+		       directory <dir>. Overrides any default setting in
+		       the HPCTOOLKIT_HPCSTRUCT_CACHE environment variable.
+  --nocache            Specify that a structure cache should not be used, 
+                       even if the HPCTOOLKIT_HPCSTRUCT_CACHE environment
+		       variable is set. With this option, advice to use
+                       a structure cache will be suppressed.
+
 Options: Override parallelism defaults
   -j <num>, --jobs <num> Use <num> threads for for concurrent analysis of
                        small binaries. Use <num> threads for parallel
@@ -53,6 +63,7 @@ Options: Override structure recovery defaults
                        Loop nesting structure is only useful with
                        instruction-level measurements collected using PC
                        sampling or instrumentation. {no} 
+
 
 Options: Specify output file when analyzing a single binary
   -o <file>, --output <file>


### PR DESCRIPTION
Cache binary analysis results of CPU and GPU binaries.

Currently, the cache can record hpcstruct files and gaps files. Some refactoring of the API will enable it to hold other kinds of analysis results, e.g. dataflow analysis results for GPU binaries.