### PR TITLE
Rewrite and fixup the auditor

### DIFF
--- a/src/tool/hpcrun/audit/audit-api.h
+++ b/src/tool/hpcrun/audit/audit-api.h
@@ -65,9 +65,6 @@ typedef struct auditor_map_entry_t {
   // handling the main application name.
   char* path;
 
-  // Base address of the file. Points to the ELF header.
-  void* ehdr;
-
   // Byterange of the mapped region
   void* start;
   void* end;
@@ -85,10 +82,6 @@ typedef struct auditor_map_entry_t {
 } auditor_map_entry_t;
 
 typedef struct auditor_hooks_t {
-  // Called early in the process startup, as soon after libc's initialization
-  // as possible, and before any of the other hooks are called.
-  void (*initialize)();
-
   // Called whenever a new entry is entering the link map.
   void (*open)(auditor_map_entry_t* entry);
 
@@ -104,6 +97,8 @@ typedef struct auditor_hooks_t {
 typedef struct auditor_exports_t {
   // Called by the mainlib once it is prepared to receive notifications.
   void (*mainlib_connected)(const char* vdso_path);
+  // Called by the mainlib when it no longer wishes to receive notifications.
+  void (*mainlib_disconnect)();
 
   // Purified environment that has our effects (mostly) removed.
   char** pure_environ;

--- a/src/tool/hpcrun/audit/fake-auditor.c
+++ b/src/tool/hpcrun/audit/fake-auditor.c
@@ -55,11 +55,11 @@
 #include <dlfcn.h>
 #include <elf.h>
 #include <pthread.h>
-#include <string.h>
 #include <sched.h>
 #include <stddef.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/auxv.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -84,6 +84,7 @@ static auditor_exports_t exports;
 static auditor_hooks_t hooks;
 
 static void mainlib_connected(const char*);
+static void mainlib_disconnect();
 static bool update_shadow();
 
 static void* (*real_dlopen)(const char*, int) = NULL;
@@ -162,6 +163,7 @@ void hpcrun_init_fake_auditor() {
   if(!exports.execve) exports.execve = monitor_real_execve;
 
   exports.mainlib_connected = mainlib_connected;
+  exports.mainlib_disconnect = mainlib_disconnect;
 
   verbose = getenv("HPCRUN_AUDIT_DEBUG");
   vdso_path = "[vdso]";  // Set later to something more reasonable.
@@ -192,11 +194,6 @@ void hpcrun_init_fake_auditor() {
 __attribute__((constructor))
 static void hpcrun_constructor_init_fake_auditor() {
   hpcrun_init_fake_auditor();
-
-  // Since we're late to the party, we can kick bits off right now
-  if(verbose)
-    fprintf(stderr, "[fake audit] Beginning initialization\n");
-  hooks.initialize();
 }
 
 // Whenever things change, we scan through with dl_iterate_phdr, update the
@@ -256,8 +253,6 @@ int update_shadow_dl(struct dl_phdr_info* map, size_t sz, void* args_vp) {
   entry->addr = map->dlpi_addr;
   entry->seen = true;
   entry->new = true;
-  entry->entry.ehdr = map->dlpi_addr != 0 ? (void*)map->dlpi_addr
-    : (void*)(uintptr_t)(map->dlpi_phdr[0].p_vaddr - map->dlpi_phdr[0].p_offset);
 
   uintptr_t start = UINTPTR_MAX;
   uintptr_t end = 0;
@@ -273,11 +268,14 @@ int update_shadow_dl(struct dl_phdr_info* map, size_t sz, void* args_vp) {
   entry->entry.end = (void*)map->dlpi_addr + end;
 
   entry->entry.path = NULL;
-  if (entry->entry.start == (void *)getauxval(AT_SYSINFO_EHDR))
+  if (map->dlpi_addr == getauxval(AT_SYSINFO_EHDR))
     entry->entry.path = realpath(vdso_path, NULL);
-  else if(map->dlpi_name[0] == '\0')
-    entry->entry.path = realpath((const char*)getauxval(AT_EXECFN), NULL);
-  else 
+  else if(map->dlpi_phdr == (void*)getauxval(AT_PHDR)) {
+    entry->entry.path = realpath("/proc/self/exe", NULL);
+    if(entry->entry.path == NULL || strcmp(entry->entry.path, "/proc/self/exe") == 0)
+      entry->entry.path = realpath((const char*)getauxval(AT_EXECFN), NULL);
+  }
+  if(entry->entry.path == NULL)
     entry->entry.path = realpath(map->dlpi_name, NULL);
 
   entry->entry.dl_info = *map;
@@ -297,6 +295,9 @@ void mainlib_connected(const char* new_vdso_path) {
   connected = true;
   vdso_path = new_vdso_path;
   update_shadow();
+}
+void mainlib_disconnect() {
+  connected = false;
 }
 
 // The remainder here is overloads for dl* that update as per the usual

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -738,6 +738,9 @@ hpcrun_fini_internal()
     // write all threads' profile data and close trace file
     hpcrun_threadMgr_data_fini(hpcrun_get_thread_data());
 
+#ifndef HPCRUN_STATIC_LINK
+    auditor_exports->mainlib_disconnect();
+#endif
     fnbounds_fini();
     hpcrun_stats_print_summary();
     messages_fini();
@@ -1733,15 +1736,9 @@ static void auditor_stable(bool additive) {
   hpcrun_safe_exit();
 }
 
-static void auditor_init() {
-  if(!hpcrun_is_initialized())
-    monitor_initialize();
-}
-
 const auditor_exports_t* auditor_exports;
 void hpcrun_auditor_attach(const auditor_exports_t* exports, auditor_hooks_t* hooks) {
   auditor_exports = exports;
-  hooks->initialize = auditor_init;
   hooks->open = auditor_open;
   hooks->close = auditor_close;
   hooks->stable = auditor_stable;


### PR DESCRIPTION
The behavior should be nearly identical, but the code has been reviewed and cleaned up based on my refined understanding of LD_AUDIT and the issues surrounding it. In particular, the global state machine is replaced with more natural piecewise logic.

Notable changes:
 - The auditor_initialize hook has been removed, auditors are no longer able to trigger Run initialization. Run initialization already happens during static constructors (or from eg. pthread_create), this cleans up the loose end.
 - Added a new hook mainlib_disconnect. This allows libhpcrun.so to fully control when it will receive notifications: only after mainlib_connected and before mainlib_disconnect. (Fixes no bugs, but is cleaner.)
 - Additional fallbacks for loading program headers. This handles cases where the programs headers are not at the front of the file. (Fixes @Lucindaaaa's issues with strange libraries in Intel software.)
 - Prefer /proc/self/exe to AT_EXECFN for getting the main executable's path. (Fixes a bug where scripts with a shebang would end up with the script as the main executable load module.)