### PR TITLE
Add a C++ GT-Pin support library for use by hpcrun

### DIFF
--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -570,6 +570,12 @@ MY_GTPIN_FILES = \
 	gpu/instrumentation/simdgroup-map.c \
 	gpu/instrumentation/gtpin-instrumentation.c \
 	gpu/instrumentation/gtpin-correlation-id-map.c
+
+pkglib_LTLIBRARIES += libhpcrun_gtpin_knob.la
+libhpcrun_gtpin_knob_la_CPPFLAGS  = $(OPT_GTPIN_IFLAGS)
+libhpcrun_gtpin_knob_la_SOURCES   = gpu/instrumentation/gtpin-knob.cpp
+libhpcrun_gtpin_knob_la_LDFLAGS   = -Wl,-Bsymbolic
+libhpcrun_gtpin_knob_la_LDFLAGS   += -L$(OPT_GTPIN_LIBDIR) -Wl,-rpath=$(OPT_GTPIN_LIBDIR) -lgtpin
 endif
 
 if OPT_ENABLE_ROCM

--- a/src/tool/hpcrun/Makefile.am
+++ b/src/tool/hpcrun/Makefile.am
@@ -571,11 +571,11 @@ MY_GTPIN_FILES = \
 	gpu/instrumentation/gtpin-instrumentation.c \
 	gpu/instrumentation/gtpin-correlation-id-map.c
 
-pkglib_LTLIBRARIES += libhpcrun_gtpin_knob.la
-libhpcrun_gtpin_knob_la_CPPFLAGS  = $(OPT_GTPIN_IFLAGS)
-libhpcrun_gtpin_knob_la_SOURCES   = gpu/instrumentation/gtpin-knob.cpp
-libhpcrun_gtpin_knob_la_LDFLAGS   = -Wl,-Bsymbolic
-libhpcrun_gtpin_knob_la_LDFLAGS   += -L$(OPT_GTPIN_LIBDIR) -Wl,-rpath=$(OPT_GTPIN_LIBDIR) -lgtpin
+pkglib_LTLIBRARIES += libhpcrun_gtpin_cxx.la
+libhpcrun_gtpin_cxx_la_CPPFLAGS  = $(OPT_GTPIN_IFLAGS)
+libhpcrun_gtpin_cxx_la_SOURCES   = gpu/instrumentation/gtpin-knob.cpp
+libhpcrun_gtpin_cxx_la_LDFLAGS   = -Wl,-Bsymbolic
+libhpcrun_gtpin_cxx_la_LDFLAGS   += -L$(OPT_GTPIN_LIBDIR) -Wl,-rpath=$(OPT_GTPIN_LIBDIR) -lgtpin
 endif
 
 if OPT_ENABLE_ROCM

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -170,27 +170,27 @@ host_triplet = @host@
 @OPT_PAPI_COMPONENT_TRUE@am__append_16 = -DHPCRUN_SS_PAPI_C_INTEL
 @OPT_PAPI_CUPTI_TRUE@am__append_17 = sample-sources/papi-c-cupti.c
 @OPT_ENABLE_OPENCL_TRUE@am__append_18 = libhpcrun_opencl.la
-@OPT_ENABLE_LEVEL0_TRUE@am__append_19 = libhpcrun_level0.la
+@OPT_ENABLE_GTPIN_TRUE@am__append_19 = libhpcrun_gtpin_knob.la
+@OPT_ENABLE_LEVEL0_TRUE@am__append_20 = libhpcrun_level0.la
 
 #
 # BG/Q backend requires special treatment to avoid deadlocks
 #
-@OPT_BGQ_BACKEND_TRUE@am__append_20 = -DUSE_HW_THREAD_ID -DNONZERO_THRESHOLD
-@OPT_BGQ_BACKEND_TRUE@am__append_21 = -I$(srcdir)/utilities/bgq-cnk
+@OPT_BGQ_BACKEND_TRUE@am__append_21 = -DUSE_HW_THREAD_ID -DNONZERO_THRESHOLD
 @OPT_BGQ_BACKEND_TRUE@am__append_22 = -I$(srcdir)/utilities/bgq-cnk
-@OPT_ENABLE_MPI_WRAP_TRUE@am__append_23 = mpi-overrides.c
+@OPT_BGQ_BACKEND_TRUE@am__append_23 = -I$(srcdir)/utilities/bgq-cnk
 @OPT_ENABLE_MPI_WRAP_TRUE@am__append_24 = mpi-overrides.c
