### PR TITLE
Fix: Separate libiberty fails to compile

### DIFF
--- a/configure
+++ b/configure
@@ -21116,6 +21116,13 @@ $as_echo_n "checking for libiberty.a for binutils... " >&6; }
   found_libiberty=no
   case "$LIBIBERTY" in
     /* )
+      # demangle.h must exist
+      if test -f "${LIBIBERTY}/include/libiberty/demangle.h" ; then
+        BINUTILS_IFLAGS="${BINUTILS_IFLAGS} -I${LIBIBERTY}/include"
+      else
+        as_fn_error $? "unable to find libiberty/demangle.h in: $LIBIBERTY" "$LINENO" 5
+      fi
+
       for lib in $multilib_path ; do
         file="${LIBIBERTY}/${lib}/libiberty.a"
 	if test -f "$file" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -2617,6 +2617,13 @@ else
   found_libiberty=no
   case "$LIBIBERTY" in
     /* )
+      # demangle.h must exist
+      if test -f "${LIBIBERTY}/include/libiberty/demangle.h" ; then
+        BINUTILS_IFLAGS="${BINUTILS_IFLAGS} -I${LIBIBERTY}/include"
+      else
+        AC_MSG_ERROR([unable to find libiberty/demangle.h in: $LIBIBERTY])
+      fi
+
       for lib in $multilib_path ; do
         file="${LIBIBERTY}/${lib}/libiberty.a"
 	if test -f "$file" ; then


### PR DESCRIPTION
When compiling with `--with-spack`, if the Binutils it picks up was compiled with `~libiberty` (which is default), the build fails with the error:
```
In file included from demangle.c:59:
.../hpctoolkit/src/include/gnu_demangle.h:68:10: fatal error: libiberty/demangle.h: No such file or directory
   68 | #include <libiberty/demangle.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

This patch adds includes handling to the separated libiberty logic.