### PR TITLE
Rework how we handle xed to link xed directly into libhpcrun.so and

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -152,7 +152,6 @@ install-exec-local:
 	@$(call copy-libs,$(TBB_COPY),$(TBB_LIB_DIR),libtbb.so*)
 	@$(call copy-libs,$(TBB_COPY),$(TBB_LIB_DIR),libtbbmalloc.so*)
 	@$(call copy-libs,$(TBB_COPY),$(TBB_LIB_DIR),libtbbmalloc_proxy.so*)
-	@$(call copy-libs,$(XED2_COPY),$(XED2_LIB_DIR),lib*)
 	@$(call copy-libs,$(XERCES_COPY),$(XERCES_LIB),libxerces*)
 	@$(call copy-libs,$(ZLIB_COPY),$(ZLIB_LIB),libz.a libz.so*)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -910,7 +910,6 @@ install-exec-local:
 	@$(call copy-libs,$(TBB_COPY),$(TBB_LIB_DIR),libtbb.so*)
 	@$(call copy-libs,$(TBB_COPY),$(TBB_LIB_DIR),libtbbmalloc.so*)
 	@$(call copy-libs,$(TBB_COPY),$(TBB_LIB_DIR),libtbbmalloc_proxy.so*)
-	@$(call copy-libs,$(XED2_COPY),$(XED2_LIB_DIR),lib*)
 	@$(call copy-libs,$(XERCES_COPY),$(XERCES_LIB),libxerces*)
 	@$(call copy-libs,$(ZLIB_COPY),$(ZLIB_LIB),libz.a libz.so*)
 

--- a/configure
+++ b/configure
@@ -22255,13 +22255,8 @@ fi
 # Option: --with-xed=PATH
 #-------------------------------------------------
 
-# Now use static and shared libxed.  hpcrun requires .so or .a + fPIC,
-# hpclink requires .a, and fnbounds, etc can use either.  hpcprof-mpi
-# requires .a, but only if fully static (Cray).
-#
-# We support both old XED (2013) with single .a + fPIC and new (2015)
-# XED with separate .so and .a without fPIC, so we test if .a can link
-# into a shared library.
+# Now require static (.a) archive + fPIC for all cases in order to
+# hide the xed symbols.
 
 XED2_INC=
 XED2_LIB_DIR=no
@@ -22293,12 +22288,11 @@ case "$XED2" in
     if test ! -f "${XED2}/include/xed-interface.h" ; then
       as_fn_error $? "invalid xed2 directory: $XED2" "$LINENO" 5
     fi
-    if test ! -f "${XED2}/lib/libxed.so" && test ! -f "${XED2}/lib/libxed.a" ; then
+    if test ! -f "${XED2}/lib/libxed.a" ; then
       as_fn_error $? "invalid xed2 directory: $XED2" "$LINENO" 5
     fi
     XED2_INC="${XED2}/include"
     XED2_LIB_DIR="${XED2}/lib"
-    XED2_COPY=yes
     xed2_avail=yes
     num_pkgs=`expr 1 + $num_pkgs`
     ;;
@@ -22368,58 +22362,20 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
     CFLAGS="$ORIG_CFLAGS"
     LIBS="$ORIG_LIBS"
   fi
+
   #
-  # default lib flags: .so if exists, else .a
+  # now require .a archive + fPIC for both hpcrun and hpclink
   #
-  if test -f "${XED2}/lib/libxed.so" ; then
-    XED2_LIB_FLAGS="-L${XED2}/lib -lxed"
-  elif test -f "${XED2}/lib/libxed.a" ; then
-    XED2_LIB_FLAGS="${XED2}/lib/libxed.a"
-  else
-    as_fn_error $? "unable to find libxed.so or libxed.a" "$LINENO" 5
+  if test "$xed2_static_fpic" = no ; then
+    as_fn_error $? "libxed.a must be compiled with -fPIC" "$LINENO" 5
   fi