-@HOST_CPU_X86_FAMILY_TRUE@am__append_25 = $(XED2_HPCRUN_LIBS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_26 = $(XED2_HPCRUN_LIBS) \
+@OPT_ENABLE_MPI_WRAP_TRUE@am__append_25 = mpi-overrides.c
+@HOST_CPU_X86_FAMILY_TRUE@am__append_26 = $(XED2_HPCRUN_LIBS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_27 = $(XED2_HPCRUN_LIBS) \
 @HOST_CPU_X86_FAMILY_TRUE@	$(XED2_HPCLINK_LIBS)
 
 #-----------------------------------------------------------
 # whirled peas
 #-----------------------------------------------------------
-@HOST_OS_LINUX_TRUE@am__append_27 = $(MY_LINUX_DYNAMIC_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_28 = $(MY_MIPS_FILES)
+@HOST_OS_LINUX_TRUE@am__append_28 = $(MY_LINUX_DYNAMIC_FILES)
 @HOST_CPU_MIPS_TRUE@am__append_29 = $(MY_MIPS_FILES)
-@HOST_CPU_MIPS_TRUE@am__append_30 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_30 = $(MY_MIPS_FILES)
 @HOST_CPU_MIPS_TRUE@am__append_31 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_32 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_33 = $(MY_MIPS_INCLUDE_DIRS)
@@ -201,15 +201,15 @@ host_triplet = @host@
 @HOST_CPU_MIPS_TRUE@am__append_38 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_39 = $(MY_MIPS_INCLUDE_DIRS)
 @HOST_CPU_MIPS_TRUE@am__append_40 = $(MY_MIPS_INCLUDE_DIRS)
+@HOST_CPU_MIPS_TRUE@am__append_41 = $(MY_MIPS_INCLUDE_DIRS)
 
 # Note: setting CCASFLAGS here is a no-op hack with the side effect of
 # prefixing the tramp.s file names so they will be compiled separately
 # for .o and .so targets.  CFLAGS does this for the .c files, but
 # CFLAGS doesn't apply to .s files.  See the automake docs section
 # 8.3.9.2, Objects created with both libtool and without.
-@HOST_CPU_PPC_TRUE@am__append_41 = $(MY_PPC_FILES)
 @HOST_CPU_PPC_TRUE@am__append_42 = $(MY_PPC_FILES)
-@HOST_CPU_PPC_TRUE@am__append_43 = $(MY_PPC_INCLUDE_DIRS)
+@HOST_CPU_PPC_TRUE@am__append_43 = $(MY_PPC_FILES)
 @HOST_CPU_PPC_TRUE@am__append_44 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_45 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_46 = $(MY_PPC_INCLUDE_DIRS)
@@ -222,9 +222,9 @@ host_triplet = @host@
 @HOST_CPU_PPC_TRUE@am__append_53 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_54 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_PPC_TRUE@am__append_55 = $(MY_PPC_INCLUDE_DIRS)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_56 = $(MY_X86_FILES)
+@HOST_CPU_PPC_TRUE@am__append_56 = $(MY_PPC_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_57 = $(MY_X86_FILES)
-@HOST_CPU_X86_FAMILY_TRUE@am__append_58 = $(MY_X86_INCLUDE_DIRS)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_58 = $(MY_X86_FILES)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_59 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_60 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_61 = $(MY_X86_INCLUDE_DIRS)
@@ -238,9 +238,9 @@ host_triplet = @host@
 @HOST_CPU_X86_FAMILY_TRUE@am__append_69 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_70 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_X86_FAMILY_TRUE@am__append_71 = $(MY_X86_INCLUDE_DIRS)
-@HOST_CPU_IA64_TRUE@am__append_72 = $(MY_IA64_FILES)
+@HOST_CPU_X86_FAMILY_TRUE@am__append_72 = $(MY_X86_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_73 = $(MY_IA64_FILES)
-@HOST_CPU_IA64_TRUE@am__append_74 = $(MY_IA64_INCLUDE_DIRS)
+@HOST_CPU_IA64_TRUE@am__append_74 = $(MY_IA64_FILES)
 @HOST_CPU_IA64_TRUE@am__append_75 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_76 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_77 = $(MY_IA64_INCLUDE_DIRS)
@@ -251,9 +251,9 @@ host_triplet = @host@
 @HOST_CPU_IA64_TRUE@am__append_82 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_83 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_IA64_TRUE@am__append_84 = $(MY_IA64_INCLUDE_DIRS)
-@HOST_CPU_AARCH64_TRUE@am__append_85 = $(MY_AARCH64_FILES)
+@HOST_CPU_IA64_TRUE@am__append_85 = $(MY_IA64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_86 = $(MY_AARCH64_FILES)
-@HOST_CPU_AARCH64_TRUE@am__append_87 = $(MY_AARCH64_INCLUDE_DIRS)
+@HOST_CPU_AARCH64_TRUE@am__append_87 = $(MY_AARCH64_FILES)
 @HOST_CPU_AARCH64_TRUE@am__append_88 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_89 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_90 = $(MY_AARCH64_INCLUDE_DIRS)
@@ -266,52 +266,53 @@ host_triplet = @host@
 @HOST_CPU_AARCH64_TRUE@am__append_97 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_98 = $(MY_AARCH64_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@am__append_99 = $(MY_AARCH64_INCLUDE_DIRS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_100 = $(MY_PAPI_FILES)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_101 = $(PAPI_INC_FLGS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_102 = $(PAPI_LD_FLGS)
-@OPT_PAPI_DYNAMIC_TRUE@am__append_103 = -DHPCRUN_SS_PAPI
-@OPT_ENABLE_CUPTI_TRUE@am__append_104 = $(MY_CUPTI_FILES)
+@HOST_CPU_AARCH64_TRUE@am__append_100 = $(MY_AARCH64_INCLUDE_DIRS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_101 = $(MY_PAPI_FILES)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_102 = $(PAPI_INC_FLGS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_103 = $(PAPI_LD_FLGS)
+@OPT_PAPI_DYNAMIC_TRUE@am__append_104 = -DHPCRUN_SS_PAPI
 @OPT_ENABLE_CUPTI_TRUE@am__append_105 = $(MY_CUPTI_FILES)
-@OPT_ENABLE_CUPTI_TRUE@am__append_106 = $(CUPTI_INC_FLGS)
-@OPT_ENABLE_CUPTI_TRUE@am__append_107 = -DHPCRUN_SS_NVIDIA
-@OPT_PAPI_CUPTI_TRUE@am__append_108 = $(CUPTI_INC_FLGS)
-@OPT_PAPI_CUPTI_TRUE@am__append_109 = -DHPCRUN_SS_PAPI_C_CUPTI
-@OPT_PAPI_ROCM_TRUE@am__append_110 = $(ROCM_INC_FLGS)
-@OPT_PAPI_ROCM_TRUE@am__append_111 = -DHPCRUN_SS_PAPI_C_ROCM
-@OPT_PAPI_STATIC_TRUE@am__append_112 = $(MY_PAPI_FILES)
-@OPT_PAPI_STATIC_TRUE@am__append_113 = $(PAPI_INC_FLGS)
-@OPT_PAPI_STATIC_TRUE@am__append_114 = $(OPT_PAPI_LIBS_STAT)
-@OPT_PAPI_STATIC_TRUE@am__append_115 = -DHPCRUN_SS_PAPI
-@OPT_ENABLE_UPC_TRUE@am__append_116 = $(MY_UPC_FILES)
+@OPT_ENABLE_CUPTI_TRUE@am__append_106 = $(MY_CUPTI_FILES)
+@OPT_ENABLE_CUPTI_TRUE@am__append_107 = $(CUPTI_INC_FLGS)
+@OPT_ENABLE_CUPTI_TRUE@am__append_108 = -DHPCRUN_SS_NVIDIA
+@OPT_PAPI_CUPTI_TRUE@am__append_109 = $(CUPTI_INC_FLGS)
+@OPT_PAPI_CUPTI_TRUE@am__append_110 = -DHPCRUN_SS_PAPI_C_CUPTI
+@OPT_PAPI_ROCM_TRUE@am__append_111 = $(ROCM_INC_FLGS)
+@OPT_PAPI_ROCM_TRUE@am__append_112 = -DHPCRUN_SS_PAPI_C_ROCM
+@OPT_PAPI_STATIC_TRUE@am__append_113 = $(MY_PAPI_FILES)
+@OPT_PAPI_STATIC_TRUE@am__append_114 = $(PAPI_INC_FLGS)
+@OPT_PAPI_STATIC_TRUE@am__append_115 = $(OPT_PAPI_LIBS_STAT)
+@OPT_PAPI_STATIC_TRUE@am__append_116 = -DHPCRUN_SS_PAPI
 @OPT_ENABLE_UPC_TRUE@am__append_117 = $(MY_UPC_FILES)
-@OPT_ENABLE_UPC_TRUE@am__append_118 = $(OPT_UPC_IFLAGS)
+@OPT_ENABLE_UPC_TRUE@am__append_118 = $(MY_UPC_FILES)
 @OPT_ENABLE_UPC_TRUE@am__append_119 = $(OPT_UPC_IFLAGS)
-@OPT_ENABLE_UPC_TRUE@am__append_120 = $(OPT_UPC_LDFLAGS)
-@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_121 = -DLUSH_PTHREADS
+@OPT_ENABLE_UPC_TRUE@am__append_120 = $(OPT_UPC_IFLAGS)
+@OPT_ENABLE_UPC_TRUE@am__append_121 = $(OPT_UPC_LDFLAGS)
 @OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_122 = -DLUSH_PTHREADS
-@OPT_ENABLE_CUDA_TRUE@am__append_123 = $(MY_CUDA_FILES)
-@OPT_ENABLE_CUDA_TRUE@am__append_124 = -DENABLE_CUDA
-@OPT_ENABLE_CUDA_TRUE@am__append_125 = $(OPT_CUDA_IFLAGS)
-@OPT_ENABLE_CUDA_TRUE@am__append_126 = $(MY_CUDA_FILES)
-@OPT_ENABLE_ROCM_TRUE@am__append_127 = $(MY_ROCM_FILES)
-@OPT_ENABLE_ROCM_TRUE@am__append_128 = -DENABLE_ROCM
-@OPT_ENABLE_ROCM_TRUE@am__append_129 = $(ROCM_INC_FLGS)
-@OPT_ENABLE_ROCM_TRUE@am__append_130 = -DHPCRUN_SS_AMD
-@OPT_ENABLE_LEVEL0_TRUE@am__append_131 = $(MY_LEVEL0_FILES)
-@OPT_ENABLE_LEVEL0_TRUE@am__append_132 = -DENABLE_LEVEL0
-@OPT_ENABLE_LEVEL0_TRUE@am__append_133 = $(OPT_LEVEL0_IFLAGS)
-@OPT_ENABLE_LEVEL0_TRUE@am__append_134 = -DHPCRUN_SS_LEVEL0
-@OPT_ENABLE_OPENCL_TRUE@am__append_135 = $(MY_OPENCL_FILES)
-@OPT_ENABLE_OPENCL_TRUE@am__append_136 = -DENABLE_OPENCL \
+@OPT_ENABLE_LUSH_PTHREADS_TRUE@am__append_123 = -DLUSH_PTHREADS
+@OPT_ENABLE_CUDA_TRUE@am__append_124 = $(MY_CUDA_FILES)
+@OPT_ENABLE_CUDA_TRUE@am__append_125 = -DENABLE_CUDA
+@OPT_ENABLE_CUDA_TRUE@am__append_126 = $(OPT_CUDA_IFLAGS)
+@OPT_ENABLE_CUDA_TRUE@am__append_127 = $(MY_CUDA_FILES)
+@OPT_ENABLE_ROCM_TRUE@am__append_128 = $(MY_ROCM_FILES)
+@OPT_ENABLE_ROCM_TRUE@am__append_129 = -DENABLE_ROCM
+@OPT_ENABLE_ROCM_TRUE@am__append_130 = $(ROCM_INC_FLGS)
+@OPT_ENABLE_ROCM_TRUE@am__append_131 = -DHPCRUN_SS_AMD
+@OPT_ENABLE_LEVEL0_TRUE@am__append_132 = $(MY_LEVEL0_FILES)
+@OPT_ENABLE_LEVEL0_TRUE@am__append_133 = -DENABLE_LEVEL0
+@OPT_ENABLE_LEVEL0_TRUE@am__append_134 = $(OPT_LEVEL0_IFLAGS)
+@OPT_ENABLE_LEVEL0_TRUE@am__append_135 = -DHPCRUN_SS_LEVEL0
+@OPT_ENABLE_OPENCL_TRUE@am__append_136 = $(MY_OPENCL_FILES)
+@OPT_ENABLE_OPENCL_TRUE@am__append_137 = -DENABLE_OPENCL \
 @OPT_ENABLE_OPENCL_TRUE@	$(OPT_OCL_BH_IFLAGS)
-@OPT_ENABLE_OPENCL_TRUE@am__append_137 = $(OPT_OPENCL_IFLAGS)
-@OPT_ENABLE_OPENCL_TRUE@am__append_138 = -DHPCRUN_SS_OPENCL
-@OPT_ENABLE_GTPIN_TRUE@am__append_139 = $(MY_GTPIN_FILES)
-@OPT_ENABLE_GTPIN_TRUE@am__append_140 = -DENABLE_GTPIN -DGTPIN_LIBDIR=$(OPT_GTPIN_LIBDIR)
-@OPT_ENABLE_GTPIN_TRUE@am__append_141 = $(OPT_GTPIN_IFLAGS)
-@OPT_ENABLE_GTPIN_TRUE@am__append_142 = -DHPCRUN_SS_GTPIN
-@OPT_ENABLE_LUSH_TRUE@@OPT_WITH_CILK_TRUE@am__append_143 = libagent-cilk.la
-@OPT_ENABLE_LUSH_TRUE@am__append_144 = libagent-pthread.la \
+@OPT_ENABLE_OPENCL_TRUE@am__append_138 = $(OPT_OPENCL_IFLAGS)
+@OPT_ENABLE_OPENCL_TRUE@am__append_139 = -DHPCRUN_SS_OPENCL
+@OPT_ENABLE_GTPIN_TRUE@am__append_140 = $(MY_GTPIN_FILES)
+@OPT_ENABLE_GTPIN_TRUE@am__append_141 = -DENABLE_GTPIN -DGTPIN_LIBDIR=$(OPT_GTPIN_LIBDIR)
+@OPT_ENABLE_GTPIN_TRUE@am__append_142 = $(OPT_GTPIN_IFLAGS)
+@OPT_ENABLE_GTPIN_TRUE@am__append_143 = -DHPCRUN_SS_GTPIN
+@OPT_ENABLE_LUSH_TRUE@@OPT_WITH_CILK_TRUE@am__append_144 = libagent-cilk.la
+@OPT_ENABLE_LUSH_TRUE@am__append_145 = libagent-pthread.la \
 @OPT_ENABLE_LUSH_TRUE@	libagent-tbb.la
 subdir = src/tool/hpcrun
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -935,6 +936,18 @@ libhpcrun_gprof_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(libhpcrun_gprof_la_LDFLAGS) $(LDFLAGS) -o $@
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am_libhpcrun_gprof_la_rpath = -rpath \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	$(pkglibdir)
+libhpcrun_gtpin_knob_la_LIBADD =
+am__libhpcrun_gtpin_knob_la_SOURCES_DIST =  \
+	gpu/instrumentation/gtpin-knob.cpp
+@OPT_ENABLE_GTPIN_TRUE@am_libhpcrun_gtpin_knob_la_OBJECTS = gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo
+libhpcrun_gtpin_knob_la_OBJECTS =  \
+	$(am_libhpcrun_gtpin_knob_la_OBJECTS)
+libhpcrun_gtpin_knob_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(AM_CXXFLAGS) $(CXXFLAGS) $(libhpcrun_gtpin_knob_la_LDFLAGS) \
+	$(LDFLAGS) -o $@
+@OPT_ENABLE_GTPIN_TRUE@am_libhpcrun_gtpin_knob_la_rpath = -rpath \
+@OPT_ENABLE_GTPIN_TRUE@	$(pkglibdir)
 libhpcrun_io_la_LIBADD =
 am_libhpcrun_io_la_OBJECTS =  \
 	sample-sources/libhpcrun_io_la-io-over.lo
@@ -1417,6 +1430,24 @@ AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
+CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
+	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
+LTCXXCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) \
+	$(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
+	$(AM_CXXFLAGS) $(CXXFLAGS)
+AM_V_CXX = $(am__v_CXX_@AM_V@)
+am__v_CXX_ = $(am__v_CXX_@AM_DEFAULT_V@)
+am__v_CXX_0 = @echo "  CXX     " $@;
+am__v_CXX_1 = 
+CXXLD = $(CXX)
+CXXLINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(AM_CXXFLAGS) \
+	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
+AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
+am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
+am__v_CXXLD_0 = @echo "  CXXLD   " $@;
+am__v_CXXLD_1 = 
 CCASCOMPILE = $(CCAS) $(AM_CCASFLAGS) $(CCASFLAGS)
 LTCCASCOMPILE = $(LIBTOOL) $(AM_V_lt) $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=compile $(CCAS) $(AM_CCASFLAGS) \
@@ -1435,7 +1466,8 @@ SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(libagent_tbb_la_SOURCES) $(libhpcrun_la_SOURCES) \
 	$(libhpcrun_audit_la_SOURCES) $(libhpcrun_dlmopen_la_SOURCES) \
 	$(libhpcrun_fake_audit_la_SOURCES) $(libhpcrun_ga_la_SOURCES) \
-	$(libhpcrun_gprof_la_SOURCES) $(libhpcrun_io_la_SOURCES) \
+	$(libhpcrun_gprof_la_SOURCES) \
+	$(libhpcrun_gtpin_knob_la_SOURCES) $(libhpcrun_io_la_SOURCES) \
 	$(libhpcrun_level0_la_SOURCES) $(libhpcrun_memleak_la_SOURCES) \
 	$(libhpcrun_mpi_la_SOURCES) $(libhpcrun_opencl_la_SOURCES) \
 	$(libhpcrun_pthread_la_SOURCES) $(libhpctoolkit_la_SOURCES) \
@@ -1452,7 +1484,9 @@ DIST_SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(am__libhpcrun_la_SOURCES_DIST) $(libhpcrun_audit_la_SOURCES) \
 	$(libhpcrun_dlmopen_la_SOURCES) \
 	$(libhpcrun_fake_audit_la_SOURCES) $(libhpcrun_ga_la_SOURCES) \
-	$(libhpcrun_gprof_la_SOURCES) $(libhpcrun_io_la_SOURCES) \
+	$(libhpcrun_gprof_la_SOURCES) \
+	$(am__libhpcrun_gtpin_knob_la_SOURCES_DIST) \
+	$(libhpcrun_io_la_SOURCES) \
 	$(am__libhpcrun_level0_la_SOURCES_DIST) \
 	$(libhpcrun_memleak_la_SOURCES) $(libhpcrun_mpi_la_SOURCES) \
 	$(am__libhpcrun_opencl_la_SOURCES_DIST) \
@@ -1855,9 +1889,10 @@ pkglibexec_SCRIPTS = $(am__append_1)
 include_HEADERS = $(am__append_2)
 pkglib_LIBRARIES = $(am__append_5)
 pkglib_LTLIBRARIES = $(am__append_3) $(am__append_7) $(am__append_18) \
-	$(am__append_19) $(am__append_143) $(am__append_144)
-BUILT_SOURCES = $(am__append_23)
-CLEANFILES = $(am__append_24)
+	$(am__append_19) $(am__append_20) $(am__append_144) \
+	$(am__append_145)
+BUILT_SOURCES = $(am__append_24)
+CLEANFILES = $(am__append_25)
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@noinst_LTLIBRARIES = libhpcrun.la
 PAPI_INC_FLGS = @OPT_PAPI_IFLAGS@ 
 PAPI_LD_FLGS = @OPT_PAPI_LDFLAGS@
@@ -1947,10 +1982,10 @@ UNW_MIPS_INCLUDE_DIRS = \
 UNW_MIPS_LD_FLAGS = 
 MY_CPP_DEFINES = -D_GNU_SOURCE -DINLINE_FN=1 -DLOCAL_BUILD=1 \
 	-D__HIP_PLATFORM_HCC__=1 $(am__append_11) $(am__append_16) \
-	$(am__append_20) $(am__append_103) $(am__append_107) \
-	$(am__append_109) $(am__append_111) $(am__append_115) \
-	$(am__append_130) $(am__append_134) $(am__append_138) \
-	$(am__append_142)
+	$(am__append_21) $(am__append_104) $(am__append_108) \
+	$(am__append_110) $(am__append_112) $(am__append_116) \
+	$(am__append_131) $(am__append_135) $(am__append_139) \
+	$(am__append_143)
 MY_BASE_FILES = utilities/first_func.c main.h main.c disabled.c \
 	closure-registry.c cct_insert_backtrace.c \
 	cct_backtrace_finalize.c env.c epoch.c files.c \
@@ -2099,6 +2134,11 @@ MY_AARCH64_FILES = \
 @OPT_ENABLE_GTPIN_TRUE@	gpu/instrumentation/gtpin-instrumentation.c \
 @OPT_ENABLE_GTPIN_TRUE@	gpu/instrumentation/gtpin-correlation-id-map.c
 
+@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_knob_la_CPPFLAGS = $(OPT_GTPIN_IFLAGS)
+@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_knob_la_SOURCES = gpu/instrumentation/gtpin-knob.cpp
+@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_knob_la_LDFLAGS =  \
+@OPT_ENABLE_GTPIN_TRUE@	-Wl,-Bsymbolic -L$(OPT_GTPIN_LIBDIR) \
+@OPT_ENABLE_GTPIN_TRUE@	-Wl,-rpath=$(OPT_GTPIN_LIBDIR) -lgtpin
 @OPT_ENABLE_ROCM_TRUE@MY_ROCM_FILES = \
 @OPT_ENABLE_ROCM_TRUE@	sample-sources/amd.c \
 @OPT_ENABLE_ROCM_TRUE@	sample-sources/amd-rocprofiler.c \
@@ -2162,11 +2202,11 @@ MY_AARCH64_INCLUDE_DIRS = \
 	-I$(srcdir)/utilities/arch/aarch64
 
 libhpcrun_la_SOURCES = $(MY_BASE_FILES) $(MY_DYNAMIC_FILES) \
-	$(am__append_27) $(am__append_28) $(am__append_41) \
-	$(am__append_56) $(am__append_72) $(am__append_85) \
-	$(am__append_100) $(am__append_104) $(am__append_116) \
-	$(am__append_123) $(am__append_127) $(am__append_131) \
-	$(am__append_135) $(am__append_139) $(UNW_SOURCE_FILES) \
+	$(am__append_28) $(am__append_29) $(am__append_42) \
+	$(am__append_57) $(am__append_73) $(am__append_86) \
+	$(am__append_101) $(am__append_105) $(am__append_117) \
+	$(am__append_124) $(am__append_128) $(am__append_132) \
+	$(am__append_136) $(am__append_140) $(UNW_SOURCE_FILES) \
 	utilities/last_func.c
 libhpcrun_fake_audit_la_SOURCES = \
 	audit/fake-auditor.c
@@ -2175,9 +2215,9 @@ libhpcrun_audit_la_SOURCES = \
 	audit/auditor.c
 
 libhpcrun_o_SOURCES = $(MY_BASE_FILES) $(MY_STATIC_FILES) \
-	$(am__append_29) $(am__append_42) $(am__append_57) \
-	$(am__append_73) $(am__append_86) $(am__append_105) \
-	$(am__append_112) $(am__append_117) $(am__append_126) \
+	$(am__append_30) $(am__append_43) $(am__append_58) \
+	$(am__append_74) $(am__append_87) $(am__append_106) \
+	$(am__append_113) $(am__append_118) $(am__append_127) \
 	$(UNW_SOURCE_FILES) utilities/last_func.c
 libhpcrun_wrap_a_SOURCES = \
 	monitor-exts/openmp.c
@@ -2222,12 +2262,12 @@ libhpctoolkit_a_SOURCES = \
 # cppflags
 #-----------------------------------------------------------
 libhpcrun_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_21) $(am__append_30) $(am__append_43) \
-	$(am__append_58) $(am__append_74) $(am__append_87) \
-	$(am__append_101) $(am__append_106) $(am__append_108) \
-	$(am__append_110) $(am__append_118) $(am__append_121) \
-	$(am__append_124) $(am__append_128) $(am__append_132) \
-	$(am__append_136) $(am__append_140) $(UNW_INCLUDE_DIRS)
+	$(am__append_22) $(am__append_31) $(am__append_44) \
+	$(am__append_59) $(am__append_75) $(am__append_88) \
+	$(am__append_102) $(am__append_107) $(am__append_109) \
+	$(am__append_111) $(am__append_119) $(am__append_122) \
+	$(am__append_125) $(am__append_129) $(am__append_133) \
+	$(am__append_137) $(am__append_141) $(UNW_INCLUDE_DIRS)
 libhpcrun_fake_audit_la_CPPFLAGS = \
 	$(MY_CPP_DEFINES)		\
 	$(MY_INCLUDE_DIRS)
@@ -2237,51 +2277,51 @@ libhpcrun_audit_la_CPPFLAGS = \
 	$(MY_INCLUDE_DIRS)
 
 libhpcrun_o_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_22) $(am__append_31) \
-	$(am__append_44) $(am__append_59) $(am__append_75) \
-	$(am__append_88) $(am__append_113) $(am__append_119) \
-	$(am__append_122) $(UNW_INCLUDE_DIRS)
+	$(MY_INCLUDE_DIRS) $(am__append_23) $(am__append_32) \
+	$(am__append_45) $(am__append_60) $(am__append_76) \
+	$(am__append_89) $(am__append_114) $(am__append_120) \
+	$(am__append_123) $(UNW_INCLUDE_DIRS)
 libhpcrun_wrap_a_CPPFLAGS = \
 	-DHPCRUN_STATIC_LINK		\
 	$(MY_CPP_DEFINES)		\
 	$(MY_INCLUDE_DIRS)
 
 libhpcrun_ga_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_32) $(am__append_45) $(am__append_60) \
-	$(am__append_76) $(am__append_89) $(UNW_INCLUDE_DIRS)
+	$(am__append_33) $(am__append_46) $(am__append_61) \
+	$(am__append_77) $(am__append_90) $(UNW_INCLUDE_DIRS)
 libhpcrun_ga_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_33) $(am__append_46) \
-	$(am__append_61) $(am__append_77) $(am__append_90) \
+	$(MY_INCLUDE_DIRS) $(am__append_34) $(am__append_47) \
+	$(am__append_62) $(am__append_78) $(am__append_91) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_gprof_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_47) $(am__append_62) $(am__append_91)
+	$(am__append_48) $(am__append_63) $(am__append_92)
 libhpcrun_gprof_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_48) \
-	$(am__append_63) $(am__append_92)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_49) \
+	$(am__append_64) $(am__append_93)
 libhpcrun_io_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_34) $(am__append_49) $(am__append_64) \
-	$(am__append_78) $(am__append_93) $(UNW_INCLUDE_DIRS)
+	$(am__append_35) $(am__append_50) $(am__append_65) \
+	$(am__append_79) $(am__append_94) $(UNW_INCLUDE_DIRS)
 libhpcrun_io_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK $(MY_CPP_DEFINES) \
-	$(MY_INCLUDE_DIRS) $(am__append_35) $(am__append_50) \
-	$(am__append_65) $(am__append_79) $(am__append_94) \
+	$(MY_INCLUDE_DIRS) $(am__append_36) $(am__append_51) \
+	$(am__append_66) $(am__append_80) $(am__append_95) \
 	$(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_36) $(am__append_51) $(am__append_66) \
-	$(am__append_80) $(am__append_95) $(UNW_INCLUDE_DIRS)
+	$(am__append_37) $(am__append_52) $(am__append_67) \
+	$(am__append_81) $(am__append_96) $(UNW_INCLUDE_DIRS)
 libhpcrun_memleak_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_37) \
-	$(am__append_52) $(am__append_67) $(am__append_81) \
-	$(am__append_96) $(UNW_INCLUDE_DIRS)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_38) \
+	$(am__append_53) $(am__append_68) $(am__append_82) \
+	$(am__append_97) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_la_CPPFLAGS = $(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) \
-	$(am__append_38) $(am__append_53) $(am__append_68) \
-	$(am__append_82) $(am__append_97) $(UNW_INCLUDE_DIRS)
+	$(am__append_39) $(am__append_54) $(am__append_69) \
+	$(am__append_83) $(am__append_98) $(UNW_INCLUDE_DIRS)
 libhpcrun_pthread_wrap_a_CPPFLAGS = -DHPCRUN_STATIC_LINK \
-	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_39) \
-	$(am__append_54) $(am__append_69) $(am__append_83) \
-	$(am__append_98) $(UNW_INCLUDE_DIRS)
+	$(MY_CPP_DEFINES) $(MY_INCLUDE_DIRS) $(am__append_40) \
+	$(am__append_55) $(am__append_70) $(am__append_84) \
+	$(am__append_99) $(UNW_INCLUDE_DIRS)
 libhpcrun_mpi_la_CPPFLAGS = $(MY_CPP_DEFINES) -I$(MPI_INC) \
