### PR TITLE
Cleanup SparseDB

### DIFF
--- a/src/lib/profile/accumulators.hpp
+++ b/src/lib/profile/accumulators.hpp
@@ -98,16 +98,20 @@ private:
   using base = std::bitset<3>;
   MetricScopeSet(const base& b) : base(b) {};
 public:
-  MetricScopeSet() = default;
-  MetricScopeSet(MetricScope s) : base(1<<static_cast<size_t>(s)) {};
+  using int_type = uint8_t;
+  constexpr MetricScopeSet() = default;
+  constexpr MetricScopeSet(MetricScope s) : base(1<<static_cast<size_t>(s)) {};
   MetricScopeSet(std::initializer_list<MetricScope> l) : base(0) {
     for(const auto s: l) base::set(static_cast<size_t>(s));
   }
+  explicit constexpr MetricScopeSet(int_type val) : base(val) {};
 
   static inline constexpr struct all_t {} all = {};
-  MetricScopeSet(all_t) : base(0) { base::set(); }
+  constexpr MetricScopeSet(all_t)
+    : base(std::numeric_limits<unsigned long long>::max()) {}
 
   bool has(MetricScope s) const noexcept { return base::operator[](static_cast<size_t>(s)); }
+  auto operator[](MetricScope s) noexcept { return base::operator[](static_cast<size_t>(s)); }
 
   MetricScopeSet operator|(const MetricScopeSet& o) { return (base)*this | (base)o; }
   MetricScopeSet operator+(const MetricScopeSet& o) { return (base)*this | (base)o; }
@@ -115,6 +119,10 @@ public:
   MetricScopeSet& operator|=(const MetricScopeSet& o) { base::operator|=(o); return *this; }
   MetricScopeSet& operator+=(const MetricScopeSet& o) { base::operator|=(o); return *this; }
   MetricScopeSet& operator&=(const MetricScopeSet& o) { base::operator&=(o); return *this; }
+  bool operator==(const MetricScopeSet& o) { return base::operator==(o); }
+  bool operator!=(const MetricScopeSet& o) { return base::operator!=(o); }
+
+  int_type toInt() const noexcept { return base::to_ullong(); }
 
   using base::count;
 
@@ -158,7 +166,7 @@ public:
     const_iterator it;
     it.set = this;
     it.scope = static_cast<MetricScope>(0);
-    if(!operator[](0)) ++it;
+    if(!base::operator[](0)) ++it;
     return it;
   }
   const_iterator end() const { return {}; }
@@ -178,12 +186,13 @@ public:
   // MT: Internally Synchronized
   void add(double) noexcept;
 
-  /// Get the Thread-local (:Sum) Statistic accumulation, for a particular Metric Scope.
+  /// Get the Thread-local sum of Metric value, for a particular Metric Scope.
   // MT: Safe (const), Unstable (before ThreadFinal wavefront)
   std::optional<double> get(MetricScope) const noexcept;
 
 private:
   void validate() const noexcept;
+  MetricScopeSet getNonZero() const noexcept;
 
   friend class PerThreadTemporary;
   std::atomic<double> point;
@@ -368,14 +377,65 @@ public:
 
   /// Access the Statistics data attributed to this Context
   // MT: Safe (const), Unstable (before `metrics` wavefront)
