### PR TITLE
don't connect to auditor in a forked child

### DIFF
--- a/src/tool/hpcrun/audit/auditor.c
+++ b/src/tool/hpcrun/audit/auditor.c
@@ -574,7 +574,9 @@ unsigned int la_objopen(struct link_map* map, Lmid_t lmid, uintptr_t* cookie) {
 
 
 static void mainlib_connected(const char* vdso_path) {
-  assert(!connected && "Attempt to connect more than once?");
+  // No need to execute this code in a forked child without exec
+  if (connected) return;
+
   connected = true;
 
   // Finalize and deliver notifications for all the objects we've buffered

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -961,7 +961,9 @@ monitor_init_process(int *argc, char **argv, void* data)
     // fnbounds must be after module_ignore_map
     fnbounds_init(process_name);
 #ifndef HPCRUN_STATIC_LINK
-    auditor_exports->mainlib_connected(get_saved_vdso_path());
+    if (!is_child) {
+      auditor_exports->mainlib_connected(get_saved_vdso_path());
+    }
 #endif
   }
   


### PR DESCRIPTION
have both the auditor and hpctoolkit ensure that auditor does not execute connect in forked child.