### PR TITLE
Fixing hpcrun_threadMgr_data_get problem

### DIFF
--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -279,7 +279,7 @@ gpu_trace_stream_acquire
 
   // XXX(Keren): This API calls allocate_and_init_thread_data to bind td with the current thread
 
-  hpcrun_threadMgr_data_get_safe(id, NULL, &td, has_trace, demand_new_thread);
+  hpcrun_threadMgr_data_get(id, NULL, &td, has_trace, demand_new_thread);
 
   return td;
 }

--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -249,10 +249,8 @@ hpcrun_thread_init_mem_pool_once
 
   if (mem_pool_initialized == false){
     hpcrun_mmap_init();
-    hpcrun_threadMgr_data_get_safe(id, thr_ctxt, &td, has_trace, demand_new_thread);
+    hpcrun_threadMgr_data_get(id, thr_ctxt, &td, has_trace, demand_new_thread);
     hpcrun_set_thread_data(td);
-
-    mem_pool_initialized = true;
   }
 }
 
@@ -360,7 +358,8 @@ hpcrun_thread_data_init
   td->memstore = memstore;
   hpcrun_make_memstore(&td->memstore, is_child);
   td->mem_low = 0;
-
+  mem_pool_initialized = true;
+  
   // ----------------------------------------
   // normalized thread id (monitor-generated)
   // ----------------------------------------

--- a/src/tool/hpcrun/threadmgr.c
+++ b/src/tool/hpcrun/threadmgr.c
@@ -261,34 +261,6 @@ hpcrun_threadMgr_compact_thread()
   return compact_thread;
 }
 
-/***
- *   Wrapper around hpcrun_threadMgr_data_get
- *   Checks if there is thread specific data and preserves it
- *****/
-bool
-hpcrun_threadMgr_data_get_safe
-(
- int id,
- cct_ctxt_t *thr_ctxt,
- thread_data_t **data,
- bool has_trace,
- bool demand_new_thread
-)
-{
-  thread_data_t *td_self;
-  bool res;
-
-  if (hpcrun_td_avail()) {
-    td_self = hpcrun_get_thread_data();
-    res = hpcrun_threadMgr_data_get(id, thr_ctxt, data, has_trace, demand_new_thread);
-    hpcrun_set_thread_data(td_self);
-  }
-  else{
-    res = hpcrun_threadMgr_data_get(id, thr_ctxt, data, has_trace, demand_new_thread);
-  }
-  return res;
-}
-
 
 /***
  * get pointer of thread local data

--- a/src/tool/hpcrun/threadmgr.h
+++ b/src/tool/hpcrun/threadmgr.h
@@ -76,9 +76,6 @@ void hpcrun_threadmgr_thread_delete();
 int hpcrun_threadmgr_thread_count();
 
 bool
-hpcrun_threadMgr_data_get_safe(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace, bool demand_new_thread);
-
-bool
 hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace, bool demand_new_thread);
 
 void


### PR DESCRIPTION
This PR fixes the problem of overwriting thread_data structure by setting mem_pool_initialized on right place.