### PR TITLE
remove assertion in hpcrun_get_threaded_data

### DIFF
--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -230,7 +230,12 @@ hpcrun_threaded_data
   void
 )
 {
+#if 0
+  // this assertion isn't true for when a threaded process forks and the child then creates a thread
+  // GNU bash, version 4.4.23(1)-release (x86_64-suse-linux-gnu) does this.
   assert(hpcrun_get_thread_data == &hpcrun_get_thread_data_local);
+#endif
+
   hpcrun_get_thread_data = &hpcrun_get_thread_data_specific;
   hpcrun_td_avail        = &hpcrun_get_thread_data_specific_avail;
 }


### PR DESCRIPTION
the assertion is false when monitoring GNU bash, version
4.4.23(1)-release (x86_64-suse-linux-gnu), which appears to fork
a threaded process.