-  #
-  # hpcrun: .so, or .a + fPIC, else fail
-  #
-  if test -f "${XED2}/lib/libxed.so" ; then
-    XED2_HPCRUN_LIBS="-L${XED2}/lib -lxed"
-  elif test "$xed2_static_fpic" = yes ; then
-    XED2_HPCRUN_LIBS="${XED2}/lib/libxed.a"
-  else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unable to build hpcrun: no libxed with -fPIC" >&5
-$as_echo "$as_me: WARNING: unable to build hpcrun: no libxed with -fPIC" >&2;}
-    no_xed_for_hpcrun=yes
-  fi
-  #
-  # hpclink: .a only (with or without -fPIC)
-  #
-  if test -f "${XED2}/lib/libxed.a" ; then
-    XED2_HPCLINK_LIBS="${XED2}/lib/libxed.a"
-  else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unable to build hpclink: no static libxed.a" >&5
-$as_echo "$as_me: WARNING: unable to build hpclink: no static libxed.a" >&2;}
-    no_xed_for_hpclink=yes
-  fi
-  #
-  # hpcprof-mpi: same as hpclink if fully static, else default
-  #
-  echo "x$HPCPROFMPI_LT_LDFLAGS" | grep -e all-static >/dev/null 2>&1
-  if test $? = 0 ; then
-    XED2_PROF_MPI_LIBS="$XED2_HPCLINK_LIBS"
-  else
-    XED2_PROF_MPI_LIBS="$XED2_LIB_FLAGS"
-  fi
-  #
-  # add libirc.a, if exists for k1om
-  #
-  if test -f "${XED2}/lib/libirc.a" ; then
-    XED2_LIB_FLAGS="${XED2_LIB_FLAGS} ${XED2}/lib/libirc.a"
-    XED2_HPCRUN_LIBS="${XED2_HPCRUN_LIBS} ${XED2}/lib/libirc.a"
-    XED2_HPCLINK_LIBS="${XED2_HPCLINK_LIBS} ${XED2}/lib/libirc.a"
-    XED2_PROF_MPI_LIBS="${XED2_PROF_MPI_LIBS} ${XED2}/lib/libirc.a"
-  fi
-  { $as_echo "$as_me:${as_lineno-$LINENO}: xed2 lib flags: $XED2_LIB_FLAGS" >&5
-$as_echo "$as_me: xed2 lib flags: $XED2_LIB_FLAGS" >&6;}
+  XED2_LIB_FLAGS="${XED2}/lib/libxed.a"
+  XED2_HPCRUN_LIBS="${XED2}/lib/libxed.a"
+  XED2_HPCLINK_LIBS="${XED2}/lib/libxed.a"
+  XED2_PROF_MPI_LIBS="$XED2_LIB_FLAGS"
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: xed2 hpcrun libs: $XED2_HPCRUN_LIBS" >&5
+$as_echo "$as_me: xed2 hpcrun libs: $XED2_HPCRUN_LIBS" >&6;}
 fi
 
 
@@ -28148,6 +28104,18 @@ if test "x$with_spack" = xno && test "$num_pkgs" -lt 7 ; then
 $as_echo "$as_me: " >&6;}
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Not using --with-spack." >&5
 $as_echo "$as_me: WARNING: Not using --with-spack." >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unless you're building hpctoolkit only for docs or make dist," >&5
+$as_echo "$as_me: WARNING: Unless you're building hpctoolkit only for docs or make dist," >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: this is probably an error.  Rerun configure with:" >&5
+$as_echo "$as_me: WARNING: this is probably an error.  Rerun configure with:" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING:   --with-spack=/path/to/spack/install/gcc-x.y.z" >&5
+$as_echo "$as_me: WARNING:   --with-spack=/path/to/spack/install/gcc-x.y.z" >&2;}
+
+elif test "$OPT_ENABLE_HPCRUN" != yes ; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: " >&5
+$as_echo "$as_me: " >&6;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Missing prerequisites for building hpcrun." >&5
+$as_echo "$as_me: WARNING: Missing prerequisites for building hpcrun." >&2;}
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unless you're building hpctoolkit only for docs or make dist," >&5
 $as_echo "$as_me: WARNING: Unless you're building hpctoolkit only for docs or make dist," >&2;}
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: this is probably an error.  Rerun configure with:" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -3523,13 +3523,8 @@ AC_SUBST([TBB_COPY])
 # Option: --with-xed=PATH
 #-------------------------------------------------
 
