### PR TITLE
Split printProc() into: earlyFormatProc() which performs most of the

### DIFF
--- a/src/lib/banal/Struct-Output.cpp
+++ b/src/lib/banal/Struct-Output.cpp
@@ -66,6 +66,7 @@
 
 //***************************************************************************
 
+#include <sys/types.h>
 #include <limits.h>
 
 #include <list>
@@ -103,14 +104,27 @@ static const char * hpcstruct_xml_head =
 #define ENABLE_TARGET_FIELD  1
 #define ENABLE_DEVICE_FIELD  1
 
+#define USE_INDEX_NUMBERS  1
+
 //----------------------------------------------------------------------
 
 // Helpers to generate fields inside tags.  The macros are designed to
 // fit within << operators.
 
+#define MARKER  "<>"
+#define MARKER_LEN  2
+
+#define GAPS_MARKER   "<>g"
+
+#if USE_INDEX_NUMBERS
 // this generates pre-order
-#define INDEX  \
-  " i=\"" << next_index++ << "\""
+#define INDEX  " i=\"" << next_index++ << "\""
+#define INDEX_MARKER  "<>i"
+
+#else
+#define INDEX         ""
+#define INDEX_MARKER  ""
+#endif
 
 #define NUMBER(label, num)  \
   " " << label << "=\"" << num << "\""
@@ -123,7 +137,6 @@ static const char * hpcstruct_xml_head =
 
 #define VRANGE(vma, len)  \
   " v=\"{[0x" << hex << vma << "-0x" << vma + len << dec << ")}\""
-
 
 static void
 doIndent(ostream * os, int depth)
@@ -174,6 +187,14 @@ locateTree(TreeNode *, ScopeInfo &, HPC::StringTable &, bool = false);
 
 //----------------------------------------------------------------------
 
+// Turn on indenting in XML output
+void setPrettyPrint(bool _pretty_print_output)
+{
+  pretty_print_output = _pretty_print_output;
+}
+
+//----------------------------------------------------------------------
+
 // Sort StmtInfo by line number and then by vma.
 static bool
 StmtLessThan(StmtInfo * s1, StmtInfo * s2)
@@ -182,7 +203,6 @@ StmtLessThan(StmtInfo * s1, StmtInfo * s2)
   if (s1->line_num > s2->line_num) { return false; }
   return s1->vma < s2->vma;
 }
-
 
 //----------------------------------------------------------------------
 
@@ -254,7 +274,6 @@ printLoadModuleEnd(ostream * os)
   *os << "</LM>\n";
 }
 
-
 //----------------------------------------------------------------------
 
 // Begin <F> file tag.
@@ -287,10 +306,15 @@ printFileEnd(ostream * os, FileInfo * finfo)
 //----------------------------------------------------------------------
 
 // Entry point for <P> proc tag and its subtree.
+//
+// This now does internal formatting of everything except index and
+// gap fields to a string stream buffer.  Note: this runs concurrently
+// with other procs, so must not touch internal state.  So, the index
+// and gap fields must be delayed.
+//
 void
