### PR TITLE
Fix trace

### DIFF
--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -313,11 +313,15 @@ gpu_trace_fini
 {
   PRINT("gpu_trace_fini called\n");
 
-  atomic_store(&stop_trace_flag, true);
+  // trace finalization is idempotent
+  if (atomic_load(&stop_trace_flag) != true) {
 
-  gpu_trace_demultiplexer_notify();
+    atomic_store(&stop_trace_flag, true);
 
-  while (atomic_load(&active_streams_counter));
+    gpu_trace_demultiplexer_notify();
+
+    while (atomic_load(&active_streams_counter));
+  }
 }
 
 

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -1212,10 +1212,10 @@ monitor_thread_pre_create(void)
   struct monitor_thread_info mti;
   monitor_get_new_thread_info(&mti);
   void *thread_pre_create_address = mti.mti_create_return_addr;
-
   if (module_ignore_map_inrange_lookup(thread_pre_create_address)) {
-    return NULL;
+    return MONITOR_IGNORE_NEW_THREAD;
   }
+
   bool is_child = false;
 
   // outer initialization

--- a/src/tool/hpcrun/ompt/ompt-device.c
+++ b/src/tool/hpcrun/ompt/ompt-device.c
@@ -81,6 +81,8 @@
 
 #include "gpu/ompt/ompt-gpu-api.h"
 
+#include "monitor.h"
+
 
 
 //*****************************************************************************
@@ -477,12 +479,18 @@ ompt_buffer_complete
 void
 ompt_trace_configure(ompt_device_t *device)
 {
+  // ignore tooling threads created while enabling a device
+  monitor_disable_new_threads();
+
   // indicate desired monitoring
   ompt_set_trace_ompt(device, 1, 0);
 
   // turn on monitoring previously indicated
   ompt_start_trace(device, ompt_buffer_request,
 		   ompt_buffer_complete);
+
+  // resume thread tracking
+  monitor_enable_new_threads();
 }
 
 


### PR DESCRIPTION
- use MONITOR_IGNORE_THREAD with module ignore map
- ignore threads setting up tracing for an openmp device
-  make gpu_trace_fini idempotent to avoid confusion
    - both vendor and openmp finalizers call gpu_trace_fini
