### PR TITLE
hpcstruct: don't SEGV when analyzing an unreadable file

### DIFF
--- a/src/tool/hpcstruct/SingleBin.cpp
+++ b/src/tool/hpcstruct/SingleBin.cpp
@@ -158,6 +158,15 @@ doSingleBinary
   string cache_flat_entry;
   string cache_directory;
 
+  // Make sure the file is readable
+  if ( access(binary_abspath.c_str(), R_OK) != 0 ) {
+    cerr << "ERROR -- input file " << args.in_filenm.c_str() << " is not readable" << endl;
+    if ( args.is_from_makefile == true ) {
+      cerr << "CACHESTAT (Input file is not readable) " << endl;
+    }
+    exit(1);
+  }
+
   if (args.nocache) {
     // the user intentionally turned off the cache
     args.cache_stat = CACHE_DISABLED;

--- a/src/tool/hpcstruct/Structure-Cache.cpp
+++ b/src/tool/hpcstruct/Structure-Cache.cpp
@@ -448,6 +448,10 @@ hpcstruct_cache_hash
 )
 {
   char *eh  = elf_hash(binary_abspath);
+
+  // handle NULL
+  if (eh == 0) return strdup("");
+
   return eh;
 }
 


### PR DESCRIPTION
computing a hash string of an unreadable file would return NULL rather than a string of hex digits. change so it computes "", which avoids a the SEGV.