-printProc(ostream * os, ostream * gaps, string gaps_file,
-	  FileInfo * finfo, GroupInfo * ginfo, ProcInfo * pinfo,
-	  HPC::StringTable & strTab)
+earlyFormatProc(ostream * os, FileInfo * finfo, GroupInfo * ginfo, ProcInfo * pinfo,
+		bool do_gaps, HPC::StringTable & strTab)
 {
   if (os == NULL || finfo == NULL || ginfo == NULL
       || pinfo == NULL || pinfo->root == NULL) {
@@ -304,7 +328,7 @@ printProc(ostream * os, ostream * gaps, string gaps_file,
 
   doIndent(os, 2);
   *os << "<P"
-      << INDEX
+      << INDEX_MARKER
       << STRING("n", pinfo->prettyName);
 
   if (pinfo->linkName != pinfo->prettyName) {
@@ -319,8 +343,8 @@ printProc(ostream * os, ostream * gaps, string gaps_file,
 
   // write the gaps to the first proc (low vma) of the group.  this
   // only applies to full gaps.
-  if (gaps != NULL && (! ginfo->alt_file) && pinfo == ginfo->procMap.begin()->second) {
-    doGaps(os, gaps, gaps_file, finfo, ginfo, pinfo);
+  if (do_gaps && (! ginfo->alt_file) && pinfo == ginfo->procMap.begin()->second) {
+    *os << GAPS_MARKER;
   }
 
   doTreeNode(os, 3, root, scope, strTab);
@@ -329,15 +353,59 @@ printProc(ostream * os, ostream * gaps, string gaps_file,
   *os << "</P>\n";
 }
 
-
 //----------------------------------------------------------------------
 
-// turn on indenting in XML output
-void setPrettyPrint(bool _pretty_print_output)
+//
+// Do the final translation of the index and gaps markers (<>i, <>g)
+// from 'buf' and write the output to 'os' (hpcstruct file) and 'gaps'
+// (gaps file, if used).  This part is run serial, inside a lock.
+//
+// Note: this is called once per group, where pinfo is the group leader.
+//
+void
+finalPrintProc(ostream * os, ostream * gaps, string & buf, string & gaps_filenm,
+	       FileInfo * finfo, GroupInfo * ginfo, ProcInfo * pinfo)
 {
-  pretty_print_output = _pretty_print_output;
-}
+  // if no index or gaps, then nothing to translate, just dump 'buf'
+  // directly to 'os'
+#if ! USE_INDEX_NUMBERS
+  if (gaps == NULL) {
+    *os << buf;
+    return;
+  }
+#endif
 
+  size_t start = 0;
+
+  for (;;) {
+    size_t pos = buf.find(MARKER, start);
+
+    // no more markers to translate
+    if (pos == string::npos) {
+      *os << buf.substr(start);
+      break;
+    }
+
+    *os << buf.substr(start, pos - start);
+
+    switch (buf[pos + MARKER_LEN]) {
+    case 'g':
+      doGaps(os, gaps, gaps_filenm, finfo, ginfo, pinfo);
+      break;
+
+    case 'i':
+      *os << INDEX;
+      break;
+
+    default:
+      cerr << "internal error (unknown marker) in hpcstruct: "
+	   << buf.substr(pos, 3) << "\n";
+      break;
+    }
+
+    start = pos + MARKER_LEN + 1;
+  }
+}
 
 //----------------------------------------------------------------------
 
@@ -505,7 +573,7 @@ doTreeNode(ostream * os, int depth, TreeNode * root, ScopeInfo scope,
     // guard alien
     doIndent(os, depth);
     *os << "<A"
-	<< INDEX
+	<< INDEX_MARKER
 	<< NUMBER("l", alien_scope.line_num)
 	<< STRING("f", strTab.index2str(file_index))
 	<< STRING("n", GUARD_NAME)
@@ -540,7 +608,7 @@ doTreeNode(ostream * os, int depth, TreeNode * root, ScopeInfo scope,
     // empty proc name.
     doIndent(os, depth);
     *os << "<A"
-	<< INDEX
+	<< INDEX_MARKER
 	<< NUMBER("l", flp.line_num)
 	<< STRING("f", strTab.index2str(flp.file_index))
 	<< STRING("n", "")
@@ -551,7 +619,7 @@ doTreeNode(ostream * os, int depth, TreeNode * root, ScopeInfo scope,
     // file and line from subtree.
     doIndent(os, depth + 1);
     *os << "<A"
-	<< INDEX
+	<< INDEX_MARKER
 	<< NUMBER("l", subscope.line_num)
 	<< STRING("f", strTab.index2str(subscope.file_index))
 	<< STRING("n", callname)
@@ -615,7 +683,7 @@ doStmtList(ostream * os, int depth, TreeNode * node)
 
     doIndent(os, depth);
     *os << "<S"
-	<< INDEX
+	<< INDEX_MARKER
 	<< NUMBER("l", line)
 	<< " v=\"" << vset->toString() << "\""
 	<< "/>\n";
@@ -629,7 +697,7 @@ doStmtList(ostream * os, int depth, TreeNode * node)
 
     doIndent(os, depth);
     *os << "<C"
-	<< INDEX
+	<< INDEX_MARKER
 	<< NUMBER("l", sinfo->line_num)
 	<< VRANGE(sinfo->vma, sinfo->len);
 
@@ -657,7 +725,7 @@ doLoopList(ostream * os, int depth, TreeNode * node, HPC::StringTable & strTab)
 
     doIndent(os, depth);
     *os << "<L"
-	<< INDEX
+	<< INDEX_MARKER
 	<< NUMBER("l", linfo->line_num)
 	<< STRING("f", strTab.index2str(linfo->file_index))
 	<< VRANGE(linfo->entry_vma, 1)

--- a/src/lib/banal/Struct-Output.hpp
+++ b/src/lib/banal/Struct-Output.hpp
@@ -75,8 +75,11 @@ void printLoadModuleEnd(ostream *);
 void printFileBegin(ostream *, FileInfo *);
 void printFileEnd(ostream *, FileInfo *);
 
-void printProc(ostream *, ostream *, string, FileInfo *, GroupInfo *,
-	       ProcInfo *, HPC::StringTable & strTab);
+void earlyFormatProc(ostream *, FileInfo *, GroupInfo *, ProcInfo *,
+		     bool, HPC::StringTable & strTab);
+
+void finalPrintProc(ostream *, ostream *, string &, string &,
+		    FileInfo *, GroupInfo *, ProcInfo *);
 
 void setPrettyPrint(bool _pretty_print_output);
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -354,6 +354,7 @@ public:
   GroupInfo * ginfo;
   WorkEnv env;
   double cost;
+  stringstream obuf;
   bool first_proc;
   bool last_proc;
   bool promote;
@@ -763,8 +764,7 @@ makeStructure(string filename,
 // run concurrently.
 //
 static void
-doWorkItem(WorkItem * witem, string & search_path, bool parsable,
-	   bool fullGaps)
+doWorkItem(WorkItem * witem, string & search_path, bool parsable, bool do_gaps)
 {
   FileInfo * finfo = witem->finfo;
   GroupInfo * ginfo = witem->ginfo;
@@ -782,10 +782,23 @@ doWorkItem(WorkItem * witem, string & search_path, bool parsable,
   witem->env.strTab = strTab;
   witem->env.realPath = realPath;
 
+  // make the inline tree for every proc in this group
   if (parsable) {
-    doFunctionList(witem->env, finfo, ginfo, fullGaps);
+    doFunctionList(witem->env, finfo, ginfo, do_gaps);
   } else {
     doUnparsableFunctionList(witem->env, finfo, ginfo);
+  }
+
+  // partially format the output (except for index and gap fields)
+  // into a string stream
+  for (auto pit = ginfo->procMap.begin(); pit != ginfo->procMap.end(); ++pit) {
+    ProcInfo * pinfo = pit->second;
+
+    if (! pinfo->gap_only) {
+      Output::earlyFormatProc(&(witem->obuf), finfo, ginfo, pinfo, do_gaps, *strTab);
+    }
+    delete pinfo->root;
+    pinfo->root = NULL;
   }
 
   ANNOTATE_HAPPENS_BEFORE(&witem->is_done);
@@ -886,20 +899,18 @@ printWorkList(WorkList & workList, uint & num_done, ostream * outFile,
     WorkItem * witem = workList[num_done];
     FileInfo * finfo = witem->finfo;
     GroupInfo * ginfo = witem->ginfo;
+    ProcInfo * pinfo = ginfo->procMap.begin()->second;
     HPC::StringTable * strTab = witem->env.strTab;
 
     if (witem->first_proc) {
       Output::printFileBegin(outFile, finfo);
     }
 
-    for (auto pit = ginfo->procMap.begin(); pit != ginfo->procMap.end(); ++pit) {
-      ProcInfo * pinfo = pit->second;
+    if (! pinfo->gap_only) {
+      string buf = witem->obuf.str();
 
-      if (! pinfo->gap_only) {
-	Output::printProc(outFile, gapsFile, gaps_filenm, finfo, ginfo, pinfo, *strTab);
-      }
-      delete pinfo->root;
-      pinfo->root = NULL;
+      Output::finalPrintProc(outFile, gapsFile, buf, gaps_filenm,
+			     finfo, ginfo, pinfo);
     }
 
     if (witem->last_proc) {


### PR DESCRIPTION
format conversion (except index numbers and gaps) and can run in
parallel, and finalPrintProc() which runs serially and adds the index
numbers and writes to the struct file.

This allows the bulk of the format conversion to run in parallel and
dramatically reduces the "print engine spike" in hpcstruct.