-# Now use static and shared libxed.  hpcrun requires .so or .a + fPIC,
-# hpclink requires .a, and fnbounds, etc can use either.  hpcprof-mpi
-# requires .a, but only if fully static (Cray).
-#
-# We support both old XED (2013) with single .a + fPIC and new (2015)
-# XED with separate .so and .a without fPIC, so we test if .a can link
-# into a shared library.
+# Now require static (.a) archive + fPIC for all cases in order to
+# hide the xed symbols.
 
 XED2_INC=
 XED2_LIB_DIR=no
@@ -3559,12 +3554,11 @@ case "$XED2" in
     if test ! -f "${XED2}/include/xed-interface.h" ; then
       AC_MSG_ERROR([invalid xed2 directory: $XED2])
     fi
-    if test ! -f "${XED2}/lib/libxed.so" && test ! -f "${XED2}/lib/libxed.a" ; then
+    if test ! -f "${XED2}/lib/libxed.a" ; then
       AC_MSG_ERROR([invalid xed2 directory: $XED2])
     fi
     XED2_INC="${XED2}/include"
     XED2_LIB_DIR="${XED2}/lib"
-    XED2_COPY=yes
     xed2_avail=yes
     num_pkgs=`expr 1 + $num_pkgs`
     ;;
@@ -3610,55 +3604,19 @@ int my_xed_init(void)
     CFLAGS="$ORIG_CFLAGS"
     LIBS="$ORIG_LIBS"
   fi
+
   #
-  # default lib flags: .so if exists, else .a
+  # now require .a archive + fPIC for both hpcrun and hpclink
   #
-  if test -f "${XED2}/lib/libxed.so" ; then
-    XED2_LIB_FLAGS="-L${XED2}/lib -lxed"
-  elif test -f "${XED2}/lib/libxed.a" ; then
-    XED2_LIB_FLAGS="${XED2}/lib/libxed.a"
-  else
-    AC_MSG_ERROR([unable to find libxed.so or libxed.a])
+  if test "$xed2_static_fpic" = no ; then
+    AC_MSG_ERROR([libxed.a must be compiled with -fPIC])
   fi
-  #
-  # hpcrun: .so, or .a + fPIC, else fail
-  #
-  if test -f "${XED2}/lib/libxed.so" ; then
-    XED2_HPCRUN_LIBS="-L${XED2}/lib -lxed"
-  elif test "$xed2_static_fpic" = yes ; then
-    XED2_HPCRUN_LIBS="${XED2}/lib/libxed.a"
-  else
-    AC_MSG_WARN([unable to build hpcrun: no libxed with -fPIC])
-    no_xed_for_hpcrun=yes
-  fi
-  #
-  # hpclink: .a only (with or without -fPIC)
-  #
-  if test -f "${XED2}/lib/libxed.a" ; then
-    XED2_HPCLINK_LIBS="${XED2}/lib/libxed.a"
-  else
-    AC_MSG_WARN([unable to build hpclink: no static libxed.a])
-    no_xed_for_hpclink=yes
-  fi
-  #
-  # hpcprof-mpi: same as hpclink if fully static, else default
-  #
-  echo "x$HPCPROFMPI_LT_LDFLAGS" | grep -e all-static >/dev/null 2>&1
-  if test $? = 0 ; then
-    XED2_PROF_MPI_LIBS="$XED2_HPCLINK_LIBS"
-  else
-    XED2_PROF_MPI_LIBS="$XED2_LIB_FLAGS"
-  fi
-  #
-  # add libirc.a, if exists for k1om
-  #
-  if test -f "${XED2}/lib/libirc.a" ; then
-    XED2_LIB_FLAGS="${XED2_LIB_FLAGS} ${XED2}/lib/libirc.a"
-    XED2_HPCRUN_LIBS="${XED2_HPCRUN_LIBS} ${XED2}/lib/libirc.a"
-    XED2_HPCLINK_LIBS="${XED2_HPCLINK_LIBS} ${XED2}/lib/libirc.a"
-    XED2_PROF_MPI_LIBS="${XED2_PROF_MPI_LIBS} ${XED2}/lib/libirc.a"
-  fi
-  AC_MSG_NOTICE([xed2 lib flags: $XED2_LIB_FLAGS])
+  XED2_LIB_FLAGS="${XED2}/lib/libxed.a"
+  XED2_HPCRUN_LIBS="${XED2}/lib/libxed.a"
+  XED2_HPCLINK_LIBS="${XED2}/lib/libxed.a"
+  XED2_PROF_MPI_LIBS="$XED2_LIB_FLAGS"
+
+  AC_MSG_NOTICE([xed2 hpcrun libs: $XED2_HPCRUN_LIBS])
 fi
 
 AC_SUBST([XED2_INC])