-	$(MY_INCLUDE_DIRS) $(am__append_40) $(am__append_55) \
-	$(am__append_70) $(am__append_84) $(am__append_99) \
+	$(MY_INCLUDE_DIRS) $(am__append_41) $(am__append_56) \
+	$(am__append_71) $(am__append_85) $(am__append_100) \
 	$(UNW_INCLUDE_DIRS)
 libhpctoolkit_la_CPPFLAGS = \
 	$(MY_CPP_DEFINES)		\
@@ -2297,8 +2337,8 @@ libhpctoolkit_a_CPPFLAGS = \
 # cflags
 #-----------------------------------------------------------
 libhpcrun_la_CFLAGS = $(CFLAGS) $(HOST_CFLAGS) $(PERFMON_CFLAGS) \
-	$(am__append_125) $(am__append_129) $(am__append_133) \
-	$(am__append_137) $(am__append_141) $(GOTCHA_IFLAGS)
+	$(am__append_126) $(am__append_130) $(am__append_134) \
+	$(am__append_138) $(am__append_142) $(GOTCHA_IFLAGS)
 libhpcrun_o_CFLAGS = $(CFLAGS) $(HOST_CFLAGS) $(PERFMON_CFLAGS)
 libhpcrun_fake_audit_la_CFLAGS = $(CFLAGS) $(HOST_CFLAGS)
 libhpcrun_audit_la_CFLAGS = $(CFLAGS) $(HOST_CFLAGS)
