### PR TITLE
Unwind callers not returns

### DIFF
--- a/src/tool/hpcrun/lush/lush.c
+++ b/src/tool/hpcrun/lush/lush.c
@@ -411,8 +411,6 @@ lush_step_pchord(lush_cursor_t* cursor)
 lush_step_t
 lush_forcestep_pnote(lush_cursor_t* cursor)
 {
-  int steps_taken = 1;
-
   if (lush_cursor_is_flag(cursor, LUSH_CURSOR_FLAGS_END_PPROJ)) {
     return LUSH_STEP_END_PROJ;
   }
@@ -427,7 +425,7 @@ lush_forcestep_pnote(lush_cursor_t* cursor)
   }
   else {
     // Identity agent: Association is 1-to-1, so p-chord is unit length
-    int t = hpcrun_unw_step(lush_cursor_get_pcursor(cursor), &steps_taken);
+    int t = hpcrun_unw_step(lush_cursor_get_pcursor(cursor));
     if (t > 0) {
       ty = LUSH_STEP_END_CHORD;
     }

--- a/src/tool/hpcrun/unwind/common/backtrace.c
+++ b/src/tool/hpcrun/unwind/common/backtrace.c
@@ -208,7 +208,6 @@ hpcrun_generate_backtrace_no_trampoline(backtrace_info_t* bt,
   hpcrun_unw_cursor_t cursor;
   hpcrun_unw_init_cursor(&cursor, context);
 
-  int steps_taken = 0;
   do {	// loop over frames in the callstack
     void* ip;
     hpcrun_unw_get_ip_unnorm_reg(&cursor, &ip);
@@ -263,7 +262,7 @@ hpcrun_generate_backtrace_no_trampoline(backtrace_info_t* bt,
       bt->fence = cursor.fence;
 
     } else {
-      ret = hpcrun_unw_step ( &cursor, &steps_taken);
+      ret = hpcrun_unw_step(&cursor);
     }
 
     switch (ret) {

--- a/src/tool/hpcrun/unwind/common/libunw_intervals.h
+++ b/src/tool/hpcrun/unwind/common/libunw_intervals.h
@@ -68,7 +68,7 @@ bool libunw_finalize_cursor(hpcrun_unw_cursor_t* cursor, int decrement_pc);
 
 step_state libunw_take_step(hpcrun_unw_cursor_t* cursor);
 
-step_state libunw_unw_step(hpcrun_unw_cursor_t* cursor, int *steps_taken);
+step_state libunw_unw_step(hpcrun_unw_cursor_t* cursor);
 
 void libunw_uw_recipe_tostr(void* uwr, char str[]);
 

--- a/src/tool/hpcrun/unwind/common/unwind.h
+++ b/src/tool/hpcrun/unwind/common/unwind.h
@@ -131,7 +131,7 @@ typedef enum {
 
 
 step_state
-hpcrun_unw_step(hpcrun_unw_cursor_t* c, int *steps_taken);
+hpcrun_unw_step(hpcrun_unw_cursor_t* c);
 
 
 //***************************************************************************

--- a/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
+++ b/src/tool/hpcrun/unwind/generic-libunwind/libunw-unwind.c
@@ -176,23 +176,14 @@ hpcrun_unw_init_cursor(hpcrun_unw_cursor_t* cursor, void* context)
 }
 
 step_state
-hpcrun_unw_step(hpcrun_unw_cursor_t* cursor, int *steps_taken)
+hpcrun_unw_step(hpcrun_unw_cursor_t* cursor)
 {
   static bool msg_sent = false;
   if (msg_sent == false) {
     TMSG(NU, "hpcrun_unw_step from libunw_unwind.c" );
     msg_sent = true;
   }
-  step_state state = STEP_ERROR;
-  state = libunw_unw_step(cursor, steps_taken);
-  if (state == STEP_ERROR) {
-    unw_cursor_t *unw_cursor = &(cursor->uc);
-    if (unw_step(unw_cursor)) {
-      state = STEP_OK;
-      libunw_finalize_cursor(cursor, *steps_taken > 0);
-    }
-  }
-  return state;
+  return libunw_unw_step(cursor);
 }
 
 btuwi_status_t

--- a/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
+++ b/src/tool/hpcrun/unwind/x86-family/x86-unwind.c
@@ -426,42 +426,26 @@ hpcrun_unw_step(hpcrun_unw_cursor_t *cursor)
   }
 
   if (cursor->libunw_status == LIBUNW_READY) {
-    unw_res = libunw_take_step(cursor);
-    // libunw_take_step() only updates PC.
-    // Here, we need to update bp, sp, ra_loc.
-    void *pc, *bp, *sp;
-    unw_save_loc_t ip_loc;
-    unw_get_reg(&cursor->uc, UNW_REG_IP, (unw_word_t *)&pc);
-    unw_get_reg(&cursor->uc, UNW_REG_SP, (unw_word_t *)&sp);
-    unw_get_reg(&cursor->uc, UNW_TDEP_BP, (unw_word_t *)&bp);
-    
-    /** libunwind version after Mar 6, 2018 
-     * (commission 7f04c2032f1a2328072f3a3733abf74a72188458)
-     * is needed to get location of IP.
-     */
-    unw_get_save_loc(&cursor->uc, UNW_REG_IP, &ip_loc);
+    void** prev_sp = cursor->sp;
 
-    // invariant: unwind must move x86 stack pointer 
-    if (sp <= (void *) cursor->sp) {
-      cursor->libunw_status = LIBUNW_UNAVAIL;
-      unw_res = STEP_ERROR;
+    unw_res = libunw_unw_step(cursor);
+
+    if (unw_res > STEP_STOP) {
+      // Invariant: unwind must move x86 stack pointer (up, since stacks grow down)
+      if (prev_sp >= cursor->sp) {
+        cursor->libunw_status = LIBUNW_UNAVAIL;
+        unw_res = STEP_ERROR;
+      }
     }
-    else
-     save_registers(cursor, pc, bp, sp, 
-            ip_loc.type == UNW_SLT_MEMORY ? (void**)ip_loc.u.addr : 0);
-    
+
     // if PC is trampoline, must skip libunw_find_step() to avoid trolling.
     if (hpcrun_trampoline_at_entry(cursor->pc_unnorm))
-        return STEP_OK;
-    
-    if (unw_res == STEP_OK) {
-      libunw_finalize_cursor(cursor, 1);
-    }
+      return STEP_OK;
 
-    if (unw_res == STEP_STOP || unw_res == STEP_OK) {
+    if (unw_res >= STEP_STOP)
       return unw_res;
-    }
-    bool found = uw_recipe_map_lookup((char *)pc - (pc > 0 ? 1 : 0), NATIVE_UNWINDER, &cursor->unwr_info);
+
+    bool found = uw_recipe_map_lookup((void *)cursor->pc_unnorm - (cursor->pc_unnorm > 0 ? 1 : 0), NATIVE_UNWINDER, &cursor->unwr_info);
 
     if (!found) {
       EMSG("hpcrun_unw_step: cursor could NOT build an interval for last libunwind pc = %p",


### PR DESCRIPTION
When unwinding a stack frame, the PC in the resulting frame is a return address, rather
than a call address. If the compiler did not expect the call to return, the compiler may
pack instructions in a way such that the unwind recipe for the return address is not the
same as the call address.

This commit changes the semantic of hpcrun_unw_step to always result in a "caller" frame,
with an approximate call address of (return address - 1), instead of the "return" frame
returned previously. This simplifies the incomplete logic added in b99930f9b3d4bb3d9e384e9f91e212cc0df53d53
and extends it to apply to the generic libunwind and Power cases as well.

The x86 native unwinder is unchanged in this commit, it fails to unwind even in the
microtest case used to validate this patch.

Fixes #540 