@@ -5904,6 +5862,13 @@ fi
 if test "x$with_spack" = xno && test "$num_pkgs" -lt 7 ; then
   AC_MSG_NOTICE([])
   AC_MSG_WARN([Not using --with-spack.])
+  AC_MSG_WARN([Unless you're building hpctoolkit only for docs or make dist,])
+  AC_MSG_WARN([this is probably an error.  Rerun configure with:])
+  AC_MSG_WARN([  --with-spack=/path/to/spack/install/gcc-x.y.z])
+
+elif test "$OPT_ENABLE_HPCRUN" != yes ; then
+  AC_MSG_NOTICE([])
+  AC_MSG_WARN([Missing prerequisites for building hpcrun.])
   AC_MSG_WARN([Unless you're building hpctoolkit only for docs or make dist,])
   AC_MSG_WARN([this is probably an error.  Rerun configure with:])
   AC_MSG_WARN([  --with-spack=/path/to/spack/install/gcc-x.y.z])

--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -869,6 +869,11 @@ libhpcrun_o_LDADD =  \
 	$(OUR_LIBUNWIND_A)  \
 	$(OUR_LZMA_A)
 
+if HOST_CPU_X86_FAMILY
+libhpcrun_la_LIBADD += $(XED2_HPCRUN_LIBS)
+libhpcrun_o_LDADD += $(XED2_HPCRUN_LIBS)
+endif
+
 
 #-----------------------------------------------------------
 # whirled peas
@@ -929,7 +934,6 @@ if HOST_CPU_X86_FAMILY
   libhpcrun_o_CPPFLAGS  += $(MY_X86_INCLUDE_DIRS)
   libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
   libhpcrun_o_CCASFLAGS  = $(AM_CCASFLAGS)
-  libhpcrun_la_LDFLAGS  += $(XED2_HPCRUN_LIBS)
   libhpcrun_o_LDADD     += $(XED2_HPCLINK_LIBS) 
   libhpcrun_ga_la_CPPFLAGS += $(MY_X86_INCLUDE_DIRS)
   libhpcrun_ga_wrap_a_CPPFLAGS += $(MY_X86_INCLUDE_DIRS)
@@ -1036,7 +1040,6 @@ endif
 if UNW_X86
   UNW_SOURCE_FILES = $(UNW_X86_FILES)
   UNW_INCLUDE_DIRS = $(UNW_X86_INCLUDE_DIRS)
-  UNW_DYNAMIC_LD_FLAGS = $(XED2_HPCRUN_LIBS)
   UNW_STATIC_LD_FLAGS =  $(XED2_HPCLINK_LIBS)
 endif
 

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -179,15 +179,16 @@ host_triplet = @host@
 @OPT_BGQ_BACKEND_TRUE@am__append_21 = -I$(srcdir)/utilities/bgq-cnk
 @OPT_ENABLE_MPI_WRAP_TRUE@am__append_22 = mpi-overrides.c
 @OPT_ENABLE_MPI_WRAP_TRUE@am__append_23 = mpi-overrides.c
+@HOST_CPU_X86_FAMILY_TRUE@am__append_24 = $(XED2_HPCRUN_LIBS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_25 = $(XED2_HPCRUN_LIBS) \
+@HOST_CPU_X86_FAMILY_TRUE@	$(XED2_HPCLINK_LIBS)
 
 #-----------------------------------------------------------
 # whirled peas
 #-----------------------------------------------------------
-@HOST_OS_LINUX_TRUE@am__append_24 = $(MY_LINUX_DYNAMIC_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_25 = $(MY_MIPS_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_26 = $(MY_MIPS_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_27 = $(MY_MIPS_INCLUDE_DIRS)
-@HOST_CPU_MIPS_TRUE@am__append_28 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_OS_LINUX_TRUE@am__append_26 = $(MY_LINUX_DYNAMIC_FILES)
+@HOST_CPU_MIPS_TRUE@am__append_27 = $(MY_MIPS_FILES)
+@HOST_CPU_MIPS_TRUE@am__append_28 = $(MY_MIPS_FILES)
 @HOST_CPU_MIPS_TRUE@am__append_29 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_30 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_31 = $(MY_MIPS_INCLUDE_DIRS)
@@ -197,16 +198,16 @@ host_triplet = @host@
 @HOST_CPU_MIPS_TRUE@am__append_35 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_36 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_37 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_38 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_39 = $(MY_MIPS_INCLUDE_DIRS)
 
 # Note: setting CCASFLAGS here is a no-op hack with the side effect of
 # prefixing the tramp.s file names so they will be compiled separately
 # for .o and .so targets.  CFLAGS does this for the .c files, but
 # CFLAGS doesn't apply to .s files.  See the automake docs section
 # 8.3.9.2, Objects created with both libtool and without.
-@HOST_CPU_PPC_TRUE@am__append_38 = $(MY_PPC_FILES)
-@HOST_CPU_PPC_TRUE@am__append_39 = $(MY_PPC_FILES)
-@HOST_CPU_PPC_TRUE@am__append_40 = $(MY_PPC_INCLUDE_DIRS)
-@HOST_CPU_PPC_TRUE@am__append_41 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_PPC_TRUE@am__append_40 = $(MY_PPC_FILES)
+@HOST_CPU_PPC_TRUE@am__append_41 = $(MY_PPC_FILES)
 @HOST_CPU_PPC_TRUE@am__append_42 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_43 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_44 = $(MY_PPC_INCLUDE_DIRS)
@@ -218,12 +219,12 @@ host_triplet = @host@
 @HOST_CPU_PPC_TRUE@am__append_50 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_51 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_52 = $(MY_PPC_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_53 = $(MY_X86_FILES)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_54 = $(MY_X86_FILES)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_55 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_56 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_57 = $(XED2_HPCRUN_LIBS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_58 = $(XED2_HPCLINK_LIBS) 
+@HOST_CPU_PPC_TRUE@am__append_53 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_PPC_TRUE@am__append_54 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_55 = $(MY_X86_FILES)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_56 = $(MY_X86_FILES)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_57 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_58 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_59 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_60 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_61 = $(MY_X86_INCLUDE_DIRS)
@@ -449,8 +450,10 @@ libagent_tbb_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(libagent_tbb_la_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) \
 	-o $@
 @OPT_ENABLE_LUSH_TRUE@am_libagent_tbb_la_rpath = -rpath $(pkglibdir)
+am__DEPENDENCIES_1 =
+@HOST_CPU_X86_FAMILY_TRUE@am__DEPENDENCIES_2 = $(am__DEPENDENCIES_1)
 libhpcrun_la_DEPENDENCIES = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
-	$(OUR_LIBUNWIND_A) $(OUR_LZMA_A)
+	$(OUR_LIBUNWIND_A) $(OUR_LZMA_A) $(am__DEPENDENCIES_2)
 am__libhpcrun_la_SOURCES_DIST = utilities/first_func.c main.h main.c \
 	disabled.c closure-registry.c cct_insert_backtrace.c \
 	cct_backtrace_finalize.c env.c epoch.c files.c \
@@ -1287,17 +1290,17 @@ am_libhpcrun_o_OBJECTS = $(am__objects_57) $(am__objects_58) \
 	$(am__objects_73) $(am__objects_75) $(am__objects_35) \
 	$(am__objects_81) utilities/libhpcrun_o-last_func.$(OBJEXT)
 libhpcrun_o_OBJECTS = $(am_libhpcrun_o_OBJECTS)
-am__DEPENDENCIES_1 =
-@HOST_CPU_X86_FAMILY_TRUE@am__DEPENDENCIES_2 = $(am__DEPENDENCIES_1)
-@OPT_PAPI_STATIC_TRUE@am__DEPENDENCIES_3 = $(am__DEPENDENCIES_1)
-@UNW_LIBUNW_FALSE@@UNW_PPC64_FALSE@@UNW_X86_TRUE@am__DEPENDENCIES_4 = $(am__DEPENDENCIES_1)
-@UNW_LIBUNW_FALSE@@UNW_PPC64_TRUE@am__DEPENDENCIES_4 =  \
+@HOST_CPU_X86_FAMILY_TRUE@am__DEPENDENCIES_3 = $(am__DEPENDENCIES_1) \
+@HOST_CPU_X86_FAMILY_TRUE@	$(am__DEPENDENCIES_1)
+@OPT_PAPI_STATIC_TRUE@am__DEPENDENCIES_4 = $(am__DEPENDENCIES_1)
+@UNW_LIBUNW_FALSE@@UNW_PPC64_FALSE@@UNW_X86_TRUE@am__DEPENDENCIES_5 = $(am__DEPENDENCIES_1)
+@UNW_LIBUNW_FALSE@@UNW_PPC64_TRUE@am__DEPENDENCIES_5 =  \
 @UNW_LIBUNW_FALSE@@UNW_PPC64_TRUE@	$(am__DEPENDENCIES_1)
-@UNW_LIBUNW_TRUE@am__DEPENDENCIES_4 = $(am__DEPENDENCIES_1)
+@UNW_LIBUNW_TRUE@am__DEPENDENCIES_5 = $(am__DEPENDENCIES_1)
 libhpcrun_o_DEPENDENCIES = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
 	$(am__DEPENDENCIES_1) $(OUR_LIBUNWIND_A) $(OUR_LZMA_A) \
-	$(am__DEPENDENCIES_2) $(am__DEPENDENCIES_3) \
-	$(am__DEPENDENCIES_4)
+	$(am__DEPENDENCIES_3) $(am__DEPENDENCIES_4) \
+	$(am__DEPENDENCIES_5)
 libhpcrun_o_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(libhpcrun_o_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -2071,8 +2074,8 @@ MY_AARCH64_INCLUDE_DIRS = \
 	-I$(srcdir)/utilities/arch/aarch64
 
 libhpcrun_la_SOURCES = $(MY_BASE_FILES) $(MY_DYNAMIC_FILES) \
-	$(am__append_24) $(am__append_25) $(am__append_38) \
-	$(am__append_53) $(am__append_71) $(am__append_84) \
+	$(am__append_26) $(am__append_27) $(am__append_40) \
+	$(am__append_55) $(am__append_71) $(am__append_84) \
 	$(am__append_99) $(am__append_103) $(am__append_115) \
 	$(am__append_122) $(am__append_126) $(am__append_130) \
 	$(am__append_134) $(am__append_138) $(UNW_SOURCE_FILES) \
@@ -2084,7 +2087,7 @@ libhpcrun_audit_la_SOURCES = \
 	audit/auditor.c
 
 libhpcrun_o_SOURCES = $(MY_BASE_FILES) $(MY_STATIC_FILES) \
-	$(am__append_26) $(am__append_39) $(am__append_54) \
+	$(am__append_28) $(am__append_41) $(am__append_56) \
 	$(am__append_72) $(am__append_85) $(am__append_104) \
 	$(am__append_111) $(am__append_116) $(am__append_125) \
 	$(UNW_SOURCE_FILES) utilities/last_func.c
@@ -2131,8 +2134,8 @@ libhpctoolkit_a_SOURCES = \
 # cppflags
 #-----------------------------------------------------------
 libhpcrun_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_20) $(am__append_27) $(am__append_40) \
-	$(am__append_55) $(am__append_73) $(am__append_86) \
+	$(am__append_20) $(am__append_29) $(am__append_42) \
+	$(am__append_57) $(am__append_73) $(am__append_86) \
 	$(am__append_100) $(am__append_105) $(am__append_107) \
 	$(am__append_109) $(am__append_117) $(am__append_120) \
 	$(am__append_123) $(am__append_127) $(am__append_131) \
@@ -2146,8 +2149,8 @@ libhpcrun_audit_la_CPPFLAGS = \
 	$(MY_INCLUDE_DIRS)
 
 libhpcrun_o_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_21) $(am__append_28) \
-	$(am__append_41) $(am__append_56) $(am__append_74) \
+	$(MY_INCLUDE_DIRS) $(am__append_21) $(am__append_30) \
+	$(am__append_43) $(am__append_58) $(am__append_74) \
 	$(am__append_87) $(am__append_112) $(am__append_118) \
 	$(am__append_121) $(UNW_INCLUDE_DIRS)
 libhpcrun_wrap_a_CPPFLAGS = \
@@ -2156,40 +2159,40 @@ libhpcrun_wrap_a_CPPFLAGS = \
 	$(MY_INCLUDE_DIRS)
 
 libhpcrun_ga_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_29) $(am__append_42) $(am__append_59) \
+	$(am__append_31) $(am__append_44) $(am__append_59) \
 	$(am__append_75) $(am__append_88) $(UNW_INCLUDE_DIRS)
 libhpcrun_ga_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_30) $(am__append_43) \
+	$(MY_INCLUDE_DIRS) $(am__append_32) $(am__append_45) \
 	$(am__append_60) $(am__append_76) $(am__append_89) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_gprof_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_44) $(am__append_61) $(am__append_90)
+	$(am__append_46) $(am__append_61) $(am__append_90)
 libhpcrun_gprof_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_45) \
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_47) \
 	$(am__append_62) $(am__append_91)
 libhpcrun_io_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_31) $(am__append_46) $(am__append_63) \
+	$(am__append_33) $(am__append_48) $(am__append_63) \
 	$(am__append_77) $(am__append_92) $(UNW_INCLUDE_DIRS)
 libhpcrun_io_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_32) $(am__append_47) \
+	$(MY_INCLUDE_DIRS) $(am__append_34) $(am__append_49) \
 	$(am__append_64) $(am__append_78) $(am__append_93) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_33) $(am__append_48) $(am__append_65) \
+	$(am__append_35) $(am__append_50) $(am__append_65) \
 	$(am__append_79) $(am__append_94) $(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_34) \
-	$(am__append_49) $(am__append_66) $(am__append_80) \
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_36) \
+	$(am__append_51) $(am__append_66) $(am__append_80) \
 	$(am__append_95) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_35) $(am__append_50) $(am__append_67) \
