### PR TITLE
Don't trace ACTIVITY_DOMAIN_HCC_OPS

### DIFF
--- a/src/tool/hpcrun/gpu/amd/roctracer-api.c
+++ b/src/tool/hpcrun/gpu/amd/roctracer-api.c
@@ -618,12 +618,12 @@ roctracer_init
   properties.buffer_size = 0x1000;
   properties.buffer_callback_fun = roctracer_buffer_completion_callback;
   HPCRUN_ROCTRACER_CALL(roctracer_open_pool_expl, (&properties, NULL));
+
   // Enable HIP API callbacks
   HPCRUN_ROCTRACER_CALL(roctracer_enable_domain_callback, (ACTIVITY_DOMAIN_HIP_API, roctracer_subscriber_callback, NULL));
   HPCRUN_ROCTRACER_CALL(roctracer_enable_domain_callback, (ACTIVITY_DOMAIN_HSA_API, roctracer_subscriber_callback, NULL));
   // Enable HIP activity tracing
   HPCRUN_ROCTRACER_CALL(roctracer_enable_domain_activity_expl, (ACTIVITY_DOMAIN_HIP_API, NULL));
-  HPCRUN_ROCTRACER_CALL(roctracer_enable_domain_activity_expl, (ACTIVITY_DOMAIN_HCC_OPS, NULL));
 
   // Enable PC sampling
   //HPCRUN_ROCTRACER_CALL(roctracer_enable_op_activity, (ACTIVITY_DOMAIN_HSA_OPS, HSA_OP_ID_PCSAMPLE));
@@ -658,7 +658,6 @@ roctracer_fini
 {
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_callback, (ACTIVITY_DOMAIN_HIP_API));
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_activity, (ACTIVITY_DOMAIN_HIP_API));
-  HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_activity, (ACTIVITY_DOMAIN_HCC_OPS));
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_activity, (ACTIVITY_DOMAIN_HSA_OPS));
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_callback, (ACTIVITY_DOMAIN_KFD_API));
   HPCRUN_ROCTRACER_CALL(roctracer_disable_domain_callback, (ACTIVITY_DOMAIN_ROCTX));


### PR DESCRIPTION
AMD merged ACTIVITY_DOMAIN_HCC_OPS into ACTIVITY_DOMAIN_HIP_OPS.
Rather than eliminating ACTIVITY_DOMAIN_HCC_OPS, they wrote

  #define ACTIVITY_DOMAIN_HCC_OPS ACTIVITY_DOMAIN_HIP_OPS

Thus, tracing both ACTIVITY_DOMAIN_HCC_OPS and
ACTIVITY_DOMAIN_HIP_OPS meant tracing ACTIVITY_DOMAIN_HIP_OPS
twice. This corrupts the heap inside roctracer.

Eliminate tracing for ACTIVITY_DOMAIN_HCC_OPS since we already
trace ACTIVITY_DOMAIN_HIP_OPS.