### PR TITLE
hpcstruct: set OMP_STACKSIZE

### DIFF
--- a/src/tool/hpcstruct/hpcstruct.in
+++ b/src/tool/hpcstruct/hpcstruct.in
@@ -44,5 +44,13 @@ case "$libexec_dir" in
     * )  libexec_dir="${HPCTOOLKIT}/${libexec_dir}" ;;
 esac
 
+#------------------------------------------------------------
+# Ensure that the stack for each worker thread is the same
+# size as the stack of the master thread. This will avoid
+# having a multi-threaded execution run out of stack when a
+# single-threaded execution would not.
+#------------------------------------------------------------
+export OMP_STACKSIZE=`ulimit -s`k
+
 export LD_LIBRARY_PATH="${ext_libs_dir}:${libcxx_path}:${LD_LIBRARY_PATH}"
 exec "${libexec_dir}/${binary_name}" "$@"

--- a/src/tool/hpcstruct/hpcstruct.in
+++ b/src/tool/hpcstruct/hpcstruct.in
@@ -83,10 +83,10 @@ do
 done
 
 #------------------------------------------------------------
-# Ensure that the stack for each worker thread is the same
-# size as the stack of the master thread. This will avoid
-# having a multi-threaded execution run out of stack when a
-# single-threaded execution would not.
+# 3 strategies to set OMP_STACKSIZE, in order of priority
+# 1. -s argument
+# 2. use existing value of OMP_STACKSIZE, if any
+# 3. default OMP_STACKSIZE to 8M (8MB)
 #------------------------------------------------------------
 if test "x$stacksize" != x; then
   export OMP_STACKSIZE=$stacksize

--- a/src/tool/hpcstruct/hpcstruct.in
+++ b/src/tool/hpcstruct/hpcstruct.in
@@ -44,13 +44,54 @@ case "$libexec_dir" in
     * )  libexec_dir="${HPCTOOLKIT}/${libexec_dir}" ;;
 esac
 
+die()
+{
+    cat <<EOF 1>&2
+hpcstruct: $*
+use 'hpcstruct -h' for a summary of options
+EOF
+    exit 1
+}
+
+# Return success (0) if $1 is not empty and not the next option.
+non_empty()
+{
+    case "x$1" in
+        x | x-* ) return 1 ;;
+        * ) return 0 ;;
+    esac
+}
+
+stacksize=""
+args=""
+while test "x$1" != x
+do
+    arg="$1" ; shift
+
+    case "$arg" in
+
+        -s | --stack )
+            non_empty "$1" || die "missing argument for $arg"
+            stacksize=$1
+            shift
+            ;;
+
+        * )
+           args="$args $arg"
+            ;;
+    esac
+done
+
 #------------------------------------------------------------
 # Ensure that the stack for each worker thread is the same
 # size as the stack of the master thread. This will avoid
 # having a multi-threaded execution run out of stack when a
 # single-threaded execution would not.
 #------------------------------------------------------------
-export OMP_STACKSIZE=`ulimit -s`k
-
+if test "x$stacksize" != x; then
+  export OMP_STACKSIZE=$stacksize
+elif test "x$OMP_STACKSIZE" == x; then
+  export OMP_STACKSIZE=8M
+fi
 export LD_LIBRARY_PATH="${ext_libs_dir}:${libcxx_path}:${LD_LIBRARY_PATH}"
-exec "${libexec_dir}/${binary_name}" "$@"
+exec "${libexec_dir}/${binary_name}" "$args"

--- a/src/tool/hpcstruct/usage.txt
+++ b/src/tool/hpcstruct/usage.txt
@@ -79,6 +79,14 @@ Options: Override parallelism defaults
                        <psize> bytes as large. hpcstruct will use more
                        OpenMP threads to analyze large binaries than
                        it uses to analyze small binaries.  {100000000}
+  -s <v>, --stack <v>  Set the stack size for OpenMP worker threads to <v>.
+                       <v> is a positive number optionally followed by
+                       a suffix: B (bytes), K (kilobytes), M (megabytes),
+                       or G (gigabytes). Without a suffix, <v> will be
+                       interpreted as kilobytes. One can also control the
+                       stack size by setting the OMP_STACKSIZE environment
+                       variable. A '-s <v>' option takes precedence,
+                       followed by OMP_STACKSIZE. {8M}
 
 Options: Override structure recovery defaults
   --cpu <yes/no>       Analyze CPU binaries referenced by a measurements


### PR DESCRIPTION
ensure that OpenMP workers have the same size stack as the main
thread by setting their stack size to "ulimit -s" kilobytes