+	$(am__append_37) $(am__append_52) $(am__append_67) \
 	$(am__append_81) $(am__append_96) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_36) \
-	$(am__append_51) $(am__append_68) $(am__append_82) \
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_38) \
+	$(am__append_53) $(am__append_68) $(am__append_82) \
 	$(am__append_97) $(UNW_INCLUDE_DIRS)
 libhpcrun_mpi_la_CPPFLAGS = $(MY_CPP_DEFINES) -I$(MPI_INC) \
-	$(MY_INCLUDE_DIRS) $(am__append_37) $(am__append_52) \
+	$(MY_INCLUDE_DIRS) $(am__append_39) $(am__append_54) \
 	$(am__append_69) $(am__append_83) $(am__append_98) \
 	$(UNW_INCLUDE_DIRS)
 libhpctoolkit_la_CPPFLAGS = \
@@ -2241,8 +2244,8 @@ OUR_LIBUNWIND_A = $(top_builddir)/src/extern/libunwind/libunwind.a
 OUR_LZMA_A = $(top_builddir)/src/extern/lzma/liblzma.a
 libhpcrun_la_LDFLAGS = -Wl,-Bsymbolic -L$(LIBMONITOR_LIB) -lmonitor \
 	-lpthread -lrt -L$(LIBELF_LIB) -lelf $(PERFMON_LDFLAGS_DYN) \
