### PR TITLE
Support call traces

### DIFF
--- a/src/lib/prof-lean/hpcrun-fmt.h
+++ b/src/lib/prof-lean/hpcrun-fmt.h
@@ -811,6 +811,7 @@ typedef struct hpctrace_hdr_flags_bitfield {
 // Substitute bit fields with macros
 #define HPCTRACE_HDR_FLAGS_DATA_CENTRIC_BIT_POS 0U
 #define HPCTRACE_HDR_FLAGS_LCA_RECORDED_BIT_POS 1U
+#define HPCTRACE_HDR_FLAGS_CALL_TRACE_BIT_POS 2U
 
 #define HPCTRACE_HDR_FLAGS_GET_BIT(flag, pos) \
   ((flag >> pos) & 1U)

--- a/src/lib/profile/sources/hpcrun4.cpp
+++ b/src/lib/profile/sources/hpcrun4.cpp
@@ -180,6 +180,7 @@ bool Hpcrun4::setupTrace(unsigned int traceDisorder) noexcept {
     std::fclose(file);
     return false;
   }
+  callTrace = HPCTRACE_HDR_FLAGS_GET_BIT(thdr.flags, HPCTRACE_HDR_FLAGS_CALL_TRACE_BIT_POS);
   // The file is now placed right at the start of the data.
   trace_off = std::ftell(file);
 
@@ -585,7 +586,7 @@ bool Hpcrun4::realread(const DataClass& needed) try {
       auto it = nodes.find(tpoint.cpId);
       if(it != nodes.end()) {
         if(auto* p_x = std::get_if<singleCtx_t>(&it->second)) {
-          switch(sink.timepoint(*thread, p_x->full,
+          switch(sink.timepoint(*thread, callTrace ? p_x->rel : p_x->full,
               std::chrono::nanoseconds(HPCTRACE_FMT_GET_TIME(tpoint.comp)))) {
           case ProfilePipeline::Source::TimepointStatus::next:
             break;  // 'Round the loop

--- a/src/lib/profile/sources/hpcrun4.hpp
+++ b/src/lib/profile/sources/hpcrun4.hpp
@@ -88,6 +88,7 @@ private:
   // Tracefile setup and arrangements.
   bool setupTrace(unsigned int) noexcept;
   PerThreadTemporary* thread;
+  bool callTrace;
 
   // The actual file. Details for reading handled in prof-lean.
   hpcrun_sparse_file_t* file;

--- a/src/tool/hpcrun/gpu/amd/rocprofiler-api.c
+++ b/src/tool/hpcrun/gpu/amd/rocprofiler-api.c
@@ -297,7 +297,7 @@ rocprofiler_context_handler
   void* arg
 )
 {
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
 
   // This wait-loop is taken from rocprofiler example.
   // It is strange that the rocprofiler thread will have to

--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -514,7 +514,7 @@ roctracer_buffer_completion_callback
  void* arg
 )
 {
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
   roctracer_buffer_completion_notify();
   roctracer_record_t* record = (roctracer_record_t*)(begin);
   roctracer_record_t* end_record = (roctracer_record_t*)(end);

--- a/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
+++ b/src/tool/hpcrun/gpu/gpu-operation-multiplexer.c
@@ -102,7 +102,7 @@ gpu_operation_record
 {
   int current_operation_channels_count;
   
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
 
   while (!atomic_load(&stop_operation_flag)){
     current_operation_channels_count = atomic_load(&operation_channels_count);

--- a/src/tool/hpcrun/gpu/gpu-trace.c
+++ b/src/tool/hpcrun/gpu/gpu-trace.c
@@ -290,9 +290,6 @@ gpu_trace_stream_acquire
  gpu_tag_t tag
 )
 {
-  bool demand_new_thread = true;
-  bool has_trace = true;
-
   thread_data_t *td = NULL;
 
   atomic_fetch_add(&active_streams_counter, 1);
@@ -301,7 +298,7 @@ gpu_trace_stream_acquire
 
   // XXX(Keren): This API calls allocate_and_init_thread_data to bind td with the current thread
 
-  hpcrun_threadMgr_data_get(id, NULL, &td, has_trace, demand_new_thread);
+  hpcrun_threadMgr_data_get(id, NULL, &td, HPCRUN_CALL_TRACE, true);
 
   gpu_compute_profile_name(tag, &td->core_profile_trace_data);
 
@@ -373,7 +370,7 @@ gpu_trace_record
 {
   gpu_trace_channel_set_t *channel_set = (gpu_trace_channel_set_t *) args;
 
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
 
   while (!atomic_load(&stop_trace_flag)) {
     //getting data from a trace channel

--- a/src/tool/hpcrun/gpu/instrumentation/gtpin-instrumentation.c
+++ b/src/tool/hpcrun/gpu/instrumentation/gtpin-instrumentation.c
@@ -852,7 +852,7 @@ onKernelComplete
     return;
   }
   
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
 
   gpu_activity_channel_t *activity_channel = gtpin_correlation_id_map_entry_activity_channel_get(entry);
   gpu_op_ccts_t gpu_op_ccts = gtpin_correlation_id_map_entry_op_ccts_get(entry);

--- a/src/tool/hpcrun/gpu/nvidia/cupti-api.c
+++ b/src/tool/hpcrun/gpu/nvidia/cupti-api.c
@@ -1251,7 +1251,7 @@ cupti_buffer_completion_callback
  size_t validSize
 )
 {
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
 
   // handle notifications
   cupti_buffer_completion_notify();

--- a/src/tool/hpcrun/gpu/opencl/opencl-api.c
+++ b/src/tool/hpcrun/gpu/opencl/opencl-api.c
@@ -1093,7 +1093,7 @@ opencl_activity_completion_callback
  void *user_data
 )
 {
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
   opencl_object_t *cb_data = (opencl_object_t*)user_data;
   cl_basic_callback_t cb_basic = opencl_cb_basic_get(cb_data);
 
@@ -1147,7 +1147,7 @@ opencl_api_initialize
 {
   ETMSG(OPENCL, "CL_TARGET_OPENCL_VERSION: %d", CL_TARGET_OPENCL_VERSION);
   // we need this even when instrumentation is off inorder to get kernel names in hpcviewer
-  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, false, true);
+  hpcrun_thread_init_mem_pool_once(TOOL_THREAD_ID, NULL, HPCRUN_NO_TRACE, true);
   
   // GPU_IDLE_CAUSE should be attributed only to application thread
   // application thread calls this fn

--- a/src/tool/hpcrun/main.c
+++ b/src/tool/hpcrun/main.c
@@ -484,7 +484,7 @@ hpcrun_init_internal(bool is_child)
 
   hpcrun_trace_init(); // this must go after thread initialization
 
-  hpcrun_trace_open(&(TD_GET(core_profile_trace_data)));
+  hpcrun_trace_open(&(TD_GET(core_profile_trace_data)), HPCRUN_SAMPLE_TRACE);
 
   // Decide whether to retain full single recursion, or collapse recursive calls to
   // first instance of recursive call
@@ -792,7 +792,8 @@ hpcrun_thread_init(int id, local_thread_data_t* local_thread_data, bool has_trac
   bool demand_new_thread = false;
   cct_ctxt_t* thr_ctxt = local_thread_data ? local_thread_data->thr_ctxt : NULL;
 
-  hpcrun_thread_init_mem_pool_once(id, thr_ctxt, has_trace, demand_new_thread);
+  hpcrun_thread_init_mem_pool_once(id, thr_ctxt,
+    has_trace ? HPCRUN_SAMPLE_TRACE : HPCRUN_NO_TRACE, demand_new_thread);
   
   hpcrun_get_thread_data()->inside_hpcrun = 1;
   

--- a/src/tool/hpcrun/sample-sources/gpu/stream-tracing.c
+++ b/src/tool/hpcrun/sample-sources/gpu/stream-tracing.c
@@ -32,7 +32,7 @@ stream_data_collecting
 
     thread_data_t* td = NULL;
     //!unsure of the first argument
-    hpcrun_threadMgr_non_compact_data_get(500 + atomic_fetch_add(&stream_id, 1), NULL, &td, true);
+    hpcrun_threadMgr_non_compact_data_get(500 + atomic_fetch_add(&stream_id, 1), NULL, &td, HPCRUN_CALL_TRACE);
     hpcrun_set_thread_data(td);
 
     while(!atomic_load(&stop_streams))

--- a/src/tool/hpcrun/thread_data.c
+++ b/src/tool/hpcrun/thread_data.c
@@ -280,7 +280,7 @@ hpcrun_thread_init_mem_pool_once
 (
   int id, 
   cct_ctxt_t *thr_ctxt,
-  bool has_trace, 
+  hpcrun_trace_type_t trace,
   bool demand_new_thread
 )
 { 
@@ -288,7 +288,7 @@ hpcrun_thread_init_mem_pool_once
 
   if (mem_pool_initialized == false){
     hpcrun_mmap_init();
-    hpcrun_threadMgr_data_get(id, thr_ctxt, &td, has_trace, demand_new_thread);
+    hpcrun_threadMgr_data_get(id, thr_ctxt, &td, trace, demand_new_thread);
     hpcrun_set_thread_data(td);
   }
 }

--- a/src/tool/hpcrun/thread_data.h
+++ b/src/tool/hpcrun/thread_data.h
@@ -58,6 +58,7 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include "trace.h"
 #include "sample_sources_registered.h"
 #include "newmem.h"
 #include "epoch.h"
@@ -347,7 +348,7 @@ hpcrun_thread_init_mem_pool_once
 (
   int id, 
   cct_ctxt_t *thr_ctxt,
-  bool has_trace, 
+  hpcrun_trace_type_t trace,
   bool demand_new_thread
 );
 

--- a/src/tool/hpcrun/threadmgr.c
+++ b/src/tool/hpcrun/threadmgr.c
@@ -139,7 +139,7 @@ is_compact_thread()
 }
 
 static thread_data_t *
-allocate_and_init_thread_data(int id, cct_ctxt_t* thr_ctxt, bool has_trace)
+allocate_and_init_thread_data(int id, cct_ctxt_t* thr_ctxt, hpcrun_trace_type_t trace)
 {
   thread_data_t *data = hpcrun_allocate_thread_data(id);
 
@@ -163,8 +163,8 @@ allocate_and_init_thread_data(int id, cct_ctxt_t* thr_ctxt, bool has_trace)
   // ----------------------------------------
   // opening trace file
   // ----------------------------------------
-  if (has_trace) {
-  	hpcrun_trace_open(&(data->core_profile_trace_data));
+  if(trace != HPCRUN_NO_TRACE) {
+    hpcrun_trace_open(&(data->core_profile_trace_data), trace);
   }
 
   return data;
@@ -279,14 +279,14 @@ hpcrun_threadMgr_compact_thread()
  *   Side effect: Overwrites pthread_specific data
  *****/
 bool
-hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace, bool demand_new_thread)
+hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, hpcrun_trace_type_t trace, bool demand_new_thread)
 {
   // -----------------------------------------------------------------
   // if we don't want coalesce threads, just allocate it and return
   // -----------------------------------------------------------------
 
   if (!is_compact_thread() || demand_new_thread) {
-    *data = allocate_and_init_thread_data(id, thr_ctxt, has_trace);
+    *data = allocate_and_init_thread_data(id, thr_ctxt, trace);
     return true;
   }
 
@@ -302,7 +302,7 @@ hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bo
   if (need_to_allocate) {
 
     adjust_num_logical_threads(1);
-    *data = allocate_and_init_thread_data(id, thr_ctxt, has_trace);
+    *data = allocate_and_init_thread_data(id, thr_ctxt, trace);
   }
 
 #if HPCRUN_THREADS_DEBUG
@@ -313,10 +313,10 @@ hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bo
 }
 
 void
-hpcrun_threadMgr_non_compact_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace)
+hpcrun_threadMgr_non_compact_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, hpcrun_trace_type_t trace)
 {
     adjust_num_logical_threads(1);
-    *data = allocate_and_init_thread_data(id, thr_ctxt, has_trace);
+    *data = allocate_and_init_thread_data(id, thr_ctxt, trace);
 
 #if HPCRUN_THREADS_DEBUG
     atomic_fetch_add_explicit(&threadmgr_tot_threads, 1, memory_order_relaxed);

--- a/src/tool/hpcrun/threadmgr.h
+++ b/src/tool/hpcrun/threadmgr.h
@@ -56,6 +56,7 @@
 #define _threadmgr_h_
 
 #include "thread_data.h"
+#include "trace.h"
 
 
 //******************************************************************************
@@ -76,10 +77,10 @@ void hpcrun_threadmgr_thread_delete();
 int hpcrun_threadmgr_thread_count();
 
 bool
-hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace, bool demand_new_thread);
+hpcrun_threadMgr_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, hpcrun_trace_type_t trace, bool demand_new_thread);
 
 void
-hpcrun_threadMgr_non_compact_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, bool has_trace);
+hpcrun_threadMgr_non_compact_data_get(int id, cct_ctxt_t* thr_ctxt, thread_data_t **data, hpcrun_trace_type_t trace);
 
 void
 hpcrun_threadMgr_data_put(epoch_t *epoch, thread_data_t *data, bool add_separator);

--- a/src/tool/hpcrun/trace.c
+++ b/src/tool/hpcrun/trace.c
@@ -128,7 +128,7 @@ hpcrun_trace_init()
 }
 
 void
-hpcrun_trace_open(core_profile_trace_data_t * cptd)
+hpcrun_trace_open(core_profile_trace_data_t * cptd, hpcrun_trace_type_t type)
 {
   if (hpcrun_get_disabled()) {
     tracing = 0;
@@ -167,6 +167,19 @@ hpcrun_trace_open(core_profile_trace_data_t * cptd)
 #else
     HPCTRACE_HDR_FLAGS_SET_BIT(flags, HPCTRACE_HDR_FLAGS_LCA_RECORDED_BIT_POS, false);
 #endif
+
+    switch(type) {
+    case HPCRUN_SAMPLE_TRACE:
+      HPCTRACE_HDR_FLAGS_SET_BIT(flags, HPCTRACE_HDR_FLAGS_CALL_TRACE_BIT_POS, 0);
+      break;
+    case HPCRUN_CALL_TRACE:
+      HPCTRACE_HDR_FLAGS_SET_BIT(flags, HPCTRACE_HDR_FLAGS_CALL_TRACE_BIT_POS, 1);
+      break;
+    case HPCRUN_NO_TRACE:
+    default:
+      assert(false && "Invalid trace type!");
+      // TODO: hpcrun_terminate()
+    }
     
     ret = hpctrace_fmt_hdr_outbuf(flags, cptd->trace_outbuf);
     hpcrun_trace_file_validate(ret == HPCFMT_OK, "write header to");

--- a/src/tool/hpcrun/trace.h
+++ b/src/tool/hpcrun/trace.h
@@ -57,10 +57,16 @@ typedef enum hpcrun_trace_type_masks {
     HPCRUN_GPU_TRACE_FLAG = 2
 } hpcrun_trace_type_masks_t;
 
+typedef enum hpcrun_trace_type {
+    HPCRUN_NO_TRACE,
+    HPCRUN_SAMPLE_TRACE,
+    HPCRUN_CALL_TRACE,
+} hpcrun_trace_type_t;
+
 void trace_other_close(void *thread_data);
 
 void hpcrun_trace_init();
-void hpcrun_trace_open(core_profile_trace_data_t * cptd);
+void hpcrun_trace_open(core_profile_trace_data_t * cptd, hpcrun_trace_type_t type);
 void hpcrun_trace_append(core_profile_trace_data_t *cptd, cct_node_t* node, uint metric_id, uint32_t dLCA, uint64_t sampling_period);
 void hpcrun_trace_append_with_time(core_profile_trace_data_t *st, unsigned int call_path_id, uint metric_id, uint64_t nanotime);
 void hpcrun_trace_close(core_profile_trace_data_t * cptd);


### PR DESCRIPTION
CPU traces are composed of a series of "samples" taken from every running thread. In contrast, GPU traces are (currently) composed only of top-level operations such as `<gpu copy>` or kernel launches. This PR better supports the latter case by marking such "call traces" and preventing deep lexical expansion (of inlined call chains) in Prof2 for these traces.

Fixes #619.