@@ -2332,7 +2372,7 @@ OUR_LIBUNWIND_A = $(top_builddir)/src/extern/libunwind/libunwind.a
 OUR_LZMA_A = $(top_builddir)/src/extern/lzma/liblzma.a
 libhpcrun_la_LDFLAGS = -Wl,-Bsymbolic -L$(LIBMONITOR_LIB) -lmonitor \
 	-lpthread -lrt -L$(LIBELF_LIB) -lelf $(PERFMON_LDFLAGS_DYN) \
-	$(OPT_ROCM_LDFLAGS) $(am__append_102) $(am__append_120) \
+	$(OPT_ROCM_LDFLAGS) $(am__append_103) $(am__append_121) \
 	$(GOTCHA_LDFLAGS) $(UNW_DYNAMIC_LD_FLAGS)
 libhpcrun_fake_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
 libhpcrun_audit_la_LDFLAGS = -Wl,-Bsymbolic -ldl
@@ -2351,11 +2391,11 @@ libhpcrun_mpi_la_LDFLAGS = -Wl,-Bsymbolic
 # and hidden into libhpcrun.o.  Other dependencies go into hpclink.
 # Don't use LDFLAGS for static case.
 libhpcrun_la_LIBADD = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
-	$(OUR_LIBUNWIND_A) $(OUR_LZMA_A) $(am__append_25)
+	$(OUR_LIBUNWIND_A) $(OUR_LZMA_A) $(am__append_26)
 libhpcrun_o_LDADD = $(PROF_LEAN_A) $(SUPPORT_LEAN_A) \
 	$(PERFMON_LDFLAGS_STAT) $(OUR_LIBUNWIND_A) $(OUR_LZMA_A) \