-	$(OPT_ROCM_LDFLAGS) $(am__append_57) $(am__append_101) \
-	$(am__append_119) $(GOTCHA_LDFLAGS) $(UNW_DYNAMIC_LD_FLAGS)
+	$(OPT_ROCM_LDFLAGS) $(am__append_101) $(am__append_119) \
+	$(GOTCHA_LDFLAGS) $(UNW_DYNAMIC_LD_FLAGS)
 libhpcrun_fake_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
 libhpcrun_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
 libhpcrun_ga_la_LDFLAGS = -Wl,-Bsymbolic
@@ -2259,15 +2262,11 @@ libhpcrun_mpi_la_LDFLAGS = -Wl,-Bsymbolic
 # (2) for static libhpcrun.o, use LDADD for archives that are linked
 # and hidden into libhpcrun.o.  Other dependencies go into hpclink.
 # Don't use LDFLAGS for static case.
-libhpcrun_la_LIBADD = \
-	$(PROF_LEAN_A)  \
-	$(SUPPORT_LEAN_A)  \
-	$(OUR_LIBUNWIND_A)  \
-	$(OUR_LZMA_A)
-
+libhpcrun_la_LIBADD = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
+	$(OUR_LIBUNWIND_A) $(OUR_LZMA_A) $(am__append_24)
 libhpcrun_o_LDADD = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
 	$(PERFMON_LDFLAGS_STAT) $(OUR_LIBUNWIND_A) $(OUR_LZMA_A) \
