### PR TITLE
fix issues with renaming structure files in the cache

### DIFF
--- a/src/tool/hpcstruct/SingleBin.cpp
+++ b/src/tool/hpcstruct/SingleBin.cpp
@@ -290,7 +290,7 @@ doSingleBinary
   // if a cache is in use, ensure that the module path in the new .struct file is correct.
   //
   if (use_cache == true ) {
-    string checkname_cmd =  string(HPCTOOLKIT_INSTALL_PREFIX) + "/libexec/hpctoolkit/renamestruct.sh "
+    string checkname_cmd = string("/bin/sh ") + string(HPCTOOLKIT_INSTALL_PREFIX) + "/libexec/hpctoolkit/renamestruct.sh "
         + args.in_filenm.c_str() + " " + hpcstruct_path.c_str();
 
 #if 0

--- a/src/tool/hpcstruct/renamestruct.sh
+++ b/src/tool/hpcstruct/renamestruct.sh
@@ -11,8 +11,8 @@ oldname=`grep "<LM" $2  | head -1 | awk '{print $3}' | sed '/n="/s///' | sed '/g
 
 #  Check to see if  the two names match 
 if [ "$oldname" ==  "$1" ] ; then
-    #  they match, we're done
-    # @echo DEBUG Pathname matched
+    # they match, we're done
+    # echo DEBUG Pathname matched
     exit 0
 fi
 
@@ -20,13 +20,13 @@ fi
 # First, make sure neither name has a pipe character in it
 err=`echo $oldname | grep "|" | wc -l ` 
 if [ $err -ne 0 ]; then
-    @echo "The original filename in the struct file has an embedded pipe character; not rewriting"
+    echo "The original filename in the struct file has an embedded pipe character; not rewriting"
     exit -1
 fi
 
 err=`echo $1 | grep "|" | wc -l ` 
 if [ $err -ne 0 ]; then
-    @echo "The new filename for the struct file has an embedded pipe character; not rewriting"
+    echo "The new filename for the struct file has an embedded pipe character; not rewriting"
     exit -1
 fi
 


### PR DESCRIPTION
- replace "@echo" with "echo" in renamestruct.sh script
  (@echo is a make construct but not legal bash)

- fix monitor_execve failure warning when using hpcrun to measure
  hpcstruct. the issue was that hpcrun was trying to exec
  a script directly. instead of running the rename script
  with command  "<path>/renamestruct.sh", run it with command
  "/bin/sh <path>/renamestruct.sh". that way, /bin/sh can be
  exec'ed. i think that if such an exec failed in the shell,
  the shell probably figures out how to launch the command
  by finding the "#!/bin/sh" in the first line of the shell
  script.