### PR TITLE
[New CUPTI] Control knob

### DIFF
--- a/src/tool/hpcrun/control-knob.c
+++ b/src/tool/hpcrun/control-knob.c
@@ -38,8 +38,8 @@ control_knob_register(char *name, char *value, control_knob_type type)
   if (iter == NULL) {
     iter = (control_knob_t*) malloc(sizeof(control_knob_t));
     iter->name = strdup(name);
-    iter->next = control_knobs;
     iter->type = type;
+    iter->next = control_knobs;
     control_knobs = iter;
   }
   iter->value = strdup(value);

--- a/src/tool/hpcrun/control-knob.c
+++ b/src/tool/hpcrun/control-knob.c
@@ -38,12 +38,11 @@ control_knob_register(char *name, char *value, control_knob_type type)
   if (iter == NULL) {
     iter = (control_knob_t*) malloc(sizeof(control_knob_t));
     iter->name = strdup(name);
-    iter->type = type;
     iter->next = control_knobs;
+    iter->type = type;
     control_knobs = iter;
   }
   iter->value = strdup(value);
-  
 }
 
 
@@ -62,20 +61,18 @@ control_knob_init()
   char *in = getenv("HPCRUN_CONTROL_KNOBS");
   if (in == NULL) return;
 
-  char *save;
+  char *save = NULL;
   for (char *f = start_tok(in); more_tok(); f = next_tok()){
     char *tmp = strdup(f);
     char *name = strtok_r(tmp, "=", &save);
-    control_knob_t *iter = NULL;
+    char *value = strtok_r(NULL, "=", &save);
 
-    if (name != NULL && (iter = control_knob_name_lookup(name))) {
-      char *value = strtok_r(NULL, "=", &save);
-      iter->value = value;
+    if (name != NULL && value != NULL) {
+      control_knob_register(name, value, ck_int);
     } else {
       fprintf(stderr, "\tcontrol token %s not recognized\n\n", f);
     }
   }
-
 }
 
 


### PR DESCRIPTION
An important fix on control knob: before this commit, external knobs using hpcrun -ck @name=@value does not work becaue only names in the default knobs are registers. Since iter = control_knob_name_lookup(name) is NULL if name is external (e.g., ones used by nvidia.c), their @values are not passed into hpcrun