-	$(am__append_58) $(am__append_113) $(UNW_STATIC_LD_FLAGS)
+	$(am__append_25) $(am__append_113) $(UNW_STATIC_LD_FLAGS)
 MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_70) \
 	$(UNW_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
@@ -2286,12 +2285,11 @@ MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_70) \
 @UNW_LIBUNW_TRUE@UNW_INCLUDE_DIRS = $(UNW_LIBUNW_INCLUDE_DIRS)
 @UNW_PPC64_TRUE@UNW_INCLUDE_DIRS = $(UNW_PPC64_INCLUDE_DIRS)
 @UNW_X86_TRUE@UNW_INCLUDE_DIRS = $(UNW_X86_INCLUDE_DIRS)
-@UNW_LIBUNW_TRUE@UNW_DYNAMIC_LD_FLAGS = $(UNW_LIBUNW_LD_FLAGS)
-@UNW_PPC64_TRUE@UNW_DYNAMIC_LD_FLAGS = $(UNW_PPC64_LD_FLAGS)
-@UNW_X86_TRUE@UNW_DYNAMIC_LD_FLAGS = $(XED2_HPCRUN_LIBS)
 @UNW_LIBUNW_TRUE@UNW_STATIC_LD_FLAGS = $(UNW_LIBUNW_LD_FLAGS)
 @UNW_PPC64_TRUE@UNW_STATIC_LD_FLAGS = $(UNW_PPC64_LD_FLAGS)
 @UNW_X86_TRUE@UNW_STATIC_LD_FLAGS = $(XED2_HPCLINK_LIBS)
+@UNW_LIBUNW_TRUE@UNW_DYNAMIC_LD_FLAGS = $(UNW_LIBUNW_LD_FLAGS)
+@UNW_PPC64_TRUE@UNW_DYNAMIC_LD_FLAGS = $(UNW_PPC64_LD_FLAGS)
 libhpcrun_dlmopen_la_SOURCES = dlmopen/dlmopen.c
 libhpcrun_dlmopen_la_LDFLAGS = -ldl
 


### PR DESCRIPTION
libhpcrun.o.  This allows us to hide the xed symbols inside our
library in case the application also uses xed.

This now requires xed to be built statically (.a) with fPIC.

----------

@jmellorcrummey  This is the fix for the xed symbol clash.
Before merging into something, I want to test three things:

1. test on ppc and arm (me)
2. test on theta with static hpcprof-mpi (me)
3. verify that it actually does fix the xed clash with 2022.04.17 (johnmc)

