### PR TITLE
Remove stray reference to ensure_kernel_ip_present() in amd/roctracer-api.c

### DIFF
--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -424,7 +424,6 @@ roctracer_subscriber_callback
 
       cct_node_t *trace_ph = gpu_op_ccts_get(&gpu_op_ccts, gpu_placeholder_type_trace);
       gpu_cct_insert(trace_ph, kernel_ip);
-      ensure_kernel_ip_present(trace_ph, kernel_ip);
 
       if (collect_counter) {
         rocprofiler_correlation_id = correlation_id;


### PR DESCRIPTION
This fixes the symbol error for said procedure when running with `-gpu=amd`.