-  const auto& statistics() const noexcept { return stats; }
+  const auto& statistics() const noexcept { return m_statistics; }
+
+  /// Access the Statistics data for a particular Metric, attributed to this Context
+  // MT: Internally Synchronized
+  StatisticAccumulator& statisticsFor(const Metric& m) noexcept;
+
+  /// Helper wrapper to allow a MetricScopeSet to be atomically modified.
+  /// Used for the metricUsage() data.
+  class AtomicMetricScopeSet final {
+  public:
+    AtomicMetricScopeSet() : val(MetricScopeSet().toInt()) {}
+    ~AtomicMetricScopeSet() = default;
+
+    AtomicMetricScopeSet(const AtomicMetricScopeSet&) = delete;
+    AtomicMetricScopeSet(AtomicMetricScopeSet&&) = delete;
+    AtomicMetricScopeSet& operator=(const AtomicMetricScopeSet&) = delete;
+    AtomicMetricScopeSet& operator=(AtomicMetricScopeSet&&) = delete;
+
+    /// Union the given MetricScopeSet into this atomic set
+    // MT: Internally Synchronized
+    AtomicMetricScopeSet& operator|=(MetricScopeSet ms) noexcept {
+      val.fetch_or(ms.toInt(), std::memory_order_relaxed);
+      return *this;
+    }
+
+    /// Load the current value of the MetricScopeSet
+    // MT: Safe (const), Unstable (before `metrics` wavefront)
+    MetricScopeSet get() const noexcept {
+      return MetricScopeSet(val.load(std::memory_order_relaxed));
+    }
+    operator MetricScopeSet() const noexcept { return get(); }
+
+  private:
+    std::atomic<MetricScopeSet::int_type> val;
+  };
+
+  /// Access the use of this Context in Metric values
+  // MT: Safe (const), Unstable (before `metrics` wavefront)
+  const auto& metricUsage() const noexcept { return m_metricUsage; }
+
+  /// Get the use of this Context for a particular Metric.
+  // MT: Safe (const), Unstable (before `metrics` wavefront)
+  MetricScopeSet metricUsageFor(const Metric& m) const noexcept {
+    if(auto use = m_metricUsage.find(m)) return use->get();
+    return {};
+  }
+
+  /// Mark this Context as having been used for the given Metric values
+  // MT: Internally Synchronized
+  void markUsed(const Metric& m, MetricScopeSet ms) noexcept;
 
 private:
   friend class PerThreadTemporary;
   friend class Metric;
   friend class ProfilePipeline;
   util::locked_unordered_map<util::reference_index<const Metric>,
-    StatisticAccumulator> stats;
+    StatisticAccumulator> m_statistics;
+  util::locked_unordered_map<util::reference_index<const Metric>,
+    AtomicMetricScopeSet> m_metricUsage;
 };
 
 }  // namespace hpctoolkit

--- a/src/lib/profile/context.hpp
+++ b/src/lib/profile/context.hpp
@@ -101,9 +101,10 @@ public:
   // MT: See ragged_vector.
   mutable ud_t userdata;
 
-  /// Access the Statistics data attributed to this Context
-  // MT: Safe (const), Unstable (before `metrics` wavefront)
+  /// Access this Context's per-Context data.
+  // MT: Internally Synchronized, Unstable (before `metrics` wavefront)
   const auto& data() const noexcept { return m_data; }
+  auto& data() noexcept { return m_data; }
 
   /// Iterate over the Context sub-tree rooted at this Context. The given
   /// functions are called before and after every Context.

--- a/src/lib/profile/pipeline.cpp
+++ b/src/lib/profile/pipeline.cpp
@@ -760,19 +760,6 @@ void Source::AccumulatorsRef::add(Metric& m, double v) {
   map[m].add(v);
 }
 
