### PR TITLE
hpcrun: fix races for level0 data node free list

### DIFF
--- a/src/tool/hpcrun/gpu/level0/level0-data-node.c
+++ b/src/tool/hpcrun/gpu/level0/level0-data-node.c
@@ -58,7 +58,7 @@
 // local data
 //******************************************************************************
 
-static level0_data_node_t *free_list = NULL;
+static __thread level0_data_node_t *free_list = NULL;
 
 //*****************************************************************************
 // interface operations


### PR DESCRIPTION
make the level0 data node free list thread private to eliminate races between threads manipulating the list concurrently.

other alternatives:
- make it shared with locking
- have it use a high-performance threaded allocator
  and no free list