-	$(am__append_26) $(am__append_114) $(UNW_STATIC_LD_FLAGS)
-MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_71) \
+	$(am__append_27) $(am__append_115) $(UNW_STATIC_LD_FLAGS)
+MY_AGENT_INCLUDE_DIRS = $(MY_INCLUDE_DIRS) $(am__append_72) \
 	$(UNW_INCLUDE_DIRS)
 @HOST_CPU_AARCH64_TRUE@libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
 @HOST_CPU_PPC_TRUE@libhpcrun_la_CCASFLAGS = $(AM_CCASFLAGS)
@@ -2458,7 +2498,7 @@ all: $(BUILT_SOURCES)
 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
 
 .SUFFIXES:
-.SUFFIXES: .S .c .lo .o .obj .s
+.SUFFIXES: .S .c .cpp .lo .o .obj .s
 $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am $(top_srcdir)/src/Makeinclude.config $(top_srcdir)/src/Makeinclude.rules $(am__configure_deps)
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
@@ -3457,6 +3497,12 @@ libhpcrun_ga.la: $(libhpcrun_ga_la_OBJECTS) $(libhpcrun_ga_la_DEPENDENCIES) $(EX
 
 libhpcrun_gprof.la: $(libhpcrun_gprof_la_OBJECTS) $(libhpcrun_gprof_la_DEPENDENCIES) $(EXTRA_libhpcrun_gprof_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(libhpcrun_gprof_la_LINK) $(am_libhpcrun_gprof_la_rpath) $(libhpcrun_gprof_la_OBJECTS) $(libhpcrun_gprof_la_LIBADD) $(LIBS)
+gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo:  \
+	gpu/instrumentation/$(am__dirstamp) \
+	gpu/instrumentation/$(DEPDIR)/$(am__dirstamp)
+
+libhpcrun_gtpin_knob.la: $(libhpcrun_gtpin_knob_la_OBJECTS) $(libhpcrun_gtpin_knob_la_DEPENDENCIES) $(EXTRA_libhpcrun_gtpin_knob_la_DEPENDENCIES) 
+	$(AM_V_CXXLD)$(libhpcrun_gtpin_knob_la_LINK) $(am_libhpcrun_gtpin_knob_la_rpath) $(libhpcrun_gtpin_knob_la_OBJECTS) $(libhpcrun_gtpin_knob_la_LIBADD) $(LIBS)
 sample-sources/libhpcrun_io_la-io-over.lo:  \
 	sample-sources/$(am__dirstamp) \
 	sample-sources/$(DEPDIR)/$(am__dirstamp)
@@ -4303,6 +4349,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/blame-shifting/$(DEPDIR)/libhpcrun_o-blame-queue-map.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/blame-shifting/$(DEPDIR)/libhpcrun_o-blame.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/blame-shifting/opencl/$(DEPDIR)/libhpcrun_la-opencl-blame.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_la-gtpin-correlation-id-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_la-gtpin-instrumentation.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_la-kernel-data-map.Plo@am__quote@
@@ -9531,6 +9578,37 @@ utilities/libhpcrun_o-last_func.obj: utilities/last_func.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='utilities/last_func.c' object='utilities/libhpcrun_o-last_func.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_o_CPPFLAGS) $(CPPFLAGS) $(libhpcrun_o_CFLAGS) $(CFLAGS) -c -o utilities/libhpcrun_o-last_func.obj `if test -f 'utilities/last_func.c'; then $(CYGPATH_W) 'utilities/last_func.c'; else $(CYGPATH_W) '$(srcdir)/utilities/last_func.c'; fi`
+
+.cpp.o:
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
+@am__fastdepCXX_TRUE@	$(CXXCOMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ $< &&\
+@am__fastdepCXX_TRUE@	$(am__mv) $$depbase.Tpo $$depbase.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXXCOMPILE) -c -o $@ $<
+
+.cpp.obj:
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.obj$$||'`;\
+@am__fastdepCXX_TRUE@	$(CXXCOMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ `$(CYGPATH_W) '$<'` &&\
+@am__fastdepCXX_TRUE@	$(am__mv) $$depbase.Tpo $$depbase.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXXCOMPILE) -c -o $@ `$(CYGPATH_W) '$<'`
+
+.cpp.lo:
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.lo$$||'`;\
+@am__fastdepCXX_TRUE@	$(LTCXXCOMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ $< &&\
+@am__fastdepCXX_TRUE@	$(am__mv) $$depbase.Tpo $$depbase.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LTCXXCOMPILE) -c -o $@ $<
+
+gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo: gpu/instrumentation/gtpin-knob.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_gtpin_knob_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo -MD -MP -MF gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Tpo -c -o gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo `test -f 'gpu/instrumentation/gtpin-knob.cpp' || echo '$(srcdir)/'`gpu/instrumentation/gtpin-knob.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Tpo gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='gpu/instrumentation/gtpin-knob.cpp' object='gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_gtpin_knob_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo `test -f 'gpu/instrumentation/gtpin-knob.cpp' || echo '$(srcdir)/'`gpu/instrumentation/gtpin-knob.cpp
 
 .s.o:
 	$(AM_V_CCAS)$(CCASCOMPILE) -c -o $@ $<

--- a/src/tool/hpcrun/Makefile.in
+++ b/src/tool/hpcrun/Makefile.in
@@ -170,7 +170,7 @@ host_triplet = @host@
 @OPT_PAPI_COMPONENT_TRUE@am__append_16 = -DHPCRUN_SS_PAPI_C_INTEL
 @OPT_PAPI_CUPTI_TRUE@am__append_17 = sample-sources/papi-c-cupti.c
 @OPT_ENABLE_OPENCL_TRUE@am__append_18 = libhpcrun_opencl.la
-@OPT_ENABLE_GTPIN_TRUE@am__append_19 = libhpcrun_gtpin_knob.la
+@OPT_ENABLE_GTPIN_TRUE@am__append_19 = libhpcrun_gtpin_cxx.la
 @OPT_ENABLE_LEVEL0_TRUE@am__append_20 = libhpcrun_level0.la
 
 #
@@ -936,17 +936,16 @@ libhpcrun_gprof_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(libhpcrun_gprof_la_LDFLAGS) $(LDFLAGS) -o $@
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@am_libhpcrun_gprof_la_rpath = -rpath \
 @OPT_ENABLE_HPCRUN_DYNAMIC_TRUE@	$(pkglibdir)
-libhpcrun_gtpin_knob_la_LIBADD =
-am__libhpcrun_gtpin_knob_la_SOURCES_DIST =  \
+libhpcrun_gtpin_cxx_la_LIBADD =
+am__libhpcrun_gtpin_cxx_la_SOURCES_DIST =  \
 	gpu/instrumentation/gtpin-knob.cpp
-@OPT_ENABLE_GTPIN_TRUE@am_libhpcrun_gtpin_knob_la_OBJECTS = gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo
-libhpcrun_gtpin_knob_la_OBJECTS =  \
-	$(am_libhpcrun_gtpin_knob_la_OBJECTS)
-libhpcrun_gtpin_knob_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+@OPT_ENABLE_GTPIN_TRUE@am_libhpcrun_gtpin_cxx_la_OBJECTS = gpu/instrumentation/libhpcrun_gtpin_cxx_la-gtpin-knob.lo
+libhpcrun_gtpin_cxx_la_OBJECTS = $(am_libhpcrun_gtpin_cxx_la_OBJECTS)
+libhpcrun_gtpin_cxx_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
-	$(AM_CXXFLAGS) $(CXXFLAGS) $(libhpcrun_gtpin_knob_la_LDFLAGS) \
+	$(AM_CXXFLAGS) $(CXXFLAGS) $(libhpcrun_gtpin_cxx_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
-@OPT_ENABLE_GTPIN_TRUE@am_libhpcrun_gtpin_knob_la_rpath = -rpath \
+@OPT_ENABLE_GTPIN_TRUE@am_libhpcrun_gtpin_cxx_la_rpath = -rpath \
 @OPT_ENABLE_GTPIN_TRUE@	$(pkglibdir)
 libhpcrun_io_la_LIBADD =
 am_libhpcrun_io_la_OBJECTS =  \
@@ -1467,7 +1466,7 @@ SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(libhpcrun_audit_la_SOURCES) $(libhpcrun_dlmopen_la_SOURCES) \
 	$(libhpcrun_fake_audit_la_SOURCES) $(libhpcrun_ga_la_SOURCES) \
 	$(libhpcrun_gprof_la_SOURCES) \
-	$(libhpcrun_gtpin_knob_la_SOURCES) $(libhpcrun_io_la_SOURCES) \
+	$(libhpcrun_gtpin_cxx_la_SOURCES) $(libhpcrun_io_la_SOURCES) \
 	$(libhpcrun_level0_la_SOURCES) $(libhpcrun_memleak_la_SOURCES) \
 	$(libhpcrun_mpi_la_SOURCES) $(libhpcrun_opencl_la_SOURCES) \
 	$(libhpcrun_pthread_la_SOURCES) $(libhpctoolkit_la_SOURCES) \
@@ -1485,7 +1484,7 @@ DIST_SOURCES = $(libhpcrun_ga_wrap_a_SOURCES) \
 	$(libhpcrun_dlmopen_la_SOURCES) \
 	$(libhpcrun_fake_audit_la_SOURCES) $(libhpcrun_ga_la_SOURCES) \
 	$(libhpcrun_gprof_la_SOURCES) \
-	$(am__libhpcrun_gtpin_knob_la_SOURCES_DIST) \
+	$(am__libhpcrun_gtpin_cxx_la_SOURCES_DIST) \
 	$(libhpcrun_io_la_SOURCES) \
 	$(am__libhpcrun_level0_la_SOURCES_DIST) \
 	$(libhpcrun_memleak_la_SOURCES) $(libhpcrun_mpi_la_SOURCES) \
@@ -2134,9 +2133,9 @@ MY_AARCH64_FILES = \
 @OPT_ENABLE_GTPIN_TRUE@	gpu/instrumentation/gtpin-instrumentation.c \
 @OPT_ENABLE_GTPIN_TRUE@	gpu/instrumentation/gtpin-correlation-id-map.c
 
-@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_knob_la_CPPFLAGS = $(OPT_GTPIN_IFLAGS)
-@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_knob_la_SOURCES = gpu/instrumentation/gtpin-knob.cpp
-@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_knob_la_LDFLAGS =  \
+@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_cxx_la_CPPFLAGS = $(OPT_GTPIN_IFLAGS)
+@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_cxx_la_SOURCES = gpu/instrumentation/gtpin-knob.cpp
+@OPT_ENABLE_GTPIN_TRUE@libhpcrun_gtpin_cxx_la_LDFLAGS =  \
 @OPT_ENABLE_GTPIN_TRUE@	-Wl,-Bsymbolic -L$(OPT_GTPIN_LIBDIR) \
 @OPT_ENABLE_GTPIN_TRUE@	-Wl,-rpath=$(OPT_GTPIN_LIBDIR) -lgtpin
 @OPT_ENABLE_ROCM_TRUE@MY_ROCM_FILES = \
@@ -3497,12 +3496,12 @@ libhpcrun_ga.la: $(libhpcrun_ga_la_OBJECTS) $(libhpcrun_ga_la_DEPENDENCIES) $(EX
 
 libhpcrun_gprof.la: $(libhpcrun_gprof_la_OBJECTS) $(libhpcrun_gprof_la_DEPENDENCIES) $(EXTRA_libhpcrun_gprof_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(libhpcrun_gprof_la_LINK) $(am_libhpcrun_gprof_la_rpath) $(libhpcrun_gprof_la_OBJECTS) $(libhpcrun_gprof_la_LIBADD) $(LIBS)
-gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo:  \
+gpu/instrumentation/libhpcrun_gtpin_cxx_la-gtpin-knob.lo:  \
 	gpu/instrumentation/$(am__dirstamp) \
 	gpu/instrumentation/$(DEPDIR)/$(am__dirstamp)
 
-libhpcrun_gtpin_knob.la: $(libhpcrun_gtpin_knob_la_OBJECTS) $(libhpcrun_gtpin_knob_la_DEPENDENCIES) $(EXTRA_libhpcrun_gtpin_knob_la_DEPENDENCIES) 
-	$(AM_V_CXXLD)$(libhpcrun_gtpin_knob_la_LINK) $(am_libhpcrun_gtpin_knob_la_rpath) $(libhpcrun_gtpin_knob_la_OBJECTS) $(libhpcrun_gtpin_knob_la_LIBADD) $(LIBS)
+libhpcrun_gtpin_cxx.la: $(libhpcrun_gtpin_cxx_la_OBJECTS) $(libhpcrun_gtpin_cxx_la_DEPENDENCIES) $(EXTRA_libhpcrun_gtpin_cxx_la_DEPENDENCIES) 
+	$(AM_V_CXXLD)$(libhpcrun_gtpin_cxx_la_LINK) $(am_libhpcrun_gtpin_cxx_la_rpath) $(libhpcrun_gtpin_cxx_la_OBJECTS) $(libhpcrun_gtpin_cxx_la_LIBADD) $(LIBS)
 sample-sources/libhpcrun_io_la-io-over.lo:  \
 	sample-sources/$(am__dirstamp) \
 	sample-sources/$(DEPDIR)/$(am__dirstamp)
@@ -4349,7 +4348,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/blame-shifting/$(DEPDIR)/libhpcrun_o-blame-queue-map.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/blame-shifting/$(DEPDIR)/libhpcrun_o-blame.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/blame-shifting/opencl/$(DEPDIR)/libhpcrun_la-opencl-blame.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_cxx_la-gtpin-knob.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_la-gtpin-correlation-id-map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_la-gtpin-instrumentation.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gpu/instrumentation/$(DEPDIR)/libhpcrun_la-kernel-data-map.Plo@am__quote@
@@ -9603,12 +9602,12 @@ utilities/libhpcrun_o-last_func.obj: utilities/last_func.c
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LTCXXCOMPILE) -c -o $@ $<
 
-gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo: gpu/instrumentation/gtpin-knob.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_gtpin_knob_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo -MD -MP -MF gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Tpo -c -o gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo `test -f 'gpu/instrumentation/gtpin-knob.cpp' || echo '$(srcdir)/'`gpu/instrumentation/gtpin-knob.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Tpo gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_knob_la-gtpin-knob.Plo
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='gpu/instrumentation/gtpin-knob.cpp' object='gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo' libtool=yes @AMDEPBACKSLASH@
+gpu/instrumentation/libhpcrun_gtpin_cxx_la-gtpin-knob.lo: gpu/instrumentation/gtpin-knob.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_gtpin_cxx_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT gpu/instrumentation/libhpcrun_gtpin_cxx_la-gtpin-knob.lo -MD -MP -MF gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_cxx_la-gtpin-knob.Tpo -c -o gpu/instrumentation/libhpcrun_gtpin_cxx_la-gtpin-knob.lo `test -f 'gpu/instrumentation/gtpin-knob.cpp' || echo '$(srcdir)/'`gpu/instrumentation/gtpin-knob.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_cxx_la-gtpin-knob.Tpo gpu/instrumentation/$(DEPDIR)/libhpcrun_gtpin_cxx_la-gtpin-knob.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='gpu/instrumentation/gtpin-knob.cpp' object='gpu/instrumentation/libhpcrun_gtpin_cxx_la-gtpin-knob.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_gtpin_knob_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o gpu/instrumentation/libhpcrun_gtpin_knob_la-gtpin-knob.lo `test -f 'gpu/instrumentation/gtpin-knob.cpp' || echo '$(srcdir)/'`gpu/instrumentation/gtpin-knob.cpp
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libhpcrun_gtpin_cxx_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o gpu/instrumentation/libhpcrun_gtpin_cxx_la-gtpin-knob.lo `test -f 'gpu/instrumentation/gtpin-knob.cpp' || echo '$(srcdir)/'`gpu/instrumentation/gtpin-knob.cpp
 
 .s.o:
 	$(AM_V_CCAS)$(CCASCOMPILE) -c -o $@ $<

--- a/src/tool/hpcrun/gpu/instrumentation/gtpin-instrumentation.c
+++ b/src/tool/hpcrun/gpu/instrumentation/gtpin-instrumentation.c
@@ -98,6 +98,8 @@
 
 #define STUB 0
 
+#define GTPIN_KNOB_AVAILABLE 1
+
 
 //******************************************************************************
 // hpctoolkit's interface to gtpin
@@ -169,28 +171,6 @@ static __thread gtpin_correlation_data_t* tail = NULL;
 //******************************************************************************
 
 // FIXME the asserts in this file should be replaced by fatal error messages
-
-#ifdef GTPIN_KNOB_AVAILABLE
-static void
-knobAddBool
-(
- const char *name,
- bool value
-)
-{
-  GTPinKnob knob = HPCRUN_GTPIN_CALL(KNOB_FindArg, (name));
-  assert(knob != NULL);
-
-  KnobValue knob_value;
-  knob_value.value._bool = value;
-  knob_value.type = KNOB_TYPE_BOOL;
-
-  KNOB_STATUS status = 
-    HPCRUN_GTPIN_CALL(KNOB_AddValue, (knob, &knob_value));
-  assert(status == KNOB_STATUS_SUCCESS);
-}
-#endif
-
 
 void
 initializeInstrumentation
@@ -1046,8 +1026,9 @@ gtpin_enable_profiling
   ETMSG(OPENCL, "inside enableProfiling");
   initializeInstrumentation();
 
-#ifdef GTPIN_KNOB_AVAILABLE
-  knobAddBool("silent_warnings", true);
+#if GTPIN_KNOB_AVAILABLE
+  gtpin_knob_bool("silent_warnings", true);
+  gtpin_knob_bool("no_empty_profile_dir", true);
 #endif
 
   // Use opencl/level zero runtime stack

--- a/src/tool/hpcrun/gpu/instrumentation/gtpin-interface.c
+++ b/src/tool/hpcrun/gpu/instrumentation/gtpin-interface.c
@@ -67,7 +67,7 @@
 #define xstr(t) str(t)
 #define gtpin_path() "libgtpin.so"
 
-#define gtpin_knob_path() "libhpcrun_gtpin_knob.so"
+#define gtpin_cxx_path() "libhpcrun_gtpin_cxx.so"
 
 #define GTPIN_FN_NAME(f) DYN_FN_NAME(f)
 
@@ -76,7 +76,7 @@
 
 #define HPCRUN_GTPIN_CALL(fn, args) (GTPIN_FN_NAME(fn) args)
 
-#define FORALL_GTPIN_KNOB_ROUTINES(macro)	\
+#define FORALL_GTPIN_CXX_ROUTINES(macro)	\
   macro(gtpin_knob_bool)
 
 #define FORALL_GTPIN_ROUTINES(macro)		\
@@ -551,14 +551,12 @@ gtpin_bind
     FORALL_GTPIN_ROUTINES(GTPIN_BIND);
   }
 
-  
-  // dynamic libraries only availabile in non-static case
   {
     hpcrun_force_dlopen(true);
-    CHK_DLOPEN(gtpin, gtpin_knob_path(), RTLD_NOW | RTLD_GLOBAL);
+    CHK_DLOPEN(gtpin, gtpin_cxx_path(), RTLD_NOW | RTLD_GLOBAL);
     hpcrun_force_dlopen(false);
 
-    FORALL_GTPIN_KNOB_ROUTINES(GTPIN_BIND);
+    FORALL_GTPIN_CXX_ROUTINES(GTPIN_BIND);
   }
     
     

--- a/src/tool/hpcrun/gpu/instrumentation/gtpin-knob.cpp
+++ b/src/tool/hpcrun/gpu/instrumentation/gtpin-knob.cpp
@@ -1,0 +1,81 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2022, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+//******************************************************************************
+// GT-Pin includes
+//******************************************************************************
+
+#include <client_knob.h>
+
+
+
+//******************************************************************************
+// local includes
+//******************************************************************************
+
+#include "gtpin-knob.h"
+
+
+//******************************************************************************
+// interface functions
+//******************************************************************************
+
+bool
+gtpin_knob_bool
+(
+ const char *name,
+ bool value
+)
+{
+  using namespace gtpin;
+  
+  GTPinKnob knob = KNOB_FindArg(name);
+  assert(knob != NULL);
+
+  KnobValue knob_value;
+  knob_value.value._bool = value;
+  knob_value.type = KNOB_TYPE_BOOL;
+
+  KNOB_STATUS status = KNOB_AddValue(knob, &knob_value);
+  return status == KNOB_STATUS_SUCCESS;
+}

--- a/src/tool/hpcrun/gpu/instrumentation/gtpin-knob.h
+++ b/src/tool/hpcrun/gpu/instrumentation/gtpin-knob.h
@@ -1,0 +1,64 @@
+// -*-Mode: C++;-*- // technically C99
+
+// * BeginRiceCopyright *****************************************************
+//
+// --------------------------------------------------------------------------
+// Part of HPCToolkit (hpctoolkit.org)
+//
+// Information about sources of support for research and development of
+// HPCToolkit is at 'hpctoolkit.org' and in 'README.Acknowledgments'.
+// --------------------------------------------------------------------------
+//
+// Copyright ((c)) 2002-2022, Rice University
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+//
+// * Neither the name of Rice University (RICE) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// This software is provided by RICE and contributors "as is" and any
+// express or implied warranties, including, but not limited to, the
+// implied warranties of merchantability and fitness for a particular
+// purpose are disclaimed. In no event shall RICE or contributors be
+// liable for any direct, indirect, incidental, special, exemplary, or
+// consequential damages (including, but not limited to, procurement of
+// substitute goods or services; loss of use, data, or profits; or
+// business interruption) however caused and on any theory of liability,
+// whether in contract, strict liability, or tort (including negligence
+// or otherwise) arising in any way out of the use of this software, even
+// if advised of the possibility of such damage.
+//
+// ******************************************************* EndRiceCopyright *
+
+//******************************************************************************
+// GT-Pin includes
+//******************************************************************************
+
+
+
+
+//******************************************************************************
+// interface functions
+//******************************************************************************
+
+extern "C" {
+
+bool
+gtpin_knob_bool
+(
+ const char *name,
+ bool value
+);
+
+};


### PR DESCRIPTION
Intel's GT-Pin tool now only has a C++ API for certain functionality.  Setting GT-Pin control knobs is one of the features only available through C++. Create a separate C++ library for hpcrun to load that controls GT-Pin knobs. 