-Source::StatisticsRef Source::accumulateTo(Context& c) {
-  assert(limit().hasMetrics() && "Source did not register for `metrics` emission!");
-  return StatisticsRef(c);
-}
-
-void Source::StatisticsRef::add(Metric& m, const StatisticPartial& sp,
-                                MetricScope ms, double v) {
-  auto& a = ctx.m_data.stats.emplace(std::piecewise_construct,
-                                     std::forward_as_tuple(m),
-                                     std::forward_as_tuple(m)).first;
-  a.get(sp).add(ms, v);
-}
-
 Thread& Source::newThread(ThreadAttributes o) {
   o.finalize(pipe->threadAttrFinalizeState);
   auto& t = *pipe->threads.emplace(new Thread(pipe->structs.thread, o)).first;

--- a/src/lib/profile/pipeline.hpp
+++ b/src/lib/profile/pipeline.hpp
@@ -476,27 +476,6 @@ public:
     AccumulatorsRef accumulateTo(PerThreadTemporary&, uint64_t group,
                                  ContextFlowGraph&);
 
-    /// Reference to the Statistic data for a particular Context.
-    /// Allows for efficient emmission of multiple Statistics' data to one location.
-    class StatisticsRef final {
-    public:
-      StatisticsRef() = delete;
-
-      /// Emit Partial value into the Pipeline, for the given MetricScope.
-      // MT: Externally Synchronized (this, Source), Internally Synchronized
-      void add(Metric& m, const StatisticPartial& sp, MetricScope ms, double v);
-
-    private:
-      friend class ProfilePipeline::Source;
-      Context& ctx;
-      explicit StatisticsRef(Context& ctx) : ctx(ctx) {};
-    };
-
-    /// Obtain a StatisticsRef for the given Context.
-    /// DataClass: `metrics`
-    // MT: Externally Synchronized (this), Internally Synchronized
-    StatisticsRef accumulateTo(Context& c);
-
     // Disable copy-assignment, and allow move assignment.
     Source& operator=(const Source&) = delete;
     Source& operator=(Source&&);

--- a/src/lib/profile/sinks/packed.cpp
+++ b/src/lib/profile/sinks/packed.cpp
@@ -225,8 +225,7 @@ void Packed::packMetrics(std::vector<std::uint8_t>& out) noexcept {
 }
 
 ParallelPacked::ParallelPacked(bool doContexts, bool doMetrics)
-    : doContexts(doContexts), doMetrics(doMetrics), ctxCnt(0),
-      fePackMetrics([this](auto& group){ packMetricGroup(group); }) {}
+    : doContexts(doContexts), doMetrics(doMetrics), ctxCnt(0) {}
 
 void ParallelPacked::notifyPipeline() noexcept {
   if(doContexts || doMetrics) {
@@ -272,7 +271,8 @@ void ParallelPacked::packMetrics(std::vector<std::uint8_t>& out) noexcept {
     prev += sz;
   }
 
-  fePackMetrics.fill(std::move(workitems));
+  fePackMetrics.fill(std::move(workitems),
+                     [this](auto& group){ packMetricGroup(group); });
   packMetricsGroups.clear();
   fePackMetrics.contribute(fePackMetrics.wait());
   output = nullptr;

--- a/src/lib/profile/sinks/packed.cpp
+++ b/src/lib/profile/sinks/packed.cpp
@@ -65,6 +65,10 @@ static void pack(std::vector<std::uint8_t>& out, const std::string& s) noexcept 
 static void pack(std::vector<std::uint8_t>& out, const std::uint8_t v) noexcept {
   out.push_back(v);
 }
+static std::uint8_t* pack(std::uint8_t* out, const std::uint8_t v) noexcept {
+  *out = v;
+  return ++out;
+}
 static void pack(std::vector<std::uint8_t>& out, const std::uint16_t v) noexcept {
   // Little-endian order. Just in case the compiler can optimize it away.
   for(int shift = 0; shift < 16; shift += 8)
@@ -204,6 +208,8 @@ void Packed::packMetrics(std::vector<std::uint8_t>& out) noexcept {
   src.contexts().citerate([&](const Context& c){
     pack(out, (std::uint64_t)c.userdata[src.identifier()]);
     for(const Metric& m: metrics) {
+      pack(out, c.data().metricUsageFor(m).toInt());
+
       for(const auto& p: m.partials()) {
         if(auto v = m.getFor(c)) {
           pack(out, (double)v->get(p).get(MetricScope::point).value_or(0));
@@ -287,6 +293,8 @@ void ParallelPacked::packMetricGroup(std::pair<std::size_t, std::vector<std::ref
   for(const Context& c: std::move(task.second)) {
     out = pack(out, (std::uint64_t)c.userdata[src.identifier()]);
     for(const Metric& m: metrics) {
+      out = pack(out, c.data().metricUsageFor(m).toInt());
+
       for(const auto& p: m.partials()) {
         if(auto v = m.getFor(c)) {
           out = pack(out, (double)v->get(p).get(MetricScope::point).value_or(0));

--- a/src/lib/profile/sinks/sparsedb.cpp
+++ b/src/lib/profile/sinks/sparsedb.cpp
@@ -1550,12 +1550,11 @@ uint32_t SparseDB::ctxGrpIdFetch()
 
 void SparseDB::rwAllCtxGroup()
 {
-  uint32_t idx = rank - 1;
+  uint32_t idx = rank > 0 ? rank - 1 : ctxGrpIdFetch();
   uint32_t num_groups = ctx_group_list.size();
   std::vector<uint32_t> ctx_ids;
 
   while(idx < num_groups - 1){
-    if(idx == (uint32_t)-1) idx = ctxGrpIdFetch();// check if there is any group left for rank 0
     ctx_ids.clear();
     auto& start_id = ctx_group_list[idx];
     auto& end_id = ctx_group_list[idx + 1];

--- a/src/lib/profile/sinks/sparsedb.hpp
+++ b/src/lib/profile/sinks/sparsedb.hpp
@@ -92,252 +92,111 @@ public:
   void notifyWavefront(hpctoolkit::DataClass) noexcept override;
   void notifyThreadFinal(const hpctoolkit::PerThreadTemporary&) override;
 
-  void cctdbSetUp();
-  void writeCCTDB();
-  void merge(int threads, bool debug);
-
-
-
-  //***************************************************************************
-  // Work with bytes
-  //***************************************************************************
-  void writeAsByte4(uint32_t val, hpctoolkit::util::File::Instance& fh, uint64_t off);
-  void writeAsByte8(uint64_t val, hpctoolkit::util::File::Instance& fh, uint64_t off);
-  uint32_t readAsByte4(hpctoolkit::util::File::Instance& fh, uint64_t off);
-  uint64_t readAsByte8(hpctoolkit::util::File::Instance& fh, uint64_t off);
-  uint16_t interpretByte2(const char *input);
-  uint32_t interpretByte4(const char *input);
-  uint64_t interpretByte8(const char *input);
-  std::vector<char> convertToByte2(uint16_t val);
-  std::vector<char> convertToByte4(uint32_t val);
-  std::vector<char> convertToByte8(uint64_t val);
-
-
 private:
-  //***************************************************************************
-  // general
-  //***************************************************************************
-  #define MULTIPLE_8(v) ((v + 7) & ~7)
-
-  hpctoolkit::stdshim::filesystem::path dir;
-  int team_size;
-  size_t rank;
-
-  std::size_t ctxcnt;
-  std::vector<std::reference_wrapper<const hpctoolkit::Context>> contexts;
-  unsigned int ctxMaxId;
-  hpctoolkit::util::Once contextWavefront;
-
-  //local exscan over a vector of T, value after exscan will be stored in the original vector
-  template<typename T> void exscan(std::vector<T>& data);
-
-  //binary search over a vector of T, unlike std::binary_search, which only returns true/false,
-  //this returns the idx of found one, SPARSE_ERR as NOT FOUND
-  template <typename T, typename MemberT>
-  int struct_member_binary_search(const std::vector<T>& datas, const T target, const MemberT target_type, const int length);
-
-
-  //***************************************************************************
-  // profile.db
-  //***************************************************************************
-  #define IDTUPLE_SUMMARY_LENGTH        1
-  #define IDTUPLE_SUMMARY_PROF_INFO_IDX 0
-  #define IDTUPLE_SUMMARY_IDX           0 //kind 0 idx 0
-
-  std::optional<hpctoolkit::util::File> pmf;
-
-  //hdr
-  uint64_t id_tuples_sec_size;
-  uint64_t id_tuples_sec_ptr;
-  uint64_t prof_info_sec_size;
-  uint64_t prof_info_sec_ptr;
-
-  void writePMSHdr(const uint32_t total_num_prof, const hpctoolkit::util::File& fh);
-
-  //id tuples
-  std::vector<char> convertTuple2Bytes(const id_tuple_t& tuple);
-  void writeIdTuples(std::vector<id_tuple_t>& id_tuples, uint64_t my_offset);
-  void workIdTuplesSection();
-
-  //prof info
-  std::vector<uint64_t> id_tuple_ptrs;
-  uint32_t min_prof_info_idx;
-  std::vector<pms_profile_info_t> prof_infos;
-  hpctoolkit::util::ParallelForEach<pms_profile_info_t> parForPi;
-
-  void setMinProfInfoIdx(const int total_num_prof);
-  void handleItemPi(pms_profile_info_t& pi);
-  void writeProfInfos();
-
-  //help write profiles in notifyWavefront, notifyThreadFinal, write
-  uint64_t fpos; // keep track of the real file cursor
-  hpctoolkit::mpi::SharedAccumulator accFpos;
-
-  struct OutBuffer{
-    std::vector<char> buf;
-    size_t cur_pos;
-    std::vector<uint32_t> buffered_pidxs;
-    std::mutex mtx;
+  struct udContext {
+    std::atomic<uint64_t> nValues = 0;
+    uint16_t nMetrics = 0;
   };
-  std::vector<OutBuffer> obuffers; //profiles in binary form waiting to be written
-  int cur_obuf_idx;
-  std::mutex outputs_l;
-
-  //help collect cct major data
-  std::vector<uint64_t> ctx_nzval_cnts;
-  std::vector<uint16_t> ctx_nzmids_cnts;
-
-  class udContext {
-  public:
-    udContext(const hpctoolkit::Context&, SparseDB&) : cnt(0) {};
-    ~udContext() = default;
-
-    std::atomic<uint64_t> cnt;
+  struct udThread {
+    pms_profile_info_t info = {
+      .metadata_ptr = 0, .spare_one = 0, .spare_two = 0,
+    };
   };
-
-  struct{
+  struct {
     hpctoolkit::Context::ud_t::typed_member_t<udContext> context;
     const auto& operator()(hpctoolkit::Context::ud_t&) const noexcept { return context; }
+    hpctoolkit::Thread::ud_t::typed_member_t<udThread> thread;
+    const auto& operator()(hpctoolkit::Thread::ud_t&) const noexcept { return thread; }
   } ud;
 
-  //write profiles
-  std::vector<char> profBytes(hpcrun_fmt_sparse_metrics_t* sm);
-  uint64_t filePosFetchOp(uint64_t val);
-  void flushOutBuffer(uint64_t wrt_off, OutBuffer& ob);
-  uint64_t writeProf(const std::vector<char>& prof_bytes, uint32_t prof_info_idx);
+  // Once that signals when the Contexts/Threads wavefront has passed
+  hpctoolkit::util::Once wavefrontDone;
 
+  // Double-buffered concurrent output for profile data, synchronized across
+  // multiple MPI ranks.
+  class DoubleBufferedOutput {
+  public:
+    DoubleBufferedOutput();
+    ~DoubleBufferedOutput() = default;
 
-  //***************************************************************************
-  // cct.db
-  //***************************************************************************
-  #define SPARSE_NOT_FOUND -1
-  #define SPARSE_END       -2
+    DoubleBufferedOutput(DoubleBufferedOutput&&) = delete;
+    DoubleBufferedOutput(const DoubleBufferedOutput&) = delete;
+    DoubleBufferedOutput& operator=(DoubleBufferedOutput&&) = delete;
+    DoubleBufferedOutput& operator=(const DoubleBufferedOutput&) = delete;
 
+    // Set the output File and the offset data written this way should start at
+    // MT: Externally Synchronized
+    void initialize(util::File& outfile, uint64_t startOffset);
+
+    // Allocate some space in the file for the given number of bytes, and return
+    // the final offset for this space.
+    // MT: Internally Synchronized
+    uint64_t allocate(uint64_t size);
+
+    // Write a new blob of profile data into the buffer, obtained by
+    // concatinating the two given blobs. The final offset of the blob will be
+    // saved to `offset` after flush() has been called.
+    // MT: Internally Synchronized
+    void write(const std::vector<char>& mvBlob, const std::vector<char>& ciBlob,
+               uint64_t& offset);
+
+    // Flush the buffers and write everything out to the file.
+    // MT: Internally Synchronized
+    void flush();
+
+  private:
+    // Counter for offsets within the file itself
+    mpi::SharedAccumulator pos;
+    // File everything gets written to in the end
+    util::optional_ref<util::File> file;
+
+    // Lock for the top-level internal state
+    std::mutex toplock;
+    // Index of the current Buffer to write new data to
+    int currentBuf = 0;
+
+    struct Buffer {
+      static constexpr size_t bufferSize = 64 * 1024 * 1024;  // 64MiB
+      Buffer() { blob.reserve(bufferSize); }
+
+      // Lock for per-Buffer state
+      std::mutex lowlock;
+      // Blob of buffered data to write out on flush
+      std::vector<char> blob;
+      // Offsets to update once this Buffer is flushed
+      std::vector<std::reference_wrapper<uint64_t>> toUpdate;
+
+      // Flush this Buffer's data to the given File.
+      // MT: Externally Synchronized (holding lowlock)
+      void flush(util::File& file, uint64_t offset);
+    };
+
+    // Buffers to rotate between for parallelism
+    std::array<Buffer, 2> bufs;
+  } profDataOut;
+
+  // Paths and Files
+  std::optional<hpctoolkit::util::File> pmf;
   std::optional<hpctoolkit::util::File> cmf;
 
-  // ctx offsets
-  std::vector<uint64_t> ctx_off;
+  // All the contexts we know about, sorted by identifier.
+  // Filled during the Contexts wavefront
+  std::deque<std::reference_wrapper<const hpctoolkit::Context>> contexts;
 
-  void setCtxOffsets();
-  void updateCtxOffsets();
-
-  // hdr
-  void writeCMSHdr();
-
-  // ctx info
-  std::vector<char> ctxInfoBytes(const cms_ctx_info_t& ctx_info);
-  void writeCtxInfoSec();
-
-  // helper - gather prof infos
-  std::vector<pms_profile_info_t> prof_info_list;
-
-  pms_profile_info_t profInfo(const char *input);
-  void fillProfInfoList();
-
-  // helper - gather ctx id idx pairs
-  struct PMS_CtxIdIdxPair{
-    uint32_t ctx_id;  // = cct node id
-    uint64_t ctx_idx; //starting location of the context's values in value array
-  };
-  struct profCtxIdIdxPairs{
-    std::vector<PMS_CtxIdIdxPair> * prof_ctx_pairs;
-    pms_profile_info_t * pi;
-  };
-  hpctoolkit::util::ParallelForEach<profCtxIdIdxPairs> parForCiip;
-  std::vector<std::vector<SparseDB::PMS_CtxIdIdxPair>> all_prof_ctx_pairs;
-
-  PMS_CtxIdIdxPair ctxIdIdxPair(const char *input);
-  void handleItemCiip(profCtxIdIdxPairs& ciip);
-  void fillAllProfileCtxIdIdxPairs();
-
-
-  // helper - extract one profile data
-  struct profData{
-    std::vector<std::pair<std::vector<std::pair<uint32_t,uint64_t>>, std::vector<char>>> * profiles_data; //ptr to the destination
-    std::vector<pms_profile_info_t> * pi_list;
-    std::vector<std::vector<PMS_CtxIdIdxPair>> * all_prof_ctx_pairs;
-    std::vector<uint32_t> * ctx_ids;
-    uint i;
-  };
-  hpctoolkit::util::ResettableParallelForEach<profData> parForPd;
-
-  int findOneCtxIdIdxPair(const uint32_t target_ctx_id,
-                          const std::vector<PMS_CtxIdIdxPair>& profile_ctx_pairs,
-                          const uint length, const int round, const int found_ctx_idx,
-                          std::vector<std::pair<uint32_t, uint64_t>>& my_ctx_pairs);
-
-  std::vector<std::pair<uint32_t, uint64_t>> myCtxPairs(const std::vector<uint32_t>& ctx_ids,
-                                                        const std::vector<PMS_CtxIdIdxPair>& profile_ctx_pairs);
-
-  std::vector<char> valMidsBytes(std::vector<std::pair<uint32_t, uint64_t>>& my_ctx_pairs,
-                                 const uint64_t& off);
-
-  void handleItemPd(profData& pd);
-
-  std::vector<std::pair<std::vector<std::pair<uint32_t,uint64_t>>, std::vector<char>>>
-  profilesData(std::vector<uint32_t>& ctx_ids);
-
-
-  // helper - convert one profile data to a CtxMetricBlock
-  struct MetricValBlock{
-    uint16_t mid;
-    uint32_t num_values; // can be set at the end, used as idx for mid
-    std::vector<std::pair<hpcrun_metricVal_t,uint32_t>> values_prof_idxs;
-  };
-  struct CtxMetricBlock{
-    uint32_t ctx_id;
-    std::map<uint16_t, MetricValBlock> metrics;
+  // prof_info for the summary profile
+  // Filled during the Threads wavefront
+  pms_profile_info_t summary_info = {
+    .prof_info_idx = 0,
+    .metadata_ptr = 0, .spare_one = 0, .spare_two = 0,
   };
 
-  MetricValBlock metValBloc(const hpcrun_metricVal_t val,const uint16_t mid, const uint32_t prof_idx);
-  void updateCtxMetBloc(const hpcrun_metricVal_t val, const uint16_t mid,
-                        const uint32_t prof_idx, CtxMetricBlock& cmb);
-  void interpretValMidsBytes(char *vminput,const uint32_t prof_idx,
-                             const std::pair<uint32_t,uint64_t>& ctx_pair,
-                             const uint64_t next_ctx_idx,const uint64_t first_ctx_idx,
-                             CtxMetricBlock& cmb);
-
-
-  // helper - convert CtxMetricBlocks to correct bytes for writing
-  std::vector<char> mvbBytes(const MetricValBlock& mvb);
-  std::vector<char> mvbsBytes(std::map<uint16_t, MetricValBlock>& metrics);
-  std::vector<char> metIdIdxPairsBytes(const std::map<uint16_t, MetricValBlock>& metrics);
-  std::vector<char> cmbBytes(const CtxMetricBlock& cmb, const uint32_t& ctx_id);
-
-  // write contexts
-  struct nextCtx{
-    uint32_t ctx_id;
-    uint32_t prof_idx;
-    size_t cursor;
-
-    //turn MaxHeap to MinHeap
-    bool operator<(const nextCtx& a) const{
-      if(ctx_id == a.ctx_id)
-        return prof_idx > a.prof_idx;
-      return ctx_id > a.ctx_id;
-    }
-  };
-
-  struct ctxRange{
-    uint64_t start;
-    uint64_t end;
-
-    std::vector<std::pair<std::vector<std::pair<uint32_t,uint64_t>>, std::vector<char>>> * pd;
-    std::vector<uint32_t>* ctx_ids;
-    std::vector<pms_profile_info_t>* pis;
-  };
-
-  std::vector<uint32_t> ctx_group_list; //each number represents the starting ctx id for this group
-  uint32_t ctxGrpId;
-  hpctoolkit::mpi::SharedAccumulator accCtxGrp;
-  hpctoolkit::util::ResettableParallelForEach<ctxRange> parForCtxs;
-
-  void handleItemCtxs(ctxRange& cr);
-  void rwOneCtxGroup(std::vector<uint32_t>& ctx_ids);
-  void buildCtxGroupList();
-  uint32_t ctxGrpIdFetch();
-  void rwAllCtxGroup();
-
+  // Parallel workshares for the various parallel operations
+  hpctoolkit::util::ParallelForEach<
+      std::reference_wrapper<const pms_profile_info_t>> forEachProfileInfo;
+  hpctoolkit::util::ParallelFor forProfilesParse;
+  hpctoolkit::util::ResettableParallelFor forProfilesLoad;
+  hpctoolkit::util::ResettableParallelForEach<
+      std::pair<uint32_t, uint32_t>> forEachContextRange;
 };
 
 }

--- a/src/lib/profile/sources/packed.cpp
+++ b/src/lib/profile/sources/packed.cpp
@@ -236,16 +236,20 @@ std::vector<uint8_t>::const_iterator Packed::unpackMetrics(iter_t it, const ctx_
   // Format: [cnt] ([context ID] ([metrics]...)...)
   auto cnt = unpack<std::uint64_t>(it);
   for(std::size_t i = 0; i < cnt; i++) {
-    auto accum = sink.accumulateTo(cs.at(unpack<std::uint64_t>(it)));
+    Context& c = cs.at(unpack<std::uint64_t>(it));
     for(Metric& m: metrics) {
+      c.data().markUsed(m, MetricScopeSet(unpack<MetricScopeSet::int_type>(it)));
+
+      auto& accums = c.data().statisticsFor(m);
       for(const auto& p: m.partials()) {
+        auto accum = accums.get(p);
         double v;
         if((v = unpack<double>(it)) != 0)
-          accum.add(m, p, MetricScope::point, v);
+          accum.add(MetricScope::point, v);
         if((v = unpack<double>(it)) != 0)
-          accum.add(m, p, MetricScope::function, v);
+          accum.add(MetricScope::function, v);
         if((v = unpack<double>(it)) != 0)
-          accum.add(m, p, MetricScope::execution, v);
+          accum.add(MetricScope::execution, v);
       }
     }
   }


### PR DESCRIPTION
The next phase for #495 requires changes to the SparseDB, however the code is somewhat complicated and hard to read. With the exception of the first commit, this patch series attempts to incrementally massage it without changing the high-level algorithm, into something more readable, better contained and somewhat better documented.

The first commit fixes a bug where cct.db would be left unwritten with a single MPI rank. Most other commits (prefixed with "Cleanup:") are incremental changes that improve the SparseDB implementation without changing the top-level algorithm or the final output. The couple of remaining commits are improvements to the Prof2 core/utilities that assist in the cleanup.