### PR TITLE
hpcstruct: no <C> tags for CPU binaries

### DIFF
--- a/src/lib/banal/Struct-Output.cpp
+++ b/src/lib/banal/Struct-Output.cpp
@@ -95,7 +95,6 @@ static long next_index;
 static long gaps_line;
 static bool pretty_print_output;
 
-
 static const char * hpcstruct_xml_head =
 #include <lib/xml/hpc-structure.dtd.h>
   ;

--- a/src/lib/banal/Struct-Output.hpp
+++ b/src/lib/banal/Struct-Output.hpp
@@ -83,6 +83,8 @@ void finalPrintProc(ostream *, ostream *, string &, string &,
 
 void setPrettyPrint(bool _pretty_print_output);
 
+void enableCallTags();
+
 }  // namespace Output
 }  // namespace BAnal
 

--- a/src/lib/banal/Struct.cpp
+++ b/src/lib/banal/Struct.cpp
@@ -682,6 +682,11 @@ makeStructure(string filename,
       cuda_arch = 0;
       cubin_size = 0;
     }
+    if (cuda_file || intel_file) {
+      // for GPU code, report call sites in structure output to support
+      // static call graph reconstruction
+      Output::enableCallTags();
+    }
 
     if (opts.show_time) {
       printTime("parse: ", &tv_symtab, &ru_symtab, &tv_parse, &ru_parse);


### PR DESCRIPTION
suppress generation of call site tags for CPU binaries.

First, nothing in hpctoolkit uses them so it is pointless to generate
them.

Second, hpcprof rejects any structure file with a <C> tag that
represents a call to an address not identified as a function in the
structure file. Some nested functions are not reported as functions,
so some structure files with <C> tags are rejected by hpcprof in
practice.