### PR TITLE
hpcrun: distinguish tool threads with TOOL_THREAD_ID

### DIFF
--- a/src/tool/hpcrun/gpu/amd/rocprofiler-api.c
+++ b/src/tool/hpcrun/gpu/amd/rocprofiler-api.c
@@ -297,7 +297,7 @@ rocprofiler_context_handler
   void* arg
 )
 {
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
 
   // This wait-loop is taken from rocprofiler example.
   // It is strange that the rocprofiler thread will have to

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -514,7 +514,7 @@ roctracer_buffer_completion_callback
  void* arg
 )
 {
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
   roctracer_buffer_completion_notify();
   roctracer_record_t* record = (roctracer_record_t*)(begin);
   roctracer_record_t* end_record = (roctracer_record_t*)(end);

--- a/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
@@ -102,7 +102,7 @@ gpu_operation_record
 {
   int current_operation_channels_count;
   
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
 
   while (!atomic_load(&stop_operation_flag)){
     current_operation_channels_count = atomic_load(&operation_channels_count);

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -373,7 +373,7 @@ gpu_trace_record
 {
   gpu_trace_channel_set_t *channel_set = (gpu_trace_channel_set_t *) args;
 
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
 
   while (!atomic_load(&stop_trace_flag)) {
     //getting data from a trace channel

--- a/src/tool/hpcrun/gpu/instrumentation/gtpin-instrumentation.c
+++ b/src/tool/hpcrun/gpu/instrumentation/gtpin-instrumentation.c
@@ -866,7 +866,7 @@ onKernelComplete
     return;
   }
   
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
 
   gpu_activity_channel_t *activity_channel = gtpin_correlation_id_map_entry_activity_channel_get(entry);
   gpu_op_ccts_t gpu_op_ccts = gtpin_correlation_id_map_entry_op_ccts_get(entry);

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -1293,7 +1293,7 @@ cupti_buffer_completion_callback
  size_t validSize
 )
 {
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
 
   // handle notifications
   cupti_buffer_completion_notify();

--- a/src/tool/hpcrun/gpu/opencl/opencl-api.c
+++ b/src/tool/hpcrun/gpu/opencl/opencl-api.c
@@ -1107,7 +1107,7 @@ opencl_activity_completion_callback
  void *user_data
 )
 {
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
   opencl_object_t *cb_data = (opencl_object_t*)user_data;
   cl_basic_callback_t cb_basic = opencl_cb_basic_get(cb_data);
 
@@ -1161,7 +1161,7 @@ opencl_api_initialize
 {
   ETMSG(OPENCL, "CL_TARGET_OPENCL_VERSION: %d", CL_TARGET_OPENCL_VERSION);
   // we need this even when instrumentation is off inorder to get kernel names in hpcviewer
-  hpcrun_thread_init_mem_pool_once(0, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
   
   // GPU_IDLE_CAUSE should be attributed only to application thread
   // application thread calls this fn

--- a/src/tool/hpcrun/sample_event.c
+++ b/src/tool/hpcrun/sample_event.c
@@ -286,7 +286,8 @@ hpcrun_sample_callpath(void* context, int metricId,
 
   bool trace_ok = ! td->deadlock_drop;
   TMSG(TRACE1, "trace ok (!deadlock drop) = %d", trace_ok);
-  if (trace_ok && hpcrun_trace_isactive() && !isSync && is_time_based_metric > 0) {
+  if (trace_ok && hpcrun_trace_isactive() && !isSync && is_time_based_metric > 0 &&
+    td->core_profile_trace_data.id != TOOL_THREAD_ID) {
     TMSG(TRACE, "Sample event encountered");
 
     cct_addr_t frm;

--- a/src/tool/hpcrun/thread_data.h
+++ b/src/tool/hpcrun/thread_data.h
@@ -72,6 +72,8 @@
 #include <lib/prof-lean/hpcio.h>
 #include <lib/prof-lean/hpcio-buffer.h>
 
+#define TOOL_THREAD_ID (-1)
+
 typedef struct {
   sigjmp_buf jb;
 } sigjmp_buf_t;

--- a/src/tool/hpcrun/threadmgr.c
+++ b/src/tool/hpcrun/threadmgr.c
@@ -173,8 +173,10 @@ allocate_and_init_thread_data(int id, cct_ctxt_t* thr_ctxt, bool has_trace)
 static void
 finalize_thread_data(core_profile_trace_data_t *current_data)
 {
-  hpcrun_write_profile_data( current_data );
-  hpcrun_trace_close( current_data );
+  if (current_data->id != TOOL_THREAD_ID) {
+    hpcrun_write_profile_data( current_data );
+    hpcrun_trace_close( current_data );
+  }
 }
 
 
@@ -348,7 +350,7 @@ hpcrun_threadMgr_data_put( epoch_t *epoch, thread_data_t *data, bool add_separat
 
   // step 1: get the dummy node that marks the end of the thread trace
 
-  if (add_separator) {
+  if (add_separator && data->core_profile_trace_data.id != TOOL_THREAD_ID) {
     cct_node_t *node  = hpcrun_cct_bundle_get_no_activity_node(&epoch->csdata);
     if (node) {
       hpcrun_trace_append(&(data->core_profile_trace_data), node, 0, 


### PR DESCRIPTION
Ideally, tool threads shouldn't be monitored. that is not true for OpenCL at present.

At a minimum:
- Don't assign an ID to a tool thread that conflicts with application thread 0
- Don't write profiles for tool thread
- Don't assemble traces for a tool thread