### PR TITLE
Handle dlopen in threads without thread_data

### DIFF
--- a/src/tool/hpcrun/safe-sampling.h
+++ b/src/tool/hpcrun/safe-sampling.h
@@ -167,6 +167,10 @@ hpcrun_safe_enter_async(void *pc)
 static inline void
 hpcrun_safe_exit(void)
 {
+  if (! hpcrun_is_initialized() || ! hpcrun_td_avail()) {
+    return 0;
+  }
+
   thread_data_t *td = hpcrun_get_thread_data();
 
   td->inside_hpcrun = 0;

--- a/src/tool/hpcrun/safe-sampling.h
+++ b/src/tool/hpcrun/safe-sampling.h
@@ -168,7 +168,7 @@ static inline void
 hpcrun_safe_exit(void)
 {
   if (! hpcrun_is_initialized() || ! hpcrun_td_avail()) {
-    return 0;
+    return;
   }
 
   thread_data_t *td = hpcrun_get_thread_data();

--- a/src/tool/hpcrun/unwind/common/uw_recipe_map.c
+++ b/src/tool/hpcrun/unwind/common/uw_recipe_map.c
@@ -588,15 +588,18 @@ uw_recipe_map_notify_unmap(load_module_t* lm)
   for (uw = 0; uw < NUM_UNWINDERS; uw++)
     uw_recipe_map_repoison((uintptr_t)start, (uintptr_t)end, uw);
 
-  thread_data_t *td = hpcrun_get_thread_data();
+  if (hpcrun_td_avail()) {
+    thread_data_t *td = hpcrun_get_thread_data();
 
-  // we need to confirm that the hashtable is allocated. if we are
-  // exiting very early (e.g. when a metric is not recognized), which
-  // means that hpcrun_init_internal has not yet been called, the hash
-  // table has not yet been allocated.
-  if (td->uw_hash_table) uw_hash_delete_range(td->uw_hash_table, start, end);
+    // we need to confirm that the hashtable is allocated. if we are
+    // exiting very early (e.g. when a metric is not recognized), which
+    // means that hpcrun_init_internal has not yet been called, the hash
+    // table has not yet been allocated.
+    if (td->uw_hash_table) uw_hash_delete_range(td->uw_hash_table, start, end);
+  }
 
   uw_recipe_map_report_and_dump("*** unmap: after poisoning", start, end);
+
 }
 
 static void

--- a/src/tool/hpcrun/unwind/common/uw_recipe_map.c
+++ b/src/tool/hpcrun/unwind/common/uw_recipe_map.c
@@ -599,7 +599,6 @@ uw_recipe_map_notify_unmap(load_module_t* lm)
   }
 
   uw_recipe_map_report_and_dump("*** unmap: after poisoning", start, end);
-
 }
 
 static void


### PR DESCRIPTION
This was observed when trying to profile PeleC with AMD GPU on ufront.cs.