### PR TITLE
improve hpcrun error message for closed log file

### DIFF
--- a/src/tool/hpcrun/messages/messages-sync.c
+++ b/src/tool/hpcrun/messages/messages-sync.c
@@ -171,9 +171,12 @@ messages_fini(void)
   if (log_file_fd != 2) {
     int rv = close(log_file_fd);
     if (rv) {
-      char *mesg = "hpctoolkit warning: unable to access log file "
-                   "(maybe application closed the file descriptor)\n";
-      write(2, mesg, strlen(mesg));
+      char executable[PATH_MAX];
+      char *exec = realpath("/proc/self/exe", executable);
+      unsigned long pid = (unsigned long) getpid();
+
+      STDERR_MSG("hpctoolkit warning: executable '%s' (pid=%ld) "
+	      "prematurely closed hpctoolkit's log file", exec, pid);
     }
     //----------------------------------------------------------------------
     // if this is an execution of an MPI program, we opened the log file 


### PR DESCRIPTION
previously, the error message just indicated that a log close failed. the new error message indicates the name of the process and pid where the log closure failed. with that, one can look in the measurement data and see the short log.

note 1: the problem came up when using hpcrun to monitor bash with spack being set up in the .bashrc. python apparently forked. jonathon reports that python closes everything except standard file descriptors on fork, which closes our log file. on jlse, using hpcrun to monitor bash then reports that a particular python process got a cropped log file. this is much better than just reporting that something bad happened.

note 2: we can't call malloc or stdio functions here because we might be ending hpctoolkit because a user typed ^c in the middle of a memory allocation while a lock is held. thus, 
- call realpath with a buffer so it doesn't need to allocate
- use STDERR_MSG, which using hpcrun's messaging system, to produce the error message rather than using stdio functions that might allocate. this also has the benefit of an atomic write of the